### PR TITLE
docs: document Ownable Validator versions

### DIFF
--- a/home/resources/address-book.mdx
+++ b/home/resources/address-book.mdx
@@ -25,6 +25,7 @@ A collection of addresses for the various contracts we have deployed or are usin
 | :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
 | Smart Session Emissary               | [0xad568b3f825a8d5ffc06dd3253526b64d810ae89](https://contractscan.xyz/contract/0xad568b3f825a8d5ffc06dd3253526b64d810ae89) |
 | Ownable Validator                    | [0x000000000013fdB5234E4E3162a810F54d9f7E98](https://contractscan.xyz/contract/0x000000000013fdB5234E4E3162a810F54d9f7E98) |
+| Ownable Validator (Contract Signers) | [0x2483DA3A338895199E5e538530213157e931Bf06](https://contractscan.xyz/contract/0x2483DA3A338895199E5e538530213157e931Bf06) |
 | Webauthn Validator                   | [0x0000000000578c4cB0e472a5462da43C495C3F33](https://contractscan.xyz/contract/0x0000000000578c4cB0e472a5462da43C495C3F33) |
 | Smart Session Compatibility Fallback | [0x000000000052e9685932845660777DF43C2dC496](https://contractscan.xyz/contract/0x000000000052e9685932845660777DF43C2dC496) |
 

--- a/smart-wallet/core/ecdsa-signer.mdx
+++ b/smart-wallet/core/ecdsa-signer.mdx
@@ -120,3 +120,19 @@ await account.sendTransaction({
   tokenRequests: [],
 })
 ```
+
+## Validator versions
+
+The SDK ships with two Ownable Validator implementations. The default is the latest version, which supports EIP-712 legible signing — wallet prompts show structured typed data instead of an opaque hash — but accepts only raw 65-byte ECDSA signatures. The legacy validator (`0x2483da3a338895199e5e538530213157e931bf06`) does not support EIP-712 legibility, but it accepts ERC-1271 contract signatures, so you can use a smart account (e.g., a Safe) as an owner.
+
+To use the legacy validator, pass its address as `module`:
+
+```ts {5}
+const account = await rhinestone.createAccount({
+  owners: {
+    type: 'ecdsa',
+    accounts: [smartAccountSigner],
+    module: '0x2483da3a338895199e5e538530213157e931bf06',
+  },
+})
+```


### PR DESCRIPTION
Adds a "Validator versions" section to the ECDSA signer page covering the two Ownable Validator implementations:

- Default — supports EIP-712 legible signing, ECDSA-only (65-byte sigs).
- Legacy (`0x2483da…`) — no EIP-712 legibility, but accepts ERC-1271 contract signatures (so a smart account can be an owner).

Includes the `module` override snippet for opting into the legacy validator. Also surfaces the contract-signer address in the V1 Modules table of the address book.

Closes [RHI-3649](https://linear.app/rhinestone/issue/RHI-3649)