### PR TITLE
docs: clarify recent SDK session and EIP-7702 behavior

### DIFF
--- a/intents/guides/signing.mdx
+++ b/intents/guides/signing.mdx
@@ -8,6 +8,10 @@ description: "Sign each element of the intent using EIP-712."
   Always fetch a fresh quote immediately before signing. Submitting signatures built from a stale quote will result in an expiry error.
 </Info>
 
+<Warning>
+  Treat `preClaimOps` and other route-derived fields as immutable once the quote is returned. If you need additional pre-claim executions for session enablement or similar flows, include them in the route request via the SDK or orchestrator request rather than mutating the returned route. Mutating these fields after quoting can invalidate the checksum signature.
+</Warning>
+
 Warp uses [EIP-712](https://eips.ethereum.org/EIPS/eip-712) for typed, human-readable signing. The signature scheme depends on the settlement layer used for each bundle element.
 
 ## Signature types

--- a/intents/use-cases/automated-zaps.mdx
+++ b/intents/use-cases/automated-zaps.mdx
@@ -167,11 +167,15 @@ await companionAccount.sendTransaction({
     enableData: {
       userSignature: enableSignature,
       hashesAndChainIds: sessionDetails.hashesAndChainIds,
-      sessionIndex: 0,
+      sessionToEnableIndex: 0,
     },
   },
 });
 ```
+
+<Note>
+The SDK handles the session enable pre-claim plumbing during route construction. Do not mutate route-derived pre-claim operations after quoting.
+</Note>
 
 <Note>
 After submitting the intent, poll the intent status until it reaches a terminal state (`COMPLETED`, `FILLED`, `FAILED`, or `EXPIRED`). This typically takes a few seconds for cross-chain settlements.

--- a/smart-wallet/chain-abstraction/error-handling.mdx
+++ b/smart-wallet/chain-abstraction/error-handling.mdx
@@ -15,8 +15,7 @@ title: "Error handling"
 ## Execution errors
 
 * `SourceChainsNotAvailableForUserOpFlowError`: when using a UserOp flow (e.g., for account recovery), you need to provide a source chain.
-* `UserOperationRequiredForSmartSessionsError`: when using smart sessions, you need to use the UserOp flow.
-* `SessionChainRequiredError`: when using smart sessions, each session needs to define a chain where it is activated.
+* `SessionChainRequiredError`: when using multi-chain smart sessions, you need to specify which chain to prepare the transaction for.
 * `IntentFailedError`: the intent failed (reverted onchain). A common reason is that a swap failed due to price action.
 * `SimulationNotSupportedForUserOpFlowError`: `simulateTransaction` can only simulate intents.
 * `OrderPathRequiredForIntentsError`: when sending an intent, you need to first get the path. When using `submitTransaction`, make sure to call `prepareTransaction` first.

--- a/smart-wallet/core/eip-7702.mdx
+++ b/smart-wallet/core/eip-7702.mdx
@@ -62,7 +62,7 @@ Sending a transaction with an EIP-7702 account requires two additional signing s
     ```
 
     <Info>
-    The init signature is valid cross-chain, so you can cache it and reuse it. Always provide it when preparing a transaction — the account may need to be initialised on any of the source or target chains.
+    The init signature is valid cross-chain, so you can cache it and reuse it. Passing `eip7702InitSignature` explicitly is still recommended when you want predictable reuse across chains, but recent SDK versions can also auto-sign the init data for supported flows if you do not provide it.
     </Info>
   </Step>
   <Step title="Prepare the transaction">


### PR DESCRIPTION
## Summary
- clarify current EIP-7702 init signature behavior
- remove stale smart sessions UserOp guidance from error handling
- warn against mutating route-derived pre-claim ops after quoting
- fix `sessionToEnableIndex` in automated zaps

## Why
Recent SDK changes made the current docs slightly stale in a few focused places. This keeps the docs aligned without expanding scope.

## Testing
- content-only changes

cc @Destiner