### PR TITLE
Glow up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,17 @@ Content...
 
 Icons are Lucide names. Be aware that some Lucide icon names don't render in Mintlify — test locally before committing icon-heavy card groups. When in doubt, skip the icon prop.
 
+### Mermaid diagrams
+
+Always use `actions={false}` to disable pan/zoom controls:
+
+````mdx
+```mermaid actions={false}
+sequenceDiagram
+    User->>Server: Request
+```
+````
+
 ### Code blocks
 
 Use TypeScript for all code examples. Highlight specific lines with curly braces:

--- a/style.css
+++ b/style.css
@@ -163,9 +163,9 @@ table th:last-child {
   fill: #C7C6CC !important;
 }
 
-.mermaid svg .edgeLabel rect {
-  fill: transparent !important;
-  stroke: none !important;
+.mermaid .labelBkg,
+.mermaid .labelBkg * {
+  background: transparent !important;
 }
 
 /* Flowchart: markers */

--- a/style.css
+++ b/style.css
@@ -7,15 +7,15 @@
 table {
   border-collapse: separate;
   border-spacing: 0;
-  border: 1px solid #374151;
+  border: 1px solid #404045;
   border-radius: 8px;
   width: fit-content !important;
 }
 
 table th,
 table td {
-  border-right: 1px solid #374151;
-  border-bottom: 1px solid #374151;
+  border-right: 1px solid #404045;
+  border-bottom: 1px solid #404045;
   padding: 12px 16px !important;
 }
 
@@ -29,7 +29,7 @@ table tr:last-child td {
 }
 
 table th {
-  background-color: #0d182f;
+  background-color: #201E2C;
 }
 
 table th:first-child {

--- a/style.css
+++ b/style.css
@@ -41,6 +41,139 @@ table th:last-child {
 }
 
 
+/* Mermaid diagrams */
+
+[data-component-name="mermaid-controls-wrapper"] {
+  display: none !important;
+}
+
+/* Sequence diagram: participant boxes */
+.mermaid svg .actor {
+  fill: #17132E !important;
+  stroke: #373352 !important;
+}
+
+.mermaid svg rect.actor {
+  rx: 6;
+  ry: 6;
+}
+
+.mermaid svg text.actor > tspan {
+  fill: #D3CFF7 !important;
+}
+
+/* Sequence diagram: lifelines */
+.mermaid svg .actor-line {
+  stroke: #464359 !important;
+  stroke-width: 1 !important;
+}
+
+/* Sequence diagram: message lines */
+.mermaid svg .messageLine0,
+.mermaid svg .messageLine1 {
+  stroke: #464359 !important;
+  stroke-width: 1.5 !important;
+}
+
+/* Arrow heads */
+.mermaid svg #arrowhead path,
+.mermaid svg [id$="-arrowhead"] path {
+  fill: #464359 !important;
+  stroke: #464359 !important;
+}
+
+.mermaid svg #crosshead path,
+.mermaid svg [id$="-crosshead"] path {
+  stroke: #464359 !important;
+}
+
+/* Sequence diagram: message text */
+.mermaid svg .messageText {
+  fill: #C7C6CC !important;
+}
+
+/* Activation boxes */
+.mermaid svg .activation0,
+.mermaid svg .activation1,
+.mermaid svg .activation2 {
+  fill: #17132E !important;
+  stroke: #373352 !important;
+}
+
+/* Notes */
+.mermaid svg .note {
+  fill: #17132E !important;
+  stroke: #373352 !important;
+}
+
+.mermaid svg .noteText,
+.mermaid svg .noteText > tspan {
+  fill: #C7C6CC !important;
+}
+
+/* Loop boxes */
+.mermaid svg .loopText,
+.mermaid svg .loopText > tspan {
+  fill: #C7C6CC !important;
+}
+
+.mermaid svg .loopLine {
+  stroke: #373352 !important;
+}
+
+.mermaid svg .labelBox {
+  fill: #17132E !important;
+  stroke: #373352 !important;
+}
+
+.mermaid svg .labelText,
+.mermaid svg .labelText > tspan {
+  fill: #C7C6CC !important;
+}
+
+/* Sequence number markers */
+.mermaid svg .sequenceNumber {
+  fill: #D3CFF7 !important;
+}
+
+/* Flowchart: nodes */
+.mermaid svg .node rect,
+.mermaid svg .node circle,
+.mermaid svg .node ellipse,
+.mermaid svg .node polygon,
+.mermaid svg .node path {
+  fill: #17132E !important;
+  stroke: #373352 !important;
+}
+
+.mermaid svg .nodeLabel,
+.mermaid svg .node .label {
+  color: #D3CFF7 !important;
+  fill: #D3CFF7 !important;
+}
+
+/* Flowchart: edges */
+.mermaid svg .flowchart-link {
+  stroke: #464359 !important;
+}
+
+.mermaid svg .edgeLabel,
+.mermaid svg .edge-label {
+  color: #C7C6CC !important;
+  fill: #C7C6CC !important;
+}
+
+.mermaid svg .edgeLabel rect {
+  fill: transparent !important;
+  stroke: none !important;
+}
+
+/* Flowchart: markers */
+.mermaid svg .marker {
+  fill: #464359 !important;
+  stroke: #464359 !important;
+}
+
 /* Sidebar active/selected item */
 .dark [data-active="true"],
 .dark [aria-current="page"],


### PR DESCRIPTION
## Summary
- Update table border color to `#404045` and header background to `#201E2C`
- Add custom mermaid diagram styling (dark purple theme matching site design)
- Hide mermaid pan/zoom controls via CSS
- Document `actions={false}` for mermaid blocks in AGENTS.md

## Visuals

### Tables

_Before_

<img width="473" height="400" alt="Screenshot 2026-04-13 at 13 19 12" src="https://github.com/user-attachments/assets/473fdbef-b151-45f9-aeae-0c3ed12ce446" />

_After_

<img width="399" height="400" alt="Screenshot 2026-04-09 at 17 20 56" src="https://github.com/user-attachments/assets/c92b0c4d-c2a7-49e5-a709-eda7b8d46f83" />

### Mermaid diagrams

_Before_

<img width="635" height="400" alt="Screenshot 2026-04-13 at 13 18 45" src="https://github.com/user-attachments/assets/cb8c686d-0fee-4e48-a15a-6946d22114b1" />

_After_

<img width="651" height="400" alt="Screenshot 2026-04-09 at 17 21 07" src="https://github.com/user-attachments/assets/5dc53c5b-06be-4f8e-ae4d-601928ffcbca" />