### PR TITLE
docs: smart sessions per-chain session API (SDK PR #388)

### DIFF
--- a/smart-wallet/smart-sessions/multi-session-signature.mdx
+++ b/smart-wallet/smart-sessions/multi-session-signature.mdx
@@ -99,7 +99,7 @@ const data = await rhinestoneAccount.prepareTransaction({
     enableData: {
       userSignature: enableSignature,
       hashesAndChainIds: sessionDetails.hashesAndChainIds,
-      sessionIndex,
+      sessionToEnableIndex: sessionIndex,
     },
   },
 })
@@ -137,10 +137,9 @@ const rhinestoneAccount = await rhinestone.createAccount({
     type: 'ecdsa',
     accounts: [ownerAccount],
   },
-  sessions: [],
 })
 
-// Define the sessions
+// Define the sessions, one per chain
 const sessions: Session[] = [
   {
     chain: baseSepolia,
@@ -164,50 +163,46 @@ const sessionDetails =
 const enableSignature =
   await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
 
-// Enable and use the session on Base
-const sessionIndexBase = 0
-const dataBase = await rhinestoneAccount.prepareTransaction({
-  chain: baseSepolia,
-  calls: [
-    {
-      to: zeroAddress,
-      data: '0xdeadbeef',
+// Build the per-chain sessions map with enable data
+// The SDK resolves the right session and enable data automatically per chain
+const signers = {
+  type: 'experimental_session' as const,
+  sessions: {
+    [baseSepolia.id]: {
+      session: sessions[0],
+      enableData: {
+        userSignature: enableSignature,
+        hashesAndChainIds: sessionDetails.hashesAndChainIds,
+        sessionToEnableIndex: 0,
+      },
     },
-  ],
-  tokenRequests: [],
-  signers: {
-    type: 'experimental_session',
-    session: sessions[sessionIndexBase],
-    enableData: {
-      userSignature: enableSignature,
-      hashesAndChainIds: sessionDetails.hashesAndChainIds,
-      sessionIndex: sessionIndexBase,
+    [optimismSepolia.id]: {
+      session: sessions[1],
+      enableData: {
+        userSignature: enableSignature,
+        hashesAndChainIds: sessionDetails.hashesAndChainIds,
+        sessionToEnableIndex: 1,
+      },
     },
   },
+}
+
+// Submit on Base
+const dataBase = await rhinestoneAccount.prepareTransaction({
+  chain: baseSepolia,
+  calls: [{ to: zeroAddress, data: '0xdeadbeef' }],
+  tokenRequests: [],
+  signers,
 })
 const signedDataBase = await rhinestoneAccount.signTransaction(dataBase)
 await rhinestoneAccount.submitTransaction(signedDataBase)
 
-// Enable and use the session on Optimism (reusing the same signature)
-const sessionIndexOptimism = 1
+// Submit on Optimism (reusing the same signature and signers map)
 const dataOptimism = await rhinestoneAccount.prepareTransaction({
   chain: optimismSepolia,
-  calls: [
-    {
-      to: zeroAddress,
-      data: '0xdeadbeef',
-    },
-  ],
+  calls: [{ to: zeroAddress, data: '0xdeadbeef' }],
   tokenRequests: [],
-  signers: {
-    type: 'experimental_session',
-    session: sessions[sessionIndexOptimism],
-    enableData: {
-      userSignature: enableSignature,
-      hashesAndChainIds: sessionDetails.hashesAndChainIds,
-      sessionIndex: sessionIndexOptimism,
-    },
-  },
+  signers,
 })
 const signedDataOptimism = await rhinestoneAccount.signTransaction(dataOptimism)
 await rhinestoneAccount.submitTransaction(signedDataOptimism)


### PR DESCRIPTION
Updates smart sessions docs to match SDK PR #388 (per-chain session configuration).

**Changes:**
- Fix `sessionIndex` → `sessionToEnableIndex` in `enableData` (this was the wrong field name all along)
- Update complete example to use the new `sessions` map pattern (`PerChainSessionSignerSet`) instead of manually indexing into a sessions array per transaction
- The SDK now determines `verifyExecutions` internally via on-chain `isSessionEnabled` checks — removed from examples

**New API pattern (sessions map):**
```ts
signers: {
  type: 'experimental_session',
  sessions: {
    [baseSepolia.id]: { session, enableData: { ..., sessionToEnableIndex: 0 } },
    [optimismSepolia.id]: { session, enableData: { ..., sessionToEnableIndex: 1 } },
  },
}
```
The SDK resolves the right session + enable data automatically for the target chain.