### PR TITLE
docs: update chains endpoint response format

### DIFF
--- a/home/resources/supported-chains.mdx
+++ b/home/resources/supported-chains.mdx
@@ -18,7 +18,7 @@ export const ChainsTable = ({ chains }) => (
         <tr key={chain.chainId} className="border-b border-gray-100 dark:border-gray-800">
           <td className="py-2 pr-4">{chain.name}</td>
           <td className="py-2 pr-4 text-right">{chain.chainId}</td>
-          <td className="py-2">{chain.supportsSwaps ? 'All' : (chain.supportedTokens?.map(t => t.symbol).join(', ') || '-')}</td>
+          <td className="py-2">{chain.supportedTokens === 'all' ? 'All' : (chain.supportedTokens?.map(t => t.symbol).join(', ') || '-')}</td>
         </tr>
       ))}
     </tbody>


### PR DESCRIPTION
## Summary
Updated the supported chains page to reflect the new `/chains` endpoint response structure from orchestrator PR #1161.

## Changes
- Changed supported tokens detection from `chain.supportsSwaps` to `chain.supportedTokens === 'all'`
- Aligns with the new endpoint which returns either the string `"all"` or an array of token objects instead of separate `supportsSwaps` and `supportedTokens` fields

🤖 Generated with Claude Code