### PR TITLE
fix: table th border-radius overlapping rounded corners

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,6 +32,14 @@ table th {
   background-color: #0d182f;
 }
 
+table th:first-child {
+  border-radius: 8px 0 0 0;
+}
+
+table th:last-child {
+  border-radius: 0 8px 0 0;
+}
+
 
 /* Sidebar active/selected item */
 .dark [data-active="true"],


### PR DESCRIPTION
## Summary
- Add `border-radius` to first and last `th` elements so the header background doesn't overlap the table's rounded corners