### PR TITLE
docs: add API versioning guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -218,6 +218,7 @@
             "group": "API guides",
             "pages": [
               "intents/guides/using-the-api",
+              "intents/guides/api-versioning",
               "intents/guides/getting-a-quote",
               "intents/guides/token-requirements",
               "intents/guides/signing",

--- a/intents/guides/api-versioning.mdx
+++ b/intents/guides/api-versioning.mdx
@@ -289,9 +289,7 @@ The list is extensible — add unknown codes to a generic fallback path.
 
 **Things you can't migrate**
 
-<Warning>
 The Compact / resource-lock surface has no blanc equivalent. If your integration depends on `topupCompact`, `emissaryConfig`, the `/withdrawals` endpoints, or `MultichainCompact` origin signatures, stay on `alps` until a replacement ships.
-</Warning>
 
 ### `2026-01.alps`
 

--- a/intents/guides/api-versioning.mdx
+++ b/intents/guides/api-versioning.mdx
@@ -123,14 +123,47 @@ const sig = await signer.signTypedData(types, hash);
 const sig = await signer.signTypedData(signData.origin[0]);
 ```
 
+**Submit response**
+
+```ts
+// Before (alps) — wrapped, with synthesised status
+const { result } = await post("/intent-operations", body);
+const id = result.id; // result.status was "PENDING" or synthesised "FAILED"
+
+// After (blanc) — id only; simulation failures surface as 4xx
+const { intentId } = await post("/intents", body);
+```
+
+**Status polling**
+
+```ts
+// Before (alps)
+const op = await get(`/intent-operation/${id}`);
+const status = op.result.status;
+
+// After (blanc)
+const op = await get(`/intents/${intentId}`);
+const status = op.status;
+```
+
+The status enum is narrower in blanc — legacy values that no longer apply are removed. `PRECONFIRMED` is gone; if your client branches on it, drop that case.
+
+**Splits endpoint**
+
+`POST /intents/split` → `POST /intents/splits`. Request and response shapes follow the same blanc-wide rules (CAIP-2 chain ids, unified error envelope).
+
 **Chain ids**
+
+CAIP-2 strings (`eip155:<chainId>`) replace numeric chain ids on every field that carries one — `chainId`, `sourceChainId`, `destinationChainId`, `chainIds`, `allChainIds`, and chain-keyed maps like `auxiliaryFunds`, `preClaimExecutions`, `chainTokens`, and `tokenRequirements`. Path parameters are unchanged.
 
 ```ts
 // Before (alps)
 { "chainId": 42161 }
+{ "tokenRequirements": { "1": [...], "42161": [...] } }
 
 // After (blanc)
 { "chainId": "eip155:42161" }
+{ "tokenRequirements": { "eip155:1": [...], "eip155:42161": [...] } }
 ```
 
 The portfolio filter switches from comma-separated lists to repeated query parameters, with `tokens` keyed as `chain:address`:
@@ -151,6 +184,69 @@ const inputAmount = response.tokensSpent[0].amount;
 // After (blanc)
 const gasUSD = route.cost.fees.breakdown.gas.usd;
 const inputAmount = route.cost.input[0].amount;
+```
+
+**Field renames**
+
+| Before (alps)         | After (blanc)         |
+| --------------------- | --------------------- |
+| `userAddress`         | `accountAddress`      |
+| `destinationGasUnits` | `destinationGasLimit` |
+| `tokensSpent`         | `cost.input`          |
+| `tokensReceived`      | `cost.output`         |
+| `feeBreakdownUSD`     | `cost.fees.breakdown` |
+| `tokenName`           | `symbol`              |
+| `tokenChainBalance`   | `chains`              |
+| `tokenAddress`        | `address`             |
+| `tokenDecimals`       | `decimals`            |
+
+Timestamps move from `BigIntLike` strings (`"1700000000"`) to integer Unix seconds (`1700000000`).
+
+**Sponsor settings**
+
+```ts
+// Before (alps)
+{
+  sponsorSettings: {
+    gasSponsored: true,
+    bridgeFeesSponsored: false,
+    swapFeesSponsored: false,
+  }
+}
+
+// After (blanc)
+{
+  sponsorSettings: {
+    gas: true,
+    bridgeFees: false,
+    swapFees: false,
+  }
+}
+```
+
+**Account types and mock signatures**
+
+`AccountType.SMART_ACCOUNT` is gone — use `ERC7579`. The flat `accountAccessList` array shape is gone — use the structured shape. Mock signatures move from a single `Account.mockSignature` to a per-chain `Account.mockSignatures` map.
+
+```ts
+// Before (alps)
+{
+  account: {
+    accountType: "SMART_ACCOUNT",
+    mockSignature: "0x...",
+  }
+}
+
+// After (blanc)
+{
+  account: {
+    accountType: "ERC7579",
+    mockSignatures: {
+      "eip155:1": "0x...",
+      "eip155:42161": "0x...",
+    },
+  }
+}
 ```
 
 **Error handling**
@@ -190,6 +286,12 @@ Honour `Retry-After` on `429 TOO_MANY_REQUESTS`.
 | `EXTERNAL_SERVICE_TIMEOUT`    | 504  |
 
 The list is extensible — add unknown codes to a generic fallback path.
+
+**Things you can't migrate**
+
+<Warning>
+The Compact / resource-lock surface has no blanc equivalent. If your integration depends on `topupCompact`, `emissaryConfig`, the `/withdrawals` endpoints, or `MultichainCompact` origin signatures, stay on `alps` until a replacement ships.
+</Warning>
 
 ### `2026-01.alps`
 

--- a/intents/guides/api-versioning.mdx
+++ b/intents/guides/api-versioning.mdx
@@ -1,0 +1,137 @@
+---
+title: "API versioning"
+description: "How the Rhinestone API evolves, how to pin a version, and how to migrate between them."
+---
+
+The Rhinestone API is versioned. Pin a version via the `x-api-version` header and upgrade on your own schedule — new versions are additive and opt-in.
+
+## Why versioning
+
+The API evolves as Rhinestone adds chains, settlement layers, and new intent patterns. Versioning lets us ship those changes without forcing every integrator to migrate in lockstep.
+
+We use dated versions (`YYYY-MM.name`) rather than semver-style major versions. Semver majors tend to hoard changes into rare, big-bang releases — each bump looks like a migration project, so teams avoid shipping them. Dated versions normalise small, frequent bumps, so each one carries a small diff. Stripe and other mature APIs follow the same model.
+
+The `.name` suffix gives each release a human handle. We name versions after mountains, one per letter — `alps`, `blanc`, `corno`, and so on. It's easier to say "switch to blanc" than "switch to 2026-04".
+
+## Pinning a version
+
+Pin a version by sending `x-api-version` on every request:
+
+```ts {6}
+const res = await fetch("https://v1.orchestrator.rhinestone.dev/intents/route", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "x-api-version": "2026-01.alps",
+  },
+  body: JSON.stringify(payload),
+});
+```
+
+The format is `YYYY-MM.name`. The header is required — requests without it are rejected.
+
+## Compatibility
+
+### What we can change without a new version
+
+Within a version, we treat the response schema as open. These changes ship freely:
+
+- New optional request fields
+- New response fields
+- New enum variants in responses (e.g. a new `settlementLayer`)
+- New endpoints
+- Widened request validation
+- Changed default values
+
+### What your client must do
+
+To consume those changes safely:
+
+- **Ignore unknown fields.** If you use a strict JSON parser (Go's `DisallowUnknownFields`, Rust `serde(deny_unknown_fields)`, Jackson's `FAIL_ON_UNKNOWN_PROPERTIES`), disable it for our responses.
+- **Handle unknown enum values gracefully.** A `switch` on `settlementLayer` that throws on default will break the day we add a new one. Treat unknown values as "not supported by this client" and fall back.
+- **Don't reconstruct EIP-712 types client-side.** Forward the server's typed data verbatim to `wallet.signTypedData()`. Hand-rolled type libraries break on additive schema changes.
+- **Treat quote 404s as normal.** Quoted intents are stored server-side with a short TTL. If a quote expires or the quote store restarts, you'll see 404 on submit. Re-quote — don't retry the submit.
+- **Take `routes[0]` unless you have your own criteria.** The array is server-sorted by cost. Re-sorting client-side usually degrades route quality.
+
+### What triggers a new version
+
+- Removing or renaming any field
+- Adding a required request field
+- Changing a field's type
+- Restructuring request or response shape
+- Narrowing request validation
+- Making a required response field optional or nullable
+- Removing an endpoint
+
+### Deprecation lifecycle
+
+Fields deprecated in version N remain present and documented as deprecated; they're removed in N+1. Versions themselves are not routinely deprecated — each version is intended to stay live indefinitely so you never have to migrate on our clock.
+
+The one exception is `2026-01.alps`, which will be sunset after integrators migrate to `blanc`. The shape difference between the two is large enough that maintaining both long-term isn't practical. Future version transitions will follow the standard per-field deprecation rule.
+
+## Versions
+
+### `2026-04.blanc`
+
+The current version. Start here if you're integrating from scratch.
+
+**What changed:**
+
+- **Server-stored intents.** `POST /intents/route` returns an `intentId`; the full intent payload stays server-side. Submit via `POST /intents/{intentId}/submit` with just signatures — no more round-tripping `intentOp`.
+- **EIP-712 typed data in the response.** Forward `signData.origin[]` and `signData.destination` directly to `wallet.signTypedData()`. The SDK no longer maintains type definitions.
+- **Flat `routes[]` array.** Each route has its own `intentId`, `cost`, and `signData`. Pre-sorted by cost — `routes[0]` is the recommended route.
+- **Flattened cost structure.** One `cost` object per route with `input`, `output`, and USD-denominated `fees.breakdown`. Replaces the scattered `tokensSpent` / `tokensReceived` / `feeBreakdownUSD` / `gasCost` / `sponsorFee` fields.
+
+#### Migrating from `alps`
+
+**Quote and submit**
+
+```ts
+// Before (alps) — client round-trips the full intentOp
+const { intentOp } = await post("/intents/route", body);
+const signatures = await sign(intentOp);
+await post("/intent-operations", {
+  signedIntentOp: { ...intentOp, ...signatures },
+});
+
+// After (blanc) — server stores the intent, client submits signatures by id
+const { routes } = await post("/intents/route", body);
+const { intentId, signData } = routes[0];
+const signatures = {
+  origin: await Promise.all(signData.origin.map(signTypedData)),
+  destination: await signTypedData(signData.destination),
+};
+await post(`/intents/${intentId}/submit`, { signatures });
+```
+
+**Signing**
+
+```ts
+// Before (alps) — client hashes intent fields with hand-built EIP-712 types
+const hash = getIntentHash(intentOp);
+const sig = await signer.signTypedData(types, hash);
+
+// After (blanc) — server provides the typed data directly
+const sig = await signer.signTypedData(signData.origin[0]);
+```
+
+**Reading costs**
+
+```ts
+// Before (alps)
+const gasUSD = response.feeBreakdownUSD.gas;
+const inputAmount = response.tokensSpent[0].amount;
+
+// After (blanc)
+const gasUSD = route.cost.fees.breakdown.gas.usd;
+const inputAmount = route.cost.input[0].amount;
+```
+
+### `2026-01.alps`
+
+The original release. Intents are round-tripped through the client, signed via client-reconstructed EIP-712, and submitted with the full `intentOp` attached to `signedIntentOp`.
+
+<Warning>
+Deprecated. Will be removed once existing integrations migrate to `blanc`. No new features will land on this version.
+</Warning>

--- a/intents/guides/api-versioning.mdx
+++ b/intents/guides/api-versioning.mdx
@@ -78,17 +78,17 @@ The current version. Start here if you're integrating from scratch.
 
 **What changed:**
 
-- **CAIP-2 chain ids.** Every chain id on the wire is now an `eip155:<chainId>` string — `1` becomes `"eip155:1"`. Affects scalar fields, arrays, and chain-keyed maps. Path parameters are unchanged.
-- **Resource-style endpoints.** `POST /quotes` (was `/intents/route`), `POST /intents` (was `/intent-operations`), `GET /intents/:id` (was `/intent-operation/:id`), `POST /intents/splits` (was `/intents/split`).
-- **Server-stored intents.** `POST /quotes` returns an `intentId`; the full intent stays server-side. Submit via `POST /intents` with `{ intentId, signatures }` — no more round-tripping `intentOp`.
-- **Submit response collapsed.** `POST /intents` returns just `{ intentId }` (was `{ result: { id, status } }`). The synthesised `status: "FAILED"` is gone — simulation failures now surface as 4xx with the unified error envelope.
-- **EIP-712 typed data in the response.** Forward `signData.origin[]` and `signData.destination` directly to `wallet.signTypedData()`. No more client-side type reconstruction.
 - **Flat `routes[]` array.** Each route carries its own `intentId`, `cost`, `signData`, and `tokenRequirements` (EOAs only — smart accounts handle approvals internally). Pre-ranked; `routes[0]` is recommended.
+- **CAIP-2 chain ids.** Every chain id on the wire is now an `eip155:<chainId>` string — `1` becomes `"eip155:1"`. Affects scalar fields, arrays, and chain-keyed maps. Path parameters are unchanged.
+- **EIP-712 typed data in the response.** Forward `signData.origin[]` and `signData.destination` directly to `wallet.signTypedData()`. No more client-side type reconstruction.
+- **Server-stored intents.** `POST /quotes` returns an `intentId`; the full intent stays server-side. Submit via `POST /intents` with `{ intentId, signatures }` — no more round-tripping `intentOp`.
+- **Resource-style endpoints.** `POST /quotes` (was `/intents/route`), `POST /intents` (was `/intent-operations`), `GET /intents/:id` (was `/intent-operation/:id`), `POST /intents/splits` (was `/intents/split`).
 - **Flattened cost structure.** One `cost` object per route with `input`, `output`, and `fees: { total, breakdown }`. Replaces scattered `tokensSpent` / `tokensReceived` / `feeBreakdownUSD` / `gasCost` / `sponsorFee`.
-- **Unified error envelope.** All non-2xx responses share `{ code, message, traceId, details? }`. Switch from message-pattern matching to `code`-based dispatch.
+- **Submit response collapsed.** `POST /intents` returns just `{ intentId }` (was `{ result: { id, status } }`). The synthesised `status: "FAILED"` is gone — simulation failures now surface as 4xx with the unified error envelope.
 - **Field renames.** Notable: `destinationGasUnits` → `destinationGasLimit`, `sponsorSettings.{gas,bridgeFees,swapFees}Sponsored` → `{gas,bridgeFees,swapFees}`, `userAddress` → `accountAddress`. Portfolio token shape uses `symbol` (was `tokenName`), `chains` (was `tokenChainBalance`), and per-chain `address`/`decimals` (were `tokenAddress`/`tokenDecimals`). Timestamps move from `BigIntLike` strings to integer Unix seconds.
+- **Unified error envelope.** All non-2xx responses share `{ code, message, traceId, details? }`. Switch from message-pattern matching to `code`-based dispatch.
 - **Schema trimming.** `Account.mockSignature` is gone — use the per-chain `Account.mockSignatures` map. `AccountType.SMART_ACCOUNT` is gone — use `ERC7579`. The `accountAccessList` flat-array variant is gone — use the structured shape.
-- **Compact / resource locks removed.** No blanc equivalent for `topupCompact`, `emissaryConfig`, `MultichainCompact` origin signatures, or the `/withdrawals` endpoints. Stay on `alps` if you depend on them.
+- **Compact / resource locks removed.** No blanc equivalent for `topupCompact`, `emissaryConfig`, `MultichainCompact` origin signatures, or the `/withdrawals` endpoints.
 
 #### Migrating from `alps`
 

--- a/intents/guides/api-versioning.mdx
+++ b/intents/guides/api-versioning.mdx
@@ -18,18 +18,18 @@ The `.name` suffix gives each release a human handle. We name versions after mou
 Pin a version by sending `x-api-version` on every request:
 
 ```ts {6}
-const res = await fetch("https://v1.orchestrator.rhinestone.dev/intents/route", {
+const res = await fetch("https://v1.orchestrator.rhinestone.dev/quotes", {
   method: "POST",
   headers: {
     "Content-Type": "application/json",
     "x-api-key": apiKey,
-    "x-api-version": "2026-01.alps",
+    "x-api-version": "2026-04.blanc",
   },
   body: JSON.stringify(payload),
 });
 ```
 
-The format is `YYYY-MM.name`. The header is required — requests without it are rejected.
+The format is `YYYY-MM.name`. Always send the header — requests without it fall back to the deprecated `2026-01.alps` shape, and unknown or malformed values return `400 VALIDATION_ERROR`.
 
 ## Compatibility
 
@@ -78,10 +78,17 @@ The current version. Start here if you're integrating from scratch.
 
 **What changed:**
 
-- **Server-stored intents.** `POST /intents/route` returns an `intentId`; the full intent payload stays server-side. Submit via `POST /intents/{intentId}/submit` with just signatures — no more round-tripping `intentOp`.
-- **EIP-712 typed data in the response.** Forward `signData.origin[]` and `signData.destination` directly to `wallet.signTypedData()`. The SDK no longer maintains type definitions.
-- **Flat `routes[]` array.** Each route has its own `intentId`, `cost`, and `signData`. Pre-sorted by cost — `routes[0]` is the recommended route.
-- **Flattened cost structure.** One `cost` object per route with `input`, `output`, and USD-denominated `fees.breakdown`. Replaces the scattered `tokensSpent` / `tokensReceived` / `feeBreakdownUSD` / `gasCost` / `sponsorFee` fields.
+- **CAIP-2 chain ids.** Every chain id on the wire is now an `eip155:<chainId>` string — `1` becomes `"eip155:1"`. Affects scalar fields, arrays, and chain-keyed maps. Path parameters are unchanged.
+- **Resource-style endpoints.** `POST /quotes` (was `/intents/route`), `POST /intents` (was `/intent-operations`), `GET /intents/:id` (was `/intent-operation/:id`), `POST /intents/splits` (was `/intents/split`).
+- **Server-stored intents.** `POST /quotes` returns an `intentId`; the full intent stays server-side. Submit via `POST /intents` with `{ intentId, signatures }` — no more round-tripping `intentOp`.
+- **Submit response collapsed.** `POST /intents` returns just `{ intentId }` (was `{ result: { id, status } }`). The synthesised `status: "FAILED"` is gone — simulation failures now surface as 4xx with the unified error envelope.
+- **EIP-712 typed data in the response.** Forward `signData.origin[]` and `signData.destination` directly to `wallet.signTypedData()`. No more client-side type reconstruction.
+- **Flat `routes[]` array.** Each route carries its own `intentId`, `cost`, `signData`, and `tokenRequirements` (EOAs only — smart accounts handle approvals internally). Pre-sorted by cost; `routes[0]` is recommended.
+- **Flattened cost structure.** One `cost` object per route with `input`, `output`, and `fees: { total, breakdown }`. Replaces scattered `tokensSpent` / `tokensReceived` / `feeBreakdownUSD` / `gasCost` / `sponsorFee`.
+- **Unified error envelope.** All non-2xx responses share `{ code, message, traceId, details? }`. Switch from message-pattern matching to `code`-based dispatch.
+- **Field renames.** Notable: `destinationGasUnits` → `destinationGasLimit`, `sponsorSettings.{gas,bridgeFees,swapFees}Sponsored` → `{gas,bridgeFees,swapFees}`, `userAddress` → `accountAddress`. Portfolio token shape uses `symbol` (was `tokenName`), `chains` (was `tokenChainBalance`), and per-chain `address`/`decimals` (were `tokenAddress`/`tokenDecimals`). Timestamps move from `BigIntLike` strings to integer Unix seconds.
+- **Schema trimming.** `Account.mockSignature` is gone — use the per-chain `Account.mockSignatures` map. `AccountType.SMART_ACCOUNT` is gone — use `ERC7579`. The `accountAccessList` flat-array variant is gone — use the structured shape.
+- **Compact / resource locks removed.** No blanc equivalent for `topupCompact`, `emissaryConfig`, `MultichainCompact` origin signatures, or the `/withdrawals` endpoints. Stay on `alps` if you depend on them.
 
 #### Migrating from `alps`
 
@@ -96,13 +103,13 @@ await post("/intent-operations", {
 });
 
 // After (blanc) — server stores the intent, client submits signatures by id
-const { routes } = await post("/intents/route", body);
+const { routes } = await post("/quotes", body);
 const { intentId, signData } = routes[0];
 const signatures = {
   origin: await Promise.all(signData.origin.map(signTypedData)),
   destination: await signTypedData(signData.destination),
 };
-await post(`/intents/${intentId}/submit`, { signatures });
+await post("/intents", { intentId, signatures });
 ```
 
 **Signing**
@@ -114,6 +121,24 @@ const sig = await signer.signTypedData(types, hash);
 
 // After (blanc) — server provides the typed data directly
 const sig = await signer.signTypedData(signData.origin[0]);
+```
+
+**Chain ids**
+
+```ts
+// Before (alps)
+{ "chainId": 42161 }
+
+// After (blanc)
+{ "chainId": "eip155:42161" }
+```
+
+The portfolio filter switches from comma-separated lists to repeated query parameters, with `tokens` keyed as `chain:address`:
+
+```
+GET /accounts/0xabc/portfolio
+  ?chainIds=eip155:1&chainIds=eip155:137
+  &tokens=eip155:1:0xa0b...&tokens=eip155:137:0xa0b...
 ```
 
 **Reading costs**
@@ -128,9 +153,47 @@ const gasUSD = route.cost.fees.breakdown.gas.usd;
 const inputAmount = route.cost.input[0].amount;
 ```
 
+**Error handling**
+
+```ts
+// Before (alps) — message-pattern matching
+if (err.message === "Insufficient balance") { /* ... */ }
+if (err.message.startsWith("Unsupported chain ")) { /* ... */ }
+
+// After (blanc) — code-based dispatch
+switch (err.code) {
+  case "INSUFFICIENT_LIQUIDITY":
+    // err.details: { availableIntents, unfillable }
+    break;
+  case "VALIDATION_ERROR":
+    // err.details: [{ message, context? }]
+    break;
+}
+```
+
+Honour `Retry-After` on `429 TOO_MANY_REQUESTS`.
+
+| Code                          | HTTP |
+| ----------------------------- | ---- |
+| `VALIDATION_ERROR`            | 400  |
+| `UNAUTHORIZED`                | 401  |
+| `FORBIDDEN`                   | 403  |
+| `NOT_FOUND`                   | 404  |
+| `CONFLICT`                    | 409  |
+| `UNPROCESSABLE_CONTENT`       | 422  |
+| `INSUFFICIENT_LIQUIDITY`      | 422  |
+| `TOO_MANY_REQUESTS`           | 429  |
+| `INTERNAL_ERROR`              | 500  |
+| `SETTLEMENT_QUOTE_ERROR`      | 502  |
+| `SETTLEMENT_EXECUTION_ERROR`  | 502  |
+| `RELAYER_MARKET_UNAVAILABLE`  | 503  |
+| `EXTERNAL_SERVICE_TIMEOUT`    | 504  |
+
+The list is extensible — add unknown codes to a generic fallback path.
+
 ### `2026-01.alps`
 
-The original release. Intents are round-tripped through the client, signed via client-reconstructed EIP-712, and submitted with the full `intentOp` attached to `signedIntentOp`.
+The original release. Intents are round-tripped through the client, signed via client-reconstructed EIP-712, and submitted with the full `intentOp` attached to `signedIntentOp`. The Compact / resource-lock surface (`topupCompact`, `emissaryConfig`, `/withdrawals`, `MultichainCompact` signatures) is only available on this version — stay on `alps` if you depend on it.
 
 <Warning>
 Deprecated. Will be removed once existing integrations migrate to `blanc`. No new features will land on this version.

--- a/intents/guides/api-versioning.mdx
+++ b/intents/guides/api-versioning.mdx
@@ -9,7 +9,7 @@ The Rhinestone API is versioned. Pin a version via the `x-api-version` header an
 
 The API evolves as Rhinestone adds chains, settlement layers, and new intent patterns. Versioning lets us ship those changes without forcing every integrator to migrate in lockstep.
 
-We use dated versions (`YYYY-MM.name`) rather than semver-style major versions. Semver majors tend to hoard changes into rare, big-bang releases — each bump looks like a migration project, so teams avoid shipping them. Dated versions normalise small, frequent bumps, so each one carries a small diff. Stripe and other mature APIs follow the same model.
+We use dated versions (`YYYY-MM.name`) rather than semver-style major versions. Semver majors tend to hoard changes into rare, big-bang releases — each bump looks like a migration project, so teams avoid shipping them. Dated versions normalise small, frequent bumps, so each one carries a small diff.
 
 The `.name` suffix gives each release a human handle. We name versions after mountains, one per letter — `alps`, `blanc`, `corno`, and so on. It's easier to say "switch to blanc" than "switch to 2026-04".
 
@@ -52,7 +52,7 @@ To consume those changes safely:
 - **Handle unknown enum values gracefully.** A `switch` on `settlementLayer` that throws on default will break the day we add a new one. Treat unknown values as "not supported by this client" and fall back.
 - **Don't reconstruct EIP-712 types client-side.** Forward the server's typed data verbatim to `wallet.signTypedData()`. Hand-rolled type libraries break on additive schema changes.
 - **Treat quote 404s as normal.** Quoted intents are stored server-side with a short TTL. If a quote expires or the quote store restarts, you'll see 404 on submit. Re-quote — don't retry the submit.
-- **Take `routes[0]` unless you have your own criteria.** The array is server-sorted by cost. Re-sorting client-side usually degrades route quality.
+- **Take `routes[0]` unless you have your own criteria.** The array is server-ranked by a cost/speed tradeoff. Re-sorting client-side usually degrades route quality.
 
 ### What triggers a new version
 
@@ -83,7 +83,7 @@ The current version. Start here if you're integrating from scratch.
 - **Server-stored intents.** `POST /quotes` returns an `intentId`; the full intent stays server-side. Submit via `POST /intents` with `{ intentId, signatures }` — no more round-tripping `intentOp`.
 - **Submit response collapsed.** `POST /intents` returns just `{ intentId }` (was `{ result: { id, status } }`). The synthesised `status: "FAILED"` is gone — simulation failures now surface as 4xx with the unified error envelope.
 - **EIP-712 typed data in the response.** Forward `signData.origin[]` and `signData.destination` directly to `wallet.signTypedData()`. No more client-side type reconstruction.
-- **Flat `routes[]` array.** Each route carries its own `intentId`, `cost`, `signData`, and `tokenRequirements` (EOAs only — smart accounts handle approvals internally). Pre-sorted by cost; `routes[0]` is recommended.
+- **Flat `routes[]` array.** Each route carries its own `intentId`, `cost`, `signData`, and `tokenRequirements` (EOAs only — smart accounts handle approvals internally). Pre-ranked; `routes[0]` is recommended.
 - **Flattened cost structure.** One `cost` object per route with `input`, `output`, and `fees: { total, breakdown }`. Replaces scattered `tokensSpent` / `tokensReceived` / `feeBreakdownUSD` / `gasCost` / `sponsorFee`.
 - **Unified error envelope.** All non-2xx responses share `{ code, message, traceId, details? }`. Switch from message-pattern matching to `code`-based dispatch.
 - **Field renames.** Notable: `destinationGasUnits` → `destinationGasLimit`, `sponsorSettings.{gas,bridgeFees,swapFees}Sponsored` → `{gas,bridgeFees,swapFees}`, `userAddress` → `accountAddress`. Portfolio token shape uses `symbol` (was `tokenName`), `chains` (was `tokenChainBalance`), and per-chain `address`/`decimals` (were `tokenAddress`/`tokenDecimals`). Timestamps move from `BigIntLike` strings to integer Unix seconds.


### PR DESCRIPTION
## Summary

- New page at `intents/guides/api-versioning` covering version header format, compatibility rules (additive vs. breaking changes, client MUST rules, deprecation lifecycle), and per-version history with migration notes.
- Documents `2026-04.blanc` (server-stored intents, flat `routes[]`, EIP-712 pass-through) and `2026-01.alps` (deprecated).

Ships with [RHI-3611](https://linear.app/rhinestone/issue/RHI-3611/implement-new-api-route-schema).

Closes [RHI-3619](https://linear.app/rhinestone/issue/RHI-3619/explain-api-versioning-and-design-choices-in-docs).