### PR TITLE
Add Smart Session Emissary address to address book

### DIFF
--- a/home/resources/address-book.mdx
+++ b/home/resources/address-book.mdx
@@ -24,6 +24,7 @@ A collection of addresses for the various contracts we have deployed or are usin
 | Contract                             | Address                                                                                                                    |
 | :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
 | Smart Sessions Validator             | [0x00000000008bdaba73cd9815d79069c247eb4bda](https://contractscan.xyz/contract/0x00000000008bdaba73cd9815d79069c247eb4bda) |
+| Smart Session Emissary               | [0xad568b3f825a8d5ffc06dd3253526b64d810ae89](https://contractscan.xyz/contract/0xad568b3f825a8d5ffc06dd3253526b64d810ae89) |
 | Ownable Validator                    | [0x000000000013fdB5234E4E3162a810F54d9f7E98](https://contractscan.xyz/contract/0x000000000013fdB5234E4E3162a810F54d9f7E98) |
 | Webauthn Validator                   | [0x0000000000578c4cB0e472a5462da43C495C3F33](https://contractscan.xyz/contract/0x0000000000578c4cB0e472a5462da43C495C3F33) |
 | Smart Session Compatibility Fallback | [0x000000000052e9685932845660777DF43C2dC496](https://contractscan.xyz/contract/0x000000000052e9685932845660777DF43C2dC496) |

--- a/home/resources/address-book.mdx
+++ b/home/resources/address-book.mdx
@@ -23,7 +23,6 @@ A collection of addresses for the various contracts we have deployed or are usin
 
 | Contract                             | Address                                                                                                                    |
 | :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
-| Smart Sessions Validator             | [0x00000000008bdaba73cd9815d79069c247eb4bda](https://contractscan.xyz/contract/0x00000000008bdaba73cd9815d79069c247eb4bda) |
 | Smart Session Emissary               | [0xad568b3f825a8d5ffc06dd3253526b64d810ae89](https://contractscan.xyz/contract/0xad568b3f825a8d5ffc06dd3253526b64d810ae89) |
 | Ownable Validator                    | [0x000000000013fdB5234E4E3162a810F54d9f7E98](https://contractscan.xyz/contract/0x000000000013fdB5234E4E3162a810F54d9f7E98) |
 | Webauthn Validator                   | [0x0000000000578c4cB0e472a5462da43C495C3F33](https://contractscan.xyz/contract/0x0000000000578c4cB0e472a5462da43C495C3F33) |


### PR DESCRIPTION
Adds the Smart Session Emissary contract address (0xad568b3f825a8d5ffc06dd3253526b64d810ae89) to the V1 Modules section of the address book, matching the latest address from the SDK.