### PR TITLE
update "Account Deployment"

### DIFF
--- a/sdk/chain-abstraction/account-deployment.mdx
+++ b/sdk/chain-abstraction/account-deployment.mdx
@@ -6,7 +6,7 @@ The SDK handles the account deployments for you. When transacting on a new chain
 
 It's possible to make the deployment completely gasless for the user if you're using [sponsorships](../core/fee-sponsorship).
 
-Otherwise, the user needs to have some tokens on either the chain you're deploying to, or one of the other [supported chain](../../home/introduction/supported-chains) (provided the account is already deployed there).
+Otherwise, the user needs to have some tokens on either the chain you're deploying to, or any other [supported chain](../../home/introduction/supported-chains) (provided the account is already deployed there).
 
 ## Check Status
 

--- a/sdk/chain-abstraction/account-deployment.mdx
+++ b/sdk/chain-abstraction/account-deployment.mdx
@@ -2,7 +2,13 @@
 title: "Account Deployment"
 ---
 
-The SDK handles the account deployments for you.
+The SDK handles the account deployments for you. When transacting on a new chain for the first time, the account will be deployed as part of the intent. The Orchestrator automatically detects if the account needs to be deployed, then passes the init data to the relayers as part of the intent, which is then exectuted by a relayer.
+
+It's possible to make the deployment completely gasless for the user if you're using [sponsorships](../core/fee-sponsorship).
+
+Otherwise, the user needs to have some tokens on either the chain you're deploying to, or one of the other chains (provided the account is already deployed there).
+
+## Manual Deployments
 
 You can manually trigger an account deployment on any chain:
 

--- a/sdk/chain-abstraction/account-deployment.mdx
+++ b/sdk/chain-abstraction/account-deployment.mdx
@@ -2,7 +2,7 @@
 title: "Account Deployment"
 ---
 
-The SDK handles the account deployments for you. When transacting on a new chain for the first time, the account will be deployed as part of the intent. The Orchestrator automatically detects if the account needs to be deployed, then passes the init data to the relayers as part of the intent, which is then exectuted by a relayer.
+The SDK handles the account deployments for you. When transacting on a new chain for the first time, the account will be deployed as part of the intent. The Orchestrator automatically detects if the account needs to be deployed, then passes the init data to the relayer market as part of the intent, which is then exectuted by a relayer.
 
 It's possible to make the deployment completely gasless for the user if you're using [sponsorships](../core/fee-sponsorship).
 

--- a/sdk/chain-abstraction/account-deployment.mdx
+++ b/sdk/chain-abstraction/account-deployment.mdx
@@ -8,6 +8,14 @@ It's possible to make the deployment completely gasless for the user if you're u
 
 Otherwise, the user needs to have some tokens on either the chain you're deploying to, or one of the other chains (provided the account is already deployed there).
 
+## Check Status
+
+You can check if the account is deployed on a specific chain:
+
+```ts
+await rhinestoneAccount.isDeployed(chain)
+```
+
 ## Manual Deployments
 
 You can manually trigger an account deployment on any chain:

--- a/sdk/chain-abstraction/account-deployment.mdx
+++ b/sdk/chain-abstraction/account-deployment.mdx
@@ -6,7 +6,7 @@ The SDK handles the account deployments for you. When transacting on a new chain
 
 It's possible to make the deployment completely gasless for the user if you're using [sponsorships](../core/fee-sponsorship).
 
-Otherwise, the user needs to have some tokens on either the chain you're deploying to, or one of the other chains (provided the account is already deployed there).
+Otherwise, the user needs to have some tokens on either the chain you're deploying to, or one of the other [supported chain](../../home/introduction/supported-chains) (provided the account is already deployed there).
 
 ## Check Status
 


### PR DESCRIPTION
* Describe why the SDK handles the account deployment. 
  * Essentially it means that when a user does their first transaction or transacts on a new chain, the Rhinestone SDK will automatically deploy as part of that first intent. This means the account deployment process is completely abstracted away from the user and the developer.
* SDK snippet – Check if the account is deployed
* SDK snippet – How to manually deploy
