### PR TITLE
update "Unified Balance"

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -96,7 +96,8 @@
 							"sdk/chain-abstraction/solver-based-swaps",
 							"sdk/chain-abstraction/account-deployment",
 							"sdk/chain-abstraction/orchestrator-errors",
-							"sdk/use-cases/chain-abstraction/unified-balance"
+							"sdk/use-cases/chain-abstraction/unified-balance",
+							"sdk/use-cases/chain-abstraction/max-spendable-amount"
 						]
 					},
 					{
@@ -179,9 +180,7 @@
 							},
 							{
 								"group": "Deploying",
-								"pages": [
-									"build-modules/guides/deploying/deploying-modules"
-								]
+								"pages": ["build-modules/guides/deploying/deploying-modules"]
 							},
 							"build-modules/guides/migration-guide"
 						]

--- a/sdk/use-cases/chain-abstraction/max-spendable-amount.mdx
+++ b/sdk/use-cases/chain-abstraction/max-spendable-amount.mdx
@@ -1,0 +1,20 @@
+---
+title: "Max Spendable Amount"
+---
+
+Often, you want to let the user spend the maximum possible amount of a specific tokens for a transaction (e.g. deposit all available funds as USDC into a savings vault).
+
+While the `getPortfolio` utility provides the total balance, it doesn't consider the execution fee, as this fee is chain-specific and depends on the transaction gas cost.
+
+To get an estimate of the maximum amount of tokens you can spend on a given transaction, use `getMaxSpendableAmount`. This will take all the gas and bridging fees for a given chain into consideration, as well as the user's token portfolio across all chains, and output the max amount of tokens you can spend
+
+In this case, we get the maximum spendable USDC amount on Base Sepolia:
+
+```ts
+const chain = baseSepolia.id
+const token = getTokenAddress('USDC', baseSepolia.id)
+const gasUnits = 200_000n
+
+const tokenAmount = await rhinestoneAccount.getMaxSpendableAmount(chain, token, gasUnits)
+// Output in wei
+```

--- a/sdk/use-cases/chain-abstraction/unified-balance.mdx
+++ b/sdk/use-cases/chain-abstraction/unified-balance.mdx
@@ -19,18 +19,3 @@ const portfolio = await rhinestoneAccount.getPortfolio(onTestnets)
 
 This will return the list of *spendable* tokens (i.e., not part of any pending transaction).
 
-## Max Spendable Amount
-
-Often, you want to let the user spend the maximum possible amount of tokens for a transaction (e.g. deposit all available USDC into a savings vault).
-
-While the `getPortfolio` util provides the total spendable balance, it doesn't consider the execution fee, as it is chain-specific and depends on the transaction gas cost.
-
-To get an estimate of the maximum amount of tokens you can spend on a given transaction, use `getMaxSpendableAmount`. In this case, we get the maximum spendable USDC amount on Base Sepolia:
-
-```ts
-const usdcAddress = getTokenAddress('USDC', baseSepolia.id)
-const gasUnits = 200_000n
-
-const tokenAmount = await rhinestoneAccount.getMaxSpendableAmount(baseSepolia.id, usdcAddress, gasUnits)
-```
-

--- a/sdk/use-cases/chain-abstraction/unified-balance.mdx
+++ b/sdk/use-cases/chain-abstraction/unified-balance.mdx
@@ -4,9 +4,9 @@ title: "Unified Balance"
 
 With Rhinestone, users' aggregated balances across all chains are always available to sponsor any intent.
 
-Rhinestone uses the aggregated balance of the user's funds across all supported chains. When calculating the user's portfolio, Rhinestone takes any outstanding intents (where funds have been allocated to a relayer as repayment but not yet processed) into account to prevent double spending.
+Rhinestone uses the aggregated balance of the user's funds across all supported chains. When calculating the user's portfolio, Rhinestone takes any outstanding intents (where funds have been allocated to a relayer as repayment but not yet processed) into account to prevent double-spending.
 
-When making a multi-chain intent, the Orchestrator finds the most optimal source of funds, taking the gas and bridging costs into account. It prioritizes same-chain and equivalent (e.g., ETH/WETH) assets, but can use other assets when needed.
+When making a multi-chain intent, the Orchestrator finds the most optimal source of funds, taking the gas and bridging costs into account. It prioritizes same-chain and equivalent (e.g., ETH/WETH, USDC/USDT) assets, but can use other assets when needed.
 
 ## How it Works
 

--- a/sdk/use-cases/chain-abstraction/unified-balance.mdx
+++ b/sdk/use-cases/chain-abstraction/unified-balance.mdx
@@ -2,7 +2,30 @@
 title: "Unified Balance"
 ---
 
-The Omni Account uses the aggregated balance of the user's funds across all supported chains, taking into account any outstanding intents.
+With Rhinestone, users' aggregated balances across all chains are always available to sponsor any intent.
+
+Rhinestone uses the aggregated balance of the user's funds across all supported chains. When calculating the user's portfolio, Rhinestone takes any outstanding intents (where funds have been allocated to a relayer as repayment but not yet processed) into account to prevent double spending.
+
+When making a multi-chain intent, the Orchestrator finds the most optimal source of funds, taking the gas and bridging costs into account. It prioritizes same-chain and equivalent (e.g., ETH/WETH) assets, but can use other assets when needed.
+
+## How it Works
+
+When choosing which asset to use, the Orchestrator uses the following priority system:
+
+- Destination token on the destination chain
+- Same token on another chain
+- Equivalent token on another chain
+- Different token on the destination chain
+- Token with the highest balance
+
+Sometimes, a single token is not enough to cover the transaction costs. In that case, the Orchestrator can use multiple source assets, sometimes on multiple source chains.
+
+The system splits tokens/chains in these cases:
+1. Insufficient single token: when one token cannot cover the full payment
+2. Multi-token requests: when multiple tokens are required for the transaction
+3. Cost optimization: when using multiple smaller amounts is cheaper than bridging large amounts
+
+## Get Portfolio
 
 To get the aggregated portfolio of tokens:
 


### PR DESCRIPTION
Update "Unified Balance" and extract "Max Spendable Amount" into a separate page.



## Unified Balance
* Explain that unified balances are possible under both JIT and Fill-First intent set ups
* When building with Rhinestone, users’ aggregated balances across all chains are always available to sponsor any intent.
*  A user portfolio consists of both the onchain balance and any pending intents where funds have been allocated to a relayer as repayment but not yet processed.
* Explain how the Orchestrator abstracts the gas requirements and path finding when funding a multichain intent
SDK functions

## Max Spendable Balance
* Explain how it works
* Pull this from the Unified Balance section 
