### PR TITLE
docs: fix apiKey required + document splitIntents

### DIFF
--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -38,8 +38,7 @@ to this:
 
 ```ts
 const rhinestone = new RhinestoneSDK({
-  // Optional
-  apiKey: rhinestoneApiKey,
+  apiKey: rhinestoneApiKey, // Required
   // Optional
   endpointUrl: orchestratorUrl,
 })

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -38,7 +38,7 @@ to this:
 
 ```ts
 const rhinestone = new RhinestoneSDK({
-  apiKey: rhinestoneApiKey, // Required
+  apiKey: rhinestoneApiKey,
   // Optional
   endpointUrl: orchestratorUrl,
 })

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -169,9 +169,9 @@ const transactionResult = await rhinestone.getIntentStatus(transaction.id)
 
 ## Large Intents
 
-When an intent is too large for a single relayer to fill, you can use `splitIntents` to break it into smaller sub-intents that can each be filled independently.
+When an intent is too large for a single relayer to fill, you can use `splitIntents` to break it into smaller intents that can each be filled independently.
 
-`splitIntents` takes the chain and a map of token addresses to amounts, and returns an array of token maps — one per sub-intent. Submit each independently using `sendTransaction`.
+`splitIntents` takes the chain and a map of token addresses to amounts, and returns an array of token maps — one per intent. Submit each independently using `sendTransaction`.
 
 ```ts
 import { splitIntents } from '@rhinestone/sdk'
@@ -179,11 +179,11 @@ import { splitIntents } from '@rhinestone/sdk'
 const { intents } = await rhinestone.splitIntents({
   chain: base,
   tokens: {
-    [USDC_ADDRESS]: parseUnits('10000', 6), // 10,000 USDC — too large for one relayer
+    [USDC_ADDRESS]: parseUnits('10000', 6), // 10,000 USDC
   },
 })
 
-// Submit each sub-intent separately
+// Submit each intent separately
 for (const tokens of intents) {
   const tokenRequests = Object.entries(tokens).map(([address, amount]) => ({
     address: address as Address,
@@ -200,7 +200,3 @@ for (const tokens of intents) {
   })
 }
 ```
-
-<Note>
-  In a future SDK version, large intent splitting will be handled automatically inside `sendTransaction`.
-</Note>

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -166,3 +166,41 @@ const transaction = await rhinestoneAccount.sendTransaction({
 })
 const transactionResult = await rhinestone.getIntentStatus(transaction.id)
 ```
+
+## Large Intents
+
+When an intent is too large for a single relayer to fill, you can use `splitIntents` to break it into smaller sub-intents that can each be filled independently.
+
+`splitIntents` takes the chain and a map of token addresses to amounts, and returns an array of token maps — one per sub-intent. Submit each independently using `sendTransaction`.
+
+```ts
+import { splitIntents } from '@rhinestone/sdk'
+
+const { intents } = await rhinestone.splitIntents({
+  chain: base,
+  tokens: {
+    [USDC_ADDRESS]: parseUnits('10000', 6), // 10,000 USDC — too large for one relayer
+  },
+})
+
+// Submit each sub-intent separately
+for (const tokens of intents) {
+  const tokenRequests = Object.entries(tokens).map(([address, amount]) => ({
+    address: address as Address,
+    amount,
+  }))
+
+  await rhinestoneAccount.sendTransaction({
+    sourceChains: [base],
+    targetChain: arbitrum,
+    calls: [
+      // …
+    ],
+    tokenRequests,
+  })
+}
+```
+
+<Note>
+  In a future SDK version, large intent splitting will be handled automatically inside `sendTransaction`.
+</Note>

--- a/smart-wallet/core/create-account.mdx
+++ b/smart-wallet/core/create-account.mdx
@@ -53,7 +53,9 @@ Here, we create an account owned by an external wallet like MetaMask and send ou
     Create an account using the external wallet as the sole owner:
 
     ```ts
-    const rhinestone = new RhinestoneSDK()
+    const rhinestone = new RhinestoneSDK({
+  apiKey: process.env.RHINESTONE_API_KEY,
+})
 
     const account = walletClientToAccount(accountClient);
     console.log(account);

--- a/smart-wallet/quickstart.mdx
+++ b/smart-wallet/quickstart.mdx
@@ -60,7 +60,9 @@ const privateKey = generatePrivateKey()
 console.log(`Owner private key: ${privateKey}`)
 const account = privateKeyToAccount(privateKey)
 
-const rhinestone = new RhinestoneSDK()
+const rhinestone = new RhinestoneSDK({
+  apiKey: process.env.RHINESTONE_API_KEY,
+})
 const rhinestoneAccount = await rhinestone.createAccount({
   owners: {
     type: 'ecdsa',


### PR DESCRIPTION
## Changes

### Fix: `apiKey` is now required in `RhinestoneSDKConfig`

The `apiKey` field became non-optional in a recent SDK release. Two pages still called `new RhinestoneSDK()` with no arguments, which throws a TypeScript error.

- **`smart-wallet/quickstart.mdx`** — updated to `new RhinestoneSDK({ apiKey: process.env.RHINESTONE_API_KEY })`
- **`smart-wallet/core/create-account.mdx`** — same fix
- **`smart-wallet/advanced/migration-guide.mdx`** — removed `// Optional` comment on `apiKey`, replaced with `// Required`

### New: Large Intents / `splitIntents`

Added a **Large Intents** section to `smart-wallet/chain-abstraction/multi-chain-intent.mdx` documenting the `splitIntents()` method for cases where a single relayer cannot fill the full intent amount. Includes a note that this will be abstracted automatically in a future SDK version.