### PR TITLE
docs: unify API reference under one tab

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,0 +1,35 @@
+---
+title: "Introduction"
+description: "Reference for the Rhinestone REST APIs."
+---
+
+The Rhinestone platform exposes two REST APIs:
+
+- **Orchestrator** — quote, submit, and track cross-chain intents. Backs the core Warp flow.
+- **Deposit Service** — register accounts and process cross-chain deposits with automatic bridging and gas sponsorship.
+
+Both share the same base host, `https://v1.orchestrator.rhinestone.dev`, with the Deposit Service mounted at `/deposit-processor`.
+
+## Authentication
+
+All endpoints require an API key sent in the `x-api-key` header. The orchestrator additionally supports short-lived JWTs as an alternative for integrators that need bounded credentials or per-request sponsorship policies.
+
+- [Get an API key](https://tally.so/r/wg22x4)
+- [JWT authentication](/intents/configuration/jwt-authentication)
+
+## Errors
+
+Errors are returned with standard HTTP status codes and a JSON body. See [Error handling](/intents/guides/error-handling) for the full taxonomy and recovery patterns.
+
+## Guides
+
+If you're integrating from scratch, start with the workflow guides — they show how the endpoints fit together end-to-end.
+
+<CardGroup cols={2}>
+  <Card title="Intents quickstart" icon="route" href="/intents/quickstart">
+    Build the full intent flow: quote, sign, submit, track.
+  </Card>
+  <Card title="Deposits quickstart" icon="wallet" href="/deposits/api/quickstart">
+    Register accounts and accept cross-chain deposits.
+  </Card>
+</CardGroup>

--- a/deposits/overview.mdx
+++ b/deposits/overview.mdx
@@ -127,7 +127,7 @@ Rhinestone Deposits supports a wide range of EVM chains plus Solana. Each chain 
 
 <Info>
   This data is also available programmatically via the [List supported chains
-  and tokens](/api-reference/info/list-supported-chains-and-tokens) endpoint.
+  and tokens](/api-reference/deposit-service/info/list-supported-chains-and-tokens) endpoint.
 </Info>
 
 ## Which should you use?

--- a/docs.json
+++ b/docs.json
@@ -263,16 +263,31 @@
               "deposits/widget/customization",
               "deposits/widget/status-tracking"
             ]
-          },
-          {
-            "group": "API Reference",
-            "openapi": "https://raw.githubusercontent.com/rhinestonewtf/openapi/refs/heads/main/deposit-service.json"
           }
         ]
       },
       {
         "tab": "API Reference",
-        "openapi": "https://raw.githubusercontent.com/rhinestonewtf/openapi/refs/heads/main/orchestrator.json"
+        "groups": [
+          {
+            "group": "Get started",
+            "pages": ["api-reference/introduction"]
+          },
+          {
+            "group": "Orchestrator",
+            "openapi": {
+              "source": "https://raw.githubusercontent.com/rhinestonewtf/openapi/refs/heads/main/orchestrator.json",
+              "directory": "api-reference/orchestrator"
+            }
+          },
+          {
+            "group": "Deposit Service",
+            "openapi": {
+              "source": "https://raw.githubusercontent.com/rhinestonewtf/openapi/refs/heads/main/deposit-service.json",
+              "directory": "api-reference/deposit-service"
+            }
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Merge orchestrator and deposit-service endpoints under a single "API Reference" tab, with separate "Orchestrator" and "Deposit Service" sections (mirrors the layout used on docs.rhino.fi).
- Add an `api-reference/introduction.mdx` landing page covering the shared base host, auth, errors, and links into the workflow guides.
- Update the deposits overview link to the new nested endpoint path.