### PR TITLE
fix: update Module SDK link and add ModuleKit link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -153,7 +153,14 @@
               "smart-wallet/advanced/security"
             ]
           },
-          "smart-wallet/module-sdk",
+          {
+            "title": "Module SDK",
+            "href": "https://erc7579.com/tooling/module-sdk"
+          },
+          {
+            "title": "ModuleKit",
+            "href": "https://erc7579.com/tooling/modulekit"
+          },
           {
             "group": "Customize",
             "pages": [


### PR DESCRIPTION
## Summary
- Fix broken Module SDK sidebar link (was returning 404)
- Replace with external link to https://erc7579.com/tooling/module-sdk
- Add new ModuleKit external link to https://erc7579.com/tooling/modulekit

## Test plan
- [ ] Verify Module SDK link in Smart Wallet SDK sidebar navigates correctly
- [ ] Verify ModuleKit link appears below Module SDK and navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)