### PR TITLE
docs: use single fetch and testnet filter for supported chains

### DIFF
--- a/home/resources/supported-chains.mdx
+++ b/home/resources/supported-chains.mdx
@@ -4,30 +4,53 @@ sidebarTitle: "Supported Chains"
 description: "Learn what chains our services are deployed on"
 ---
 
-export const ChainsTable = ({ apiUrl }) => {
+export const ChainsTable = ({ chains }) => (
+  <table className="min-w-full">
+    <thead>
+      <tr className="border-b border-gray-200 dark:border-gray-700">
+        <th className="text-left py-2 pr-4 font-semibold">Name</th>
+        <th className="text-right py-2 pr-4 font-semibold">Chain ID</th>
+        <th className="text-left py-2 font-semibold">Tokens</th>
+      </tr>
+    </thead>
+    <tbody>
+      {chains.map((chain) => (
+        <tr key={chain.chainId} className="border-b border-gray-100 dark:border-gray-800">
+          <td className="py-2 pr-4">{chain.name}</td>
+          <td className="py-2 pr-4 text-right">{chain.chainId}</td>
+          <td className="py-2">{chain.supportsSwaps ? 'All' : (chain.supportedTokens?.map(t => t.symbol).join(', ') || '-')}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export const IntentChains = () => {
   const [chains, setChains] = React.useState([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
 
   React.useEffect(() => {
-    fetch(apiUrl)
+    fetch("https://v1.orchestrator.rhinestone.dev/chains")
       .then(res => {
         if (!res.ok) throw new Error('Failed to fetch chains');
         return res.json();
       })
       .then(data => {
-        const chainsArray = Object.entries(data).map(([chainId, chain]) => ({
-          ...chain,
-          chainId: parseInt(chainId, 10)
-        }));
-        setChains(chainsArray.sort((a, b) => a.chainId - b.chainId));
+        const chainsArray = Object.entries(data)
+          .map(([chainId, chain]) => ({
+            ...chain,
+            chainId: parseInt(chainId, 10)
+          }))
+          .sort((a, b) => a.chainId - b.chainId);
+        setChains(chainsArray);
         setLoading(false);
       })
       .catch(err => {
         setError(err.message);
         setLoading(false);
       });
-  }, [apiUrl]);
+  }, []);
 
   if (loading) {
     return <div className="text-gray-500 dark:text-gray-400 py-4">Loading chains...</div>;
@@ -37,25 +60,16 @@ export const ChainsTable = ({ apiUrl }) => {
     return <div className="text-red-500 dark:text-red-400 py-4">Error loading chains: {error}</div>;
   }
 
+  const mainnets = chains.filter(chain => !chain.testnet);
+  const testnets = chains.filter(chain => chain.testnet);
+
   return (
-    <table className="min-w-full">
-      <thead>
-        <tr className="border-b border-gray-200 dark:border-gray-700">
-          <th className="text-left py-2 pr-4 font-semibold">Name</th>
-          <th className="text-right py-2 pr-4 font-semibold">Chain ID</th>
-          <th className="text-left py-2 font-semibold">Tokens</th>
-        </tr>
-      </thead>
-      <tbody>
-        {chains.map((chain) => (
-          <tr key={chain.chainId} className="border-b border-gray-100 dark:border-gray-800">
-            <td className="py-2 pr-4">{chain.name}</td>
-            <td className="py-2 pr-4 text-right">{chain.chainId}</td>
-            <td className="py-2">{chain.supportsSwaps ? 'All' : (chain.supportedTokens?.map(t => t.symbol).join(', ') || '-')}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <>
+      <h3>Mainnet</h3>
+      <ChainsTable chains={mainnets} />
+      <h3>Testnet</h3>
+      <ChainsTable chains={testnets} />
+    </>
   );
 };
 
@@ -63,13 +77,7 @@ export const ChainsTable = ({ apiUrl }) => {
 
 Rhinestone intents can be supported on any chain where an integrated settlement layer is deployed. Today, we support Across, Relay, and Eco.
 
-### Mainnet
-
-<ChainsTable apiUrl="https://v1.orchestrator.rhinestone.dev/chains" />
-
-### Testnet
-
-<ChainsTable apiUrl="https://staging.v1.orchestrator.rhinestone.dev/chains" />
+<IntentChains />
 
 ## Smart Account Infra
 


### PR DESCRIPTION
## Summary
- Consolidate two separate API fetches (production and staging) into a single fetch from the production endpoint
- Use the new `testnet` boolean field to filter chains into mainnet/testnet tables
- Removes deprecated staging API dependency

## Changes
- Extract table rendering into a presentational `ChainsTable` component
- Create `IntentChains` wrapper that fetches once and splits results by `testnet` field
- Simplifies API calls and aligns with the changes in rhinestonewtf/orchestrator#1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)