### PR TITLE
docs: clarify account deployment, funding, and sponsorship

### DIFF
--- a/smart-wallet/chain-abstraction/account-deployment.mdx
+++ b/smart-wallet/chain-abstraction/account-deployment.mdx
@@ -2,9 +2,24 @@
 title: "Account deployment"
 ---
 
-The SDK handles the account deployments for you. When transacting on a new chain for the first time, the account will be deployed as part of the intent. The Orchestrator automatically detects if the account needs to be deployed, then passes the init data to the relayer market as part of the intent, which is then exectuted by a relayer.
+The SDK handles the account deployments for you. When transacting on a new chain for the first time, the account will be deployed as part of the intent. The Orchestrator automatically detects if the account needs to be deployed, then passes the init data to the relayer market as part of the intent, which is then executed by a relayer.
 
-It's possible to make the deployment completely gasless for the user if you're using [sponsorships](../gas-sponsorship/overview).
+## How deployment works
+
+Deployment is per-chain. When you call `sendTransaction` targeting a chain where the account is not deployed yet, the Orchestrator bundles the deployment into the intent automatically. The account is only deployed on that specific chain, not on all supported chains at once.
+
+Receiving tokens at the counterfactual address does not trigger deployment. Only an outbound transaction submitted through the SDK does.
+
+## Who pays for deployment?
+
+| Scenario | Who pays | Source |
+|---|---|---|
+| Sponsorship enabled (`sponsored: true`) | You (the developer) | Your USDC sponsorship deposit on Base |
+| No sponsorship | The user | Tokens in the user's account on the target chain, or on another chain where they are already deployed |
+
+Developer sponsorship and the user's account balance are separate. Sponsorship is a developer-funded deposit that subsidises fees on behalf of users. The user's account balance is whatever tokens the user holds. See [Gas and fee sponsorship](../core/gas-fee-sponsorship) for setup details.
+
+<Note>You can make deployment completely gasless for the user with [sponsorships](../gas-sponsorship/overview).</Note>
 
 Otherwise, the user needs to have some tokens on either the chain you're deploying to, or any other [supported chain](../../home/resources/supported-chains) (provided the account is already deployed there).
 

--- a/smart-wallet/core/create-account.mdx
+++ b/smart-wallet/core/create-account.mdx
@@ -37,6 +37,8 @@ const accountAddress = account.getAddress()
 
 The SDK derives a deterministic account address from the owner configuration. The same owners always produce the same address, with no deployment transaction required upfront.
 
+<Note>Creating an account only computes a counterfactual address. The smart contract is not deployed until you send the first outbound transaction on a given chain. Receiving tokens (funding the address) does not trigger deployment.</Note>
+
 ## Custom nonce
 
 By default, the SDK uses a nonce of `0` to derive the account address. Pass a custom nonce to get a different address for the same set of owners. This is useful when you need multiple accounts per signer.

--- a/smart-wallet/core/create-account.mdx
+++ b/smart-wallet/core/create-account.mdx
@@ -39,6 +39,8 @@ The SDK derives a deterministic account address from the owner configuration. Th
 
 <Note>Creating an account only computes a counterfactual address. The smart contract is not deployed until you send the first outbound transaction on a given chain. Receiving tokens (funding the address) does not trigger deployment.</Note>
 
+<Warning>The smart account address is not the same as the signer address. If you look up your signer (EOA) on a block explorer, it will appear as a regular account. The smart account is a separate contract address derived from the owner configuration.</Warning>
+
 ## Custom nonce
 
 By default, the SDK uses a nonce of `0` to derive the account address. Pass a custom nonce to get a different address for the same set of owners. This is useful when you need multiple accounts per signer.
@@ -56,6 +58,22 @@ const account = await rhinestone.createAccount({
 ```
 
 <Note>Different nonce = different account address, even with identical owners.</Note>
+
+## Restore an existing account
+
+There is no `importAccount` method. The SDK derives the account address deterministically from the owner configuration, so calling `createAccount` with the same owners (and nonce) always returns the same account. To restore an account in a new session or on a different device, just call `createAccount` again with the original signer:
+
+```ts
+// Same signer + same nonce = same account address, every time
+const account = await rhinestone.createAccount({
+  owners: {
+    type: 'ecdsa',
+    accounts: [signer],
+  },
+})
+```
+
+No state is lost. The account's onchain history, balances, and modules are all tied to the deterministic address, not to the SDK instance.
 
 ## Choose a signer type
 

--- a/smart-wallet/core/create-first-transaction.mdx
+++ b/smart-wallet/core/create-first-transaction.mdx
@@ -85,6 +85,8 @@ const transaction = await rhinestoneAccount.submitTransaction(signedData)
 
 <Note>To deploy the account on a specific chain before transacting, call `await rhinestoneAccount.deploy(chain)` first.</Note>
 
+<Note>Any `sendTransaction` call triggers deployment if the account is not yet deployed on that chain. It does not have to be a token transfer. Contract calls, approvals, or any other action will deploy the account as part of the intent.</Note>
+
 ## Next steps
 
 <CardGroup cols={3}>

--- a/smart-wallet/core/gas-fee-sponsorship.mdx
+++ b/smart-wallet/core/gas-fee-sponsorship.mdx
@@ -7,6 +7,8 @@ Rhinestone lets you cover the fees for your users with a single onchain deposit.
 
 You can deposit USDC on Base, and subsidise gas, bridge fees, and swap fees across all chains.
 
+<Note>Sponsorship is separate from the user's own token balance. Without sponsorship, fees are deducted from the user's tokens. With sponsorship enabled, fees come from your developer deposit instead. The user's funds are never mixed with the sponsorship balance.</Note>
+
 ## Fee Types
 
 You can sponsor user fees in three ways:


### PR DESCRIPTION
Addresses customer questions about when smart accounts actually deploy and who pays for it.

## Changes

**`smart-wallet/core/create-account.mdx`**
- Added note that `createAccount` only computes a counterfactual address; receiving tokens does not trigger deployment

**`smart-wallet/chain-abstraction/account-deployment.mdx`**
- Added "How deployment works" section: deployment is per-chain, only on the target chain (not all chains at once)
- Added "Who pays for deployment?" table distinguishing developer sponsorship deposits from user account balances
- Fixed typo (exectuted → executed)

**`smart-wallet/core/gas-fee-sponsorship.mdx`**
- Added callout clarifying that sponsorship and user balances are separate

**`smart-wallet/core/create-first-transaction.mdx`**
- Added note that any `sendTransaction` call triggers deployment (not just transfers)

## Context

A customer (Daniel) had several questions about deployment that our docs didn't clearly answer:
- Does funding count as the first transaction?
- Is deployment per-chain or across all chains?
- What's the difference between the sponsorship pot and providing the orchestrator with funding?

All additive changes — no existing content removed.