### PR TITLE
docs: add auxiliary funds section to intent pages

### DIFF
--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -48,12 +48,6 @@ Under the hood, this will:
 4) Execute the _claim_ transaction on Arbitrum
 5) Execute the _fill_ transaction on Base
 
-## Token Requests
-
-`tokenRequests` is a list of token assets and their amounts that are required on the target chain to make the transaction. It tells the solvers to ensure those assets are present before executing the transaction `calls`. If you don't need any assets on the target chain, you can omit this.
-
-<Note>Solvers will supply all assets specified in the `tokenRequests`. If the user already has the required assets, don't add them into `tokenRequests`.</Note>
-
 ## Source Chain
 
 Providing the source chain deploys the account on that chain, as well as uses the funds on that chain to fulfill the intent.
@@ -121,6 +115,30 @@ const transaction = await rhinestoneAccount.sendTransaction({
 ```
 
 <Note>Chain-specific `sourceAssets` take precendence over `sourceChain` parameter.</Note>
+
+## Auxiliary Funds
+
+In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
+
+```ts {9-14}
+const transaction = await rhinestoneAccount.prepareTransaction({
+  targetChain: arbitrum,
+  calls: [
+    // …
+  ],
+  tokenRequests: [
+    // …
+  ],
+  auxiliaryFunds: {
+    [base.id]: {
+      [USDC_ADDRESS]: parseUnits('100', 6),
+      [WETH_ADDRESS]: parseUnits('1', 18)
+    }
+  }
+})
+```
+
+This lets you get a quote before getting the funds ready on the account.
 
 ## Wait for Execution
 

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -58,8 +58,6 @@ If you already have an account deployed on one or more source chains, you can om
 
 `tokenRequests` is a list of token assets and their amounts that are required on the target chain to make the transaction. It tells the solvers to ensure those assets are present before executing the transaction `calls`. If you don't need any assets on the target chain, you can omit this.
 
-<Note>Solvers will supply all assets specified in the `tokenRequests`. If the user already has the required assets, don't add them into `tokenRequests`.</Note>
-
 ## Gas Limit
 
 You can override the default gas limit for the target chain execution with `gasLimit`. Doing this will make the intent better priced, because we can more accurately calculate the fee that a solver needs to be reimbursed with for paying the gas. If this is not provided, we calculate using a gas limit of `1_000_000`.

--- a/smart-wallet/chain-abstraction/single-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/single-chain-intent.mdx
@@ -63,6 +63,30 @@ const transaction = await rhinestoneAccount.sendTransaction({
 })
 ```
 
+## Auxiliary Funds
+
+In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
+
+```ts {9-14}
+const transaction = await rhinestoneAccount.prepareTransaction({
+  chain: base,
+  calls: [
+    // …
+  ],
+  tokenRequests: [
+    // …
+  ],
+  auxiliaryFunds: {
+    [base.id]: {
+      [USDC_ADDRESS]: parseUnits('100', 6),
+      [WETH_ADDRESS]: parseUnits('1', 18)
+    }
+  }
+})
+```
+
+This lets you get a quote before getting the funds ready on the account.
+
 ## Wait for Execution
 
 `sendTransaction` returns a pending intent. To wait until it gets executed, use `waitForExecution`:


### PR DESCRIPTION
## Summary
- Add "Auxiliary Funds" section to both single-chain and multi-chain intent pages
- Documents the `auxiliaryFunds` transaction option introduced in rhinestonewtf/sdk#339
