### PR TITLE
docs: add K1 validator opt-in to Startale example

### DIFF
--- a/smart-wallet/customize/smart-account-providers.mdx
+++ b/smart-wallet/customize/smart-account-providers.mdx
@@ -51,10 +51,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
   owners: {
     type: 'ecdsa',
     accounts: [account],
-    // Optional: use the K1 validator instead of the default ownable validator.
-    // K1 enables ERC-7739/EIP-1271 signing support but only works with a single
-    // owner and produces a different account address than the default setup.
-    // module: '0x00000072f286204bb934ed49d8969e86f7dec7b1',
+    module: '0x00000072f286204bb934ed49d8969e86f7dec7b1',
   },
 })
 ```

--- a/smart-wallet/customize/smart-account-providers.mdx
+++ b/smart-wallet/customize/smart-account-providers.mdx
@@ -51,6 +51,10 @@ const rhinestoneAccount = await rhinestone.createAccount({
   owners: {
     type: 'ecdsa',
     accounts: [account],
+    // Optional: use the K1 validator instead of the default ownable validator.
+    // K1 enables ERC-7739/EIP-1271 signing support but only works with a single
+    // owner and produces a different account address than the default setup.
+    // module: '0x00000072f286204bb934ed49d8969e86f7dec7b1',
   },
 })
 ```


### PR DESCRIPTION
Adds an inline commented-out `module` field to the Startale code example showing how to opt in to the K1 (ECDSA) validator (`0x00000072f286204bb934ed49d8969e86f7dec7b1`).

Comment explains:
- K1 enables ERC-7739/EIP-1271 signing support
- Single-owner only
- Produces a different account address than the default ownable setup

Follows up on SDK PR #386.