### PR TITLE
docs: update snippets for v2 SDK and blanc API releases

### DIFF
--- a/home/resources/quick-reference.mdx
+++ b/home/resources/quick-reference.mdx
@@ -57,7 +57,6 @@ See [Error handling](/intents/guides/error-handling) for the full list.
 | Status | Meaning |
 |---|---|
 | `PENDING` | Submitted and in progress |
-| `PRECONFIRMED` | Accepted by a solver, waiting for onchain execution |
 | `CLAIMED` | Source funds claimed by the solver, destination execution pending |
 | `FILLED` | Executed on the destination chain, source funds not yet claimed |
 | `COMPLETED` | Fully executed and settled onchain |

--- a/home/resources/quick-reference.mdx
+++ b/home/resources/quick-reference.mdx
@@ -5,20 +5,20 @@ description: "Key addresses, endpoints, chain IDs, and common error codes for qu
 
 ## API endpoints
 
-| Environment | Base URL |
+| Service | Base URL |
 |---|---|
-| Mainnet | `https://orchestrator.rhinestone.wtf` |
-| Staging | `https://orchestrator-staging.rhinestone.wtf` |
+| Orchestrator | `https://v1.orchestrator.rhinestone.dev` |
+| Deposit Service | `https://v1.orchestrator.rhinestone.dev/deposit-processor` |
 
-Authentication: pass your API key in the `x-api-key` header. [Request a key](https://tally.so/r/wg22x4).
+Authentication: pass your API key in the `x-api-key` header. [Request a key](https://tally.so/r/wg22x4). Pin a version with `x-api-version: 2026-04.blanc` — see [API versioning](/intents/guides/api-versioning).
 
 ## Key endpoints
 
 | Endpoint | Method | Purpose |
 |---|---|---|
-| `/intents/route` | POST | Get a quote for an intent |
-| `/intents/submit` | POST | Submit a signed intent |
-| `/intents/status/{id}` | GET | Track intent status |
+| `/quotes` | POST | Get a quote for an intent |
+| `/intents` | POST | Submit a signed intent |
+| `/intents/{id}` | GET | Track intent status |
 | `/accounts/{address}/portfolio` | GET | Fetch user token balances across chains |
 
 ## Supported chains
@@ -44,13 +44,17 @@ The default transaction path is **Warp** (native relay). ERC-4337 userops are op
 
 ## Common error codes
 
-| Code | Meaning | Fix |
-|---|---|---|
-| `INSUFFICIENT_BALANCE` | User lacks sufficient funds on source chain | Check balance before quoting |
-| `Bundle simulation failed` | Onchain simulation of the intent execution failed | Make sure the signature and the execution calldata are valid |
-| `Authorization header with Bearer token is required` | Missing or malformed auth header | Pass your API key in the `Authorization: Bearer <key>` header |
+All non-2xx responses share the envelope `{ code, message, traceId, details? }`. Switch on `code`.
 
-See [Error handling](/intents/guides/error-handling) for the full list.
+| Code | HTTP | Meaning | Fix |
+|---|---|---|---|
+| `VALIDATION_ERROR` | 400 | Request didn't validate (bad chain id, missing version header, unsupported token, etc.) | Inspect `details[]` and correct the payload |
+| `UNAUTHORIZED` | 401 | API key missing or invalid | Pass your key in `x-api-key` |
+| `NOT_FOUND` | 404 | Quote TTL elapsed before submit | Re-quote and re-sign — don't retry the submit |
+| `INSUFFICIENT_LIQUIDITY` | 422 | Account can't cover the intent given gas and fees | Check balance; see `details.availableIntents` for fallbacks |
+| `TOO_MANY_REQUESTS` | 429 | Rate limited | Honour `Retry-After` |
+
+See [Error handling](/intents/guides/error-handling) and the [versioning guide](/intents/guides/api-versioning) for the full list.
 
 ## Intent status values
 

--- a/intents/features/execute-crosschain-calls.mdx
+++ b/intents/features/execute-crosschain-calls.mdx
@@ -23,7 +23,7 @@ import { encodeFunctionData, parseUnits } from 'viem'
 const usdcArbitrum = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
 const usdcAmount = parseUnits('100', 6)
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   tokenRequests: [
@@ -53,6 +53,8 @@ const transaction = await rhinestoneAccount.sendTransaction({
     },
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 ```
 
 <Note>
@@ -68,7 +70,7 @@ The relayer fronts gas on the destination chain and claims repayment from the us
 ```ts
 import { arbitrum } from 'viem/chains'
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   targetChain: arbitrum,
   calls: [
     {
@@ -88,7 +90,7 @@ To restrict which chain the gas repayment is taken from, provide `sourceChains`:
 ```ts
 import { base, arbitrum } from 'viem/chains'
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [

--- a/intents/features/execute-crosschain-calls.mdx
+++ b/intents/features/execute-crosschain-calls.mdx
@@ -70,7 +70,7 @@ The relayer fronts gas on the destination chain and claims repayment from the us
 ```ts
 import { arbitrum } from 'viem/chains'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   targetChain: arbitrum,
   calls: [
     {
@@ -90,7 +90,7 @@ To restrict which chain the gas repayment is taken from, provide `sourceChains`:
 ```ts
 import { base, arbitrum } from 'viem/chains'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [

--- a/intents/guides/api-versioning.mdx
+++ b/intents/guides/api-versioning.mdx
@@ -269,6 +269,8 @@ switch (err.code) {
 
 Honour `Retry-After` on `429 TOO_MANY_REQUESTS`.
 
+### Error codes
+
 | Code                          | HTTP |
 | ----------------------------- | ---- |
 | `VALIDATION_ERROR`            | 400  |

--- a/intents/guides/error-handling.mdx
+++ b/intents/guides/error-handling.mdx
@@ -3,59 +3,85 @@ title: "Error handling"
 description: "Common Orchestrator errors and how to resolve them"
 ---
 
+Every non-2xx response shares the same shape:
+
+```json
+{
+  "code": "INSUFFICIENT_LIQUIDITY",
+  "message": "...",
+  "traceId": "...",
+  "details": { /* optional, code-specific */ }
+}
+```
+
+Switch on `code`, not `message`. The full code/HTTP table lives in the [versioning guide](./api-versioning#deprecation-lifecycle).
+
+```ts
+switch (err.code) {
+  case "INSUFFICIENT_LIQUIDITY":
+    // err.details: { availableIntents, unfillable }
+    break;
+  case "VALIDATION_ERROR":
+    // err.details: [{ message, context? }]
+    break;
+  case "TOO_MANY_REQUESTS":
+    // honour the Retry-After header
+    break;
+  default:
+    // unknown codes — fall through to a generic error
+    break;
+}
+```
+
+The list is extensible — always include a default fallback for codes you don't recognise.
+
 <AccordionGroup>
-<Accordion title="Insufficient Balance">
+<Accordion title="INSUFFICIENT_LIQUIDITY (422)">
 
-In most cases, getting this error means the account balance is not enough to cover the tokens required on the target chain, together with the gas costs.
+The account balance can't cover the requested tokens together with gas and fees, or the cost to claim funds (e.g. on Ethereum mainnet) is too high to fill profitably.
 
-Sometimes, you have enough balance, but the cost to claim it is too high (e.g., on Ethereum Mainnet).
+`details` contains `availableIntents` (alternative routes you could fall back to) and `unfillable` (the routes that couldn't be filled and why).
 
-You can also get the error if the contract is not deployed on any supported chain.
-
-Make sure your account is deployed and funded.
-
-Also, make sure you have enough funds for your transaction, taking gas costs into account. You can use the [spendable amount utility](/smart-wallet/chain-abstraction/source-token-amount) to get an estimate of how much you can spend.
+Make sure the account is deployed and funded. For SDK users, the [spendable amount utility](/smart-wallet/chain-abstraction/source-token-amount) gives an estimate of how much can be spent.
 
 </Accordion>
-<Accordion title="Unsupported chain id">
+<Accordion title="VALIDATION_ERROR (400)">
 
-This error could mean that your `targetChain` [is not supported](/home/resources/supported-chains).
+The request payload didn't validate. Common causes:
 
-It could also mean that you're using testnet chains on a production environment, or mainnet chains on a dev environment.
+- Unsupported `destinationChainId` — check the [supported chains](/home/resources/supported-chains).
+- Unsupported token address on the destination chain.
+- Mainnet chain ids on a development API key, or testnet chain ids on a production key.
+- Malformed CAIP-2 chain ids — they must be `eip155:<chainId>` strings.
+- Missing or unknown `x-api-version` header.
 
-Make sure the chain you're using matches the environment.
-
-Also, make sure that the chain you're using is supported.
-
-</Accordion>
-<Accordion title="Unsupported token addresses">
-
-Most likely, you will encounter this when the token that you're requesting on the target chain doesn't exist or is not supported.
-
-Make sure the token that you request corresponds to the target execution chain.
+`details` is an array of `{ message, context? }` entries.
 
 </Accordion>
-<Accordion title="Authentication is required">
+<Accordion title="UNAUTHORIZED (401)">
 
-Every request to the Orchestrator on mainnets requires an API key.
+The API key is missing or invalid. Pass it in `x-api-key`. [Reach out to us](https://t.me/konradkopp) if you need a key.
 
-Make sure you provide a key. [Reach out to us](https://t.me/konradkopp) if you need one.
-
-</Accordion>
-<Accordion title="Invalid API key">
-
-The API key you've provided when making a request is not valid.
-
-Make sure you provide a development API key if you're working with testnets, and a production API key if you're working with mainnets. [Reach out to us](https://t.me/konradkopp) if you miss the proper key.
+Make sure you're using a development API key for testnets and a production API key for mainnets.
 
 </Accordion>
-<Accordion title="Invalid bundle signature">
+<Accordion title="NOT_FOUND (404) on submit">
 
-The bundle signature doesn't match the account.
+`POST /intents` returns 404 when the `intentId` no longer exists server-side — typically because the quote TTL elapsed or the quote store was restarted.
 
-Make sure the bundle hash you're signing is correct.
+Re-quote and re-sign. Don't retry the submit with the same `intentId`.
 
-Also, make sure the signer (or signers) of the hash is the owner of the account.
+</Accordion>
+<Accordion title="UNPROCESSABLE_CONTENT (422) on submit">
+
+The signature didn't validate against the account. Either the typed data was modified before signing, or the signer isn't an authorised owner of the account.
+
+Forward `signData.origin[]` and `signData.destination` verbatim to `signTypedData` — don't reconstruct the types client-side. For smart accounts, make sure the validator wraps the signature using its expected encoding.
+
+</Accordion>
+<Accordion title="TOO_MANY_REQUESTS (429)">
+
+Rate limited. Honour the `Retry-After` header before retrying.
 
 </Accordion>
 </AccordionGroup>

--- a/intents/guides/error-handling.mdx
+++ b/intents/guides/error-handling.mdx
@@ -14,7 +14,7 @@ Every non-2xx response shares the same shape:
 }
 ```
 
-Switch on `code`, not `message`. The full code/HTTP table lives in the [versioning guide](./api-versioning#deprecation-lifecycle).
+Switch on `code`, not `message`. The full code/HTTP table lives in the [versioning guide](./api-versioning#error-codes).
 
 ```ts
 switch (err.code) {

--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -3,17 +3,14 @@ title: "Getting a quote"
 description: "Request a Quote for an Intent"
 ---
 
-To get started with Warp, let's get a quote for a cross-chain intent.
+To get started with Warp, request a quote for a crosschain intent.
 
-You can do that using the `/intents/route` endpoint.
-
-To get a quote, you'll need the **destination chain**, the **token** and **amount** on that chain, and the **account address**:
+Use the `/quotes` endpoint. You'll need the **destination chain**, the **token** and **amount** on that chain, and the **account address**:
 
 <CodeGroup dropdown>
 
 ```ts Get Quote
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
-const endpoint = `${baseUrl}/intents/route`;
 const apiKey = "YOUR_RHINESTONE_API_KEY";
 
 const payload = {
@@ -21,7 +18,7 @@ const payload = {
     address: EOA_ADDRESS,
     accountType: "EOA",
   },
-  destinationChainId: 8453,
+  destinationChainId: "eip155:8453",
   tokenRequests: [
     {
       tokenAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
@@ -30,96 +27,57 @@ const payload = {
   ],
 };
 
-const res = await fetch(endpoint, {
+const res = await fetch(`${baseUrl}/quotes`, {
   method: "POST",
   headers: {
     "Content-Type": "application/json",
     "x-api-key": apiKey,
-    Accept: "application/json",
+    "x-api-version": "2026-04.blanc",
   },
   body: JSON.stringify(payload),
 });
 
-if (!res.ok) {
-  const errorBody = await res.text().catch(() => "");
-  throw new Error(
-    `Request failed: ${res.status} ${res.statusText}${errorBody ? ` - ${errorBody}` : ""}`
-  );
-}
-
-const data = await res.json();
-console.log("Quote:", data);
+const { routes } = await res.json();
+const route = routes[0];
 ```
 </CodeGroup>
 
-The API response includes three top-level fields:
-
-* `intentOp`: the full intent operation the user must sign (see below)
-* `intentCost`: the cost breakdown including tokens spent, tokens received, and fees
-* `tokenRequirements`: the list of [token requirements](./token-requirements) to fulfill before signing
+Chain ids on every field are CAIP-2 strings (`eip155:<chainId>`).
 
 ## Understanding the response
 
-### `intentOp`
+The response is `{ routes }`, an array pre-ranked by a cost/speed tradeoff. Pick `routes[0]` unless you have your own criteria.
 
-The `intentOp` object contains everything needed to build signatures and submit the intent. Key fields:
-
-| Field | Description |
-|---|---|
-| `elements` | One entry per source chain involved. Each element describes what tokens are pulled from that chain and what the user receives on the destination. |
-| `nonce` | A unique nonce for Permit2 signing. |
-| `expires` | Unix timestamp when the quote expires. Fetch a fresh quote if this has passed. |
-| `signedMetadata` | Orchestrator-signed metadata including token prices. Do not modify this. |
-
-#### Element fields
-
-Each element in `intentOp.elements` describes one source chain:
+Each route carries everything you need to sign and submit:
 
 | Field | Description |
 |---|---|
-| `chainId` | The source chain ID (e.g. `"8453"` for Base). |
-| `arbiter` | The arbiter contract that validates the fill. |
-| `idsAndAmounts` | Array of `[tokenId, amount]` pairs: tokens pulled from the user on this chain. |
-| `mandate.recipient` | Address that receives tokens on the destination. |
-| `mandate.tokenOut` | Array of `[tokenId, amount]` pairs: tokens delivered to the recipient. |
-| `mandate.destinationChainId` | The destination chain ID. |
-| `mandate.fillDeadline` | Unix timestamp by which the solver must fill. |
-| `mandate.destinationOps` | Calls to execute on the destination chain after fill. |
+| `intentId` | Server-stored quote handle. Pass it to `POST /intents` to submit. |
+| `cost` | Cost breakdown. See below. |
+| `signData` | EIP-712 typed data to sign. `signData.origin[]` has one entry per source chain; `signData.destination` is the destination signature. |
+| `tokenRequirements` | Approvals or ETH wrapping the user must complete before signing. EOAs only — smart accounts handle this automatically. |
 
-Token amounts in `elements` use a packed uint256 encoding called a **token ID**. The token ID encodes the ERC-20 address in its lower 160 bits. To extract the address:
+### `cost`
+
+The `cost` object on each route describes what the user pays:
+
+| Field | Description |
+|---|---|
+| `input` | Tokens spent. Array of `{ chainId, tokenAddress, symbol, decimals, price, amount }`. |
+| `output` | Tokens delivered to the recipient on the destination chain. Same shape as `input`. |
+| `fees` | `{ total: { usd }, breakdown: { gas, swap, bridge } }`. Each breakdown entry has `{ usd, sponsored }` — `sponsored` reflects what was actually covered for this route, given the request's `sponsorSettings` and the project's sponsorship balance. |
 
 ```ts
-function toToken(id: bigint): `0x${string}` {
-  return `0x${(id & ((1n << 160n) - 1n)).toString(16).padStart(40, "0")}`;
-}
-
-// Example: extract the token address from an element
-const element = intentOp.elements[0];
-const [tokenId, amount] = element.idsAndAmounts[0];
-const tokenAddress = toToken(BigInt(tokenId));
-// tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" (USDC on Base)
+const inputAmount = route.cost.input[0].amount;
+const gasUSD = route.cost.fees.breakdown.gas.usd;
+const totalFeeUSD = route.cost.fees.total.usd;
 ```
-
-The same encoding applies to:
-- `element.idsAndAmounts`: tokens pulled from the source chain (what the user spends)
-- `element.spendTokens`: tokens the solver must lock
-- `element.mandate.tokenOut`: tokens delivered on the destination chain
-
-### `intentCost`
-
-The `intentCost` object breaks down what the user pays:
-
-| Field | Description |
-|---|---|
-| `tokensSpent` | Map of `chainId -> tokenAddress -> { locked, unlocked, version }`. Shows exactly what leaves the user's wallet per chain. |
-| `tokensReceived` | Array of objects showing what arrives on the destination, including `amountSpent`, `destinationAmount`, and `fee`. |
-| `feeBreakdownUSD` | USD breakdown of swap, bridge, gas, and settlement fees (when available). |
 
 ## Executions (calls)
 
-You can make executions on behalf of the EOA on the destination chain.
+You can run executions on behalf of the EOA on the destination chain.
 
-Note: the executions run in the context of the multicall contract. If you're sending any tokens, make sure to add a call to transfer any output back to the EOA.
+For EOAs, executions run in the context of an intermediary contract — not the user's account. If you receive any tokens (vault shares, swap output, etc.), include an explicit `transfer` call to send them back to the EOA.
 
 ```ts
 const payload = {
@@ -151,12 +109,12 @@ const payload = {
 
 ## Sponsorship
 
-You can mark the intent as sponsored (covering the gas and bridging costs for the user) by setting the `sponsorSettings` field:
+Mark the intent as sponsored (covering gas and bridging costs for the user) by setting `sponsorSettings`:
 
 <CodeGroup dropdown>
 ```ts {13-19} Sponsor the Intent
 const payload = {
-  destinationChainId: 8453,
+  destinationChainId: "eip155:8453",
   tokenRequests: [
     {
       tokenAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
@@ -169,18 +127,18 @@ const payload = {
   },
   options: {
     sponsorSettings: {
-      gasSponsored: true,
-      bridgeFeesSponsored: true,
-      swapFeesSponsored: false
-    }
-  }
+      gas: true,
+      bridgeFees: true,
+      swapFees: false,
+    },
+  },
 };
 ```
 </CodeGroup>
 
-## Source Chain / Token
+## Source chain / token
 
-You can select which tokens and/or chains to use as the source of funds.
+Select which tokens and/or chains to use as the source of funds via `accountAccessList`.
 
 To limit the source of funds to specific chains:
 
@@ -189,8 +147,8 @@ To limit the source of funds to specific chains:
 const payload = {
   // …
   accountAccessList: {
-    chainIds: [10, 8453]
-  }
+    chainIds: ["eip155:10", "eip155:8453"],
+  },
 };
 ```
 </CodeGroup>
@@ -202,8 +160,8 @@ To limit the source of funds to specific tokens:
 const payload = {
   // …
   accountAccessList: {
-    tokens: ["USDC", "0x4200000000000000000000000000000000000006"]
-  }
+    tokens: ["USDC", "0x4200000000000000000000000000000000000006"],
+  },
 };
 ```
 </CodeGroup>
@@ -215,9 +173,9 @@ To limit the source of funds to specific chains *and* tokens:
 const payload = {
   // …
   accountAccessList: {
-    chainIds: [10, 8453],
-    tokens: ["USDC"]
-  }
+    chainIds: ["eip155:10", "eip155:8453"],
+    tokens: ["USDC"],
+  },
 };
 ```
 </CodeGroup>
@@ -230,10 +188,10 @@ const payload = {
   // …
   accountAccessList: {
     chainTokens: {
-      "10": ["USDC"],
-      "8453": ["WETH"]
-    }
-  }
+      "eip155:10": ["USDC"],
+      "eip155:8453": ["WETH"],
+    },
+  },
 };
 ```
 </CodeGroup>
@@ -242,34 +200,44 @@ const payload = {
 
 If the destination token differs from the user's source token, Warp handles the bridge and swap automatically. No additional parameters are needed — just specify the token you want on the destination chain.
 
-In a swap quote, `tokensSpent` and `tokensReceived` will show different tokens:
+In a swap quote, `cost.input` and `cost.output` show different tokens:
 
 ```json
 {
-  "intentCost": {
-    "tokensReceived": [
+  "cost": {
+    "input": [
       {
-        "tokenAddress": "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
-        "hasFulfilled": true,
-        "amountSpent": "81032981",
-        "destinationAmount": "81029468",
-        "fee": "3513"
+        "chainId": "eip155:8453",
+        "tokenAddress": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "decimals": 18,
+        "price": { "usd": 2412.37 },
+        "amount": "959454558006521"
       }
     ],
-    "tokensSpent": {
-      "8453": {
-        "0x4200000000000000000000000000000000000006": {
-          "locked": "0",
-          "unlocked": "22291303013436002",
-          "version": 0
-        }
+    "output": [
+      {
+        "chainId": "eip155:10",
+        "tokenAddress": "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+        "symbol": "USDC",
+        "decimals": 6,
+        "price": { "usd": 0.99 },
+        "amount": "2000000"
+      }
+    ],
+    "fees": {
+      "total": { "usd": 0.31 },
+      "breakdown": {
+        "gas": { "usd": 0.30, "sponsored": false },
+        "swap": { "usd": 0.01, "sponsored": false },
+        "bridge": { "usd": 0.0004, "sponsored": false }
       }
     }
   }
 }
 ```
 
-Here the user is spending WETH on Base (chain 8453) to receive USDC on Optimism. The fee is deducted from the received amount (`amountSpent` minus `destinationAmount`).
+Here the user spends WETH on Base (`eip155:8453`) to receive USDC on Optimism. `output.amount` matches the requested amount exactly — fees are paid in input tokens, not deducted from the output. Compare `input.amount × input.price.usd` to `output.amount × output.price.usd` to see the cost.
 
 ## Next Steps
 

--- a/intents/guides/installing-intent-executor.mdx
+++ b/intents/guides/installing-intent-executor.mdx
@@ -23,7 +23,7 @@ The Intent Executor is a standard ERC-7579 executor module (module type `2`). In
 ```ts
 import { installModule } from '@rhinestone/sdk/actions'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   targetChain: base,
   calls: [
     installModule({
@@ -72,7 +72,7 @@ Returns `true` once the module has been installed on the account.
 ```ts
 import { uninstallModule } from '@rhinestone/sdk/actions'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   targetChain: base,
   calls: [
     uninstallModule({

--- a/intents/guides/installing-intent-executor.mdx
+++ b/intents/guides/installing-intent-executor.mdx
@@ -23,7 +23,7 @@ The Intent Executor is a standard ERC-7579 executor module (module type `2`). In
 ```ts
 import { installModule } from '@rhinestone/sdk/actions'
 
-const result = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   targetChain: base,
   calls: [
     installModule({
@@ -72,7 +72,7 @@ Returns `true` once the module has been installed on the account.
 ```ts
 import { uninstallModule } from '@rhinestone/sdk/actions'
 
-const result = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   targetChain: base,
   calls: [
     uninstallModule({

--- a/intents/guides/portfolio-endpoint.mdx
+++ b/intents/guides/portfolio-endpoint.mdx
@@ -13,14 +13,14 @@ Pass a user address and your API key to get aggregated balances across all chain
 ```ts
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
 const apiKey = "YOUR_RHINESTONE_API_KEY";
-const userAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+const accountAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
 
 const res = await fetch(
-  `${baseUrl}/accounts/${userAddress}/portfolio?filterEmpty=true`,
+  `${baseUrl}/accounts/${accountAddress}/portfolio?filterEmpty=true`,
   {
     headers: {
       "x-api-key": apiKey,
-      Accept: "application/json",
+      "x-api-version": "2026-04.blanc",
     },
   }
 );
@@ -28,28 +28,56 @@ const res = await fetch(
 const { portfolio } = await res.json();
 ```
 
-Each entry in `portfolio` represents a token aggregated across chains. Use `balance.unlocked` to determine whether the user can fund an intent — `balance.locked` reflects tokens already allocated to a pending intent.
+Each entry in `portfolio` is a token aggregated across chains: `{ symbol, chains: [{ chainId, address, decimals, amount }] }`. Amounts are raw (apply `decimals` to display).
+
+```json
+{
+  "portfolio": [
+    {
+      "symbol": "USDC",
+      "chains": [
+        {
+          "chainId": "eip155:8453",
+          "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+          "decimals": 6,
+          "amount": "500000"
+        }
+      ]
+    }
+  ]
+}
+```
 
 ## Filter by chain or token
 
-To scope results to specific chains, pass `chainIds`:
+To scope results to specific chains, pass `chainIds` as a repeated query parameter using CAIP-2 ids:
 
 ```ts
 const res = await fetch(
-  `${baseUrl}/accounts/${userAddress}/portfolio?chainIds=10,8453&filterEmpty=true`,
-  { headers: { "x-api-key": apiKey } }
+  `${baseUrl}/accounts/${accountAddress}/portfolio?chainIds=eip155:10&chainIds=eip155:8453&filterEmpty=true`,
+  {
+    headers: {
+      "x-api-key": apiKey,
+      "x-api-version": "2026-04.blanc",
+    },
+  }
 );
 ```
 
-To scope to specific tokens, pass `chainId:tokenAddress` pairs via `tokens`:
+To scope to specific tokens, pass `chain:address` pairs as repeated `tokens` parameters:
 
 ```ts
-const usdc10 = "10:0x0b2c639c533813f4aa9d7837caf62653d097ff85";
-const usdc8453 = "8453:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const usdcOptimism = "eip155:10:0x0b2c639c533813f4aa9d7837caf62653d097ff85";
+const usdcBase = "eip155:8453:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 
 const res = await fetch(
-  `${baseUrl}/accounts/${userAddress}/portfolio?tokens=${usdc10},${usdc8453}`,
-  { headers: { "x-api-key": apiKey } }
+  `${baseUrl}/accounts/${accountAddress}/portfolio?tokens=${usdcOptimism}&tokens=${usdcBase}`,
+  {
+    headers: {
+      "x-api-key": apiKey,
+      "x-api-version": "2026-04.blanc",
+    },
+  }
 );
 ```
 

--- a/intents/guides/set-account-type.mdx
+++ b/intents/guides/set-account-type.mdx
@@ -3,7 +3,7 @@ title: "Set account type"
 description: "Configure which account type to use with Rhinestone intents: smart account, EOA, or EIP-7702."
 ---
 
-Rhinestone supports three account types. All of them use the same `sendTransaction` API — the orchestrator abstracts the differences at the transport layer.
+Rhinestone supports three account types. All of them share the same transaction API — the orchestrator abstracts the differences at the transport layer.
 
 - **Smart account** — new users, full feature set (modules, session keys, gas sponsorship)
 - **EOA** — existing EOA users, no migration required, basic intent support
@@ -34,7 +34,7 @@ const account = await rhinestone.createAccount({
 
 const recipientAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
-const result = await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   sourceChains: [arbitrum],
   targetChain: base,
   calls: [
@@ -54,6 +54,8 @@ const result = await account.sendTransaction({
     },
   ],
 })
+const signed = await account.signTransaction(prepared)
+const result = await account.submitTransaction(signed)
 
 const status = await account.waitForExecution(result)
 ```
@@ -83,7 +85,7 @@ const account = await rhinestone.createAccount({
 
 const recipientAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
-const result = await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   sourceChains: [arbitrum],
   targetChain: base,
   calls: [
@@ -103,6 +105,8 @@ const result = await account.sendTransaction({
     },
   ],
 })
+const signed = await account.signTransaction(prepared)
+const result = await account.submitTransaction(signed)
 
 const status = await account.waitForExecution(result)
 ```
@@ -193,7 +197,7 @@ Sending a transaction with an EIP-7702 account requires two additional signing s
   </Step>
   <Step title="Submit and wait">
     ```ts
-    const result = await account.submitTransaction(signedTx, authorizations)
+    const result = await account.submitTransaction(signedTx, { authorizations })
     const status = await account.waitForExecution(result)
     ```
   </Step>

--- a/intents/guides/signing.mdx
+++ b/intents/guides/signing.mdx
@@ -1,198 +1,34 @@
 ---
 title: "Signing the intent"
 sidebarTitle: "Signing the intent"
-description: "Sign each element of the intent using EIP-712."
+description: "Sign each entry in signData using EIP-712."
 ---
 
-<Info>
-  Always fetch a fresh quote immediately before signing. Submitting signatures built from a stale quote will result in an expiry error.
-</Info>
+The quote response includes everything needed to sign. Forward `signData.origin[]` and `signData.destination` directly to your wallet's `signTypedData()` — don't reconstruct the EIP-712 types client-side.
 
-Warp uses [EIP-712](https://eips.ethereum.org/EIPS/eip-712) for typed, human-readable signing. The signature scheme depends on the settlement layer used for each bundle element.
+## Origin signatures
 
-## Signature types
-
-**Permit2 signatures** are used for standard crosschain intents. Each source chain element requires a unique signature. The index of the signature must correspond to the index of the element it signs.
-
-**Intent Executor signatures** are used when the bundle uses the Intent Executor settlement layer (i.e. the user has an ERC-7579 smart account with the Intent Executor installed). These use a different EIP-712 domain — not the standard Permit2 domain. The `getTypedData` function below handles this automatically based on the `settlementLayer` field in the element.
-
-## Recipient signatures
-
-If the recipient is different from the sender, the recipient is a smart account, and there are destination executions to run, the recipient must also sign. Their signature is attached as the `destinationSignature`.
-
-## Preparing the typed data
+`signData.origin` has one entry per source chain. Sign each entry in order. The signature index must match the entry index.
 
 ```ts
-interface TokenPermissions {
-  token: Address;
-  amount: bigint;
-}
-
-interface Ops {
-  to: Address;
-  value: string;
-  data: Hex;
-}
-
-interface Op {
-  vt: Hex;
-  ops: Ops[];
-}
-
-interface IntentOpElementMandate {
-  recipient: Address;
-  tokenOut: [[string, string]];
-  destinationChainId: string;
-  fillDeadline: string;
-  destinationOps: Op;
-  preClaimOps: Op;
-  qualifier: {
-    settlementContext: {
-      settlementLayer: string;
-      usingJIT: boolean;
-      using7579: boolean;
-    };
-    encodedVal: Hex;
-  };
-  minGas: string;
-}
-
-interface IntentOpElement {
-  arbiter: Address;
-  chainId: string;
-  idsAndAmounts: [[string, string]];
-  spendTokens: [[string, string]];
-  beforeFill: boolean;
-  smartAccountStatus: {
-    accountType: string;
-    isDeployed: boolean;
-    isERC7579: boolean;
-    erc7579AccountType: string;
-    erc7579AccountVersion: string;
-  };
-  mandate: IntentOpElementMandate;
-}
-
-function toToken(id: bigint): Address {
-  return `0x${(id & ((1n << 160n) - 1n)).toString(16).padStart(40, "0")}`;
-}
-
-function getTypedData(
-  element: IntentOpElement,
-  nonce: bigint,
-  expires: bigint,
-) {
-  const PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
-
-  const tokens = element.idsAndAmounts.map(([id, amount]) => [
-    BigInt(id),
-    BigInt(amount),
-  ]);
-  const tokenPermissions = tokens.reduce<TokenPermissions[]>(
-    (permissions, [id, amountIn]) => {
-      const token = toToken(BigInt(id));
-      const amount = BigInt(amountIn);
-      permissions.push({ token, amount });
-      return permissions;
-    },
-    [],
-  );
-
-  const spender = element.arbiter;
-  const mandate = element.mandate;
-
-  return {
-    domain: {
-      name: "Permit2",
-      chainId: Number(element.chainId),
-      verifyingContract: PERMIT2_ADDRESS,
-    },
-    types: {
-      TokenPermissions: [
-        { name: "token", type: "address" },
-        { name: "amount", type: "uint256" },
-      ],
-      Token: [
-        { name: "token", type: "address" },
-        { name: "amount", type: "uint256" },
-      ],
-      Target: [
-        { name: "recipient", type: "address" },
-        { name: "tokenOut", type: "Token[]" },
-        { name: "targetChain", type: "uint256" },
-        { name: "fillExpiry", type: "uint256" },
-      ],
-      Ops: [
-        { name: "to", type: "address" },
-        { name: "value", type: "uint256" },
-        { name: "data", type: "bytes" },
-      ],
-      Op: [
-        { name: "vt", type: "bytes32" },
-        { name: "ops", type: "Ops[]" },
-      ],
-      Mandate: [
-        { name: "target", type: "Target" },
-        { name: "minGas", type: "uint128" },
-        { name: "originOps", type: "Op" },
-        { name: "destOps", type: "Op" },
-        { name: "q", type: "bytes32" },
-      ],
-      PermitBatchWitnessTransferFrom: [
-        { name: "permitted", type: "TokenPermissions[]" },
-        { name: "spender", type: "address" },
-        { name: "nonce", type: "uint256" },
-        { name: "deadline", type: "uint256" },
-        { name: "mandate", type: "Mandate" },
-      ],
-    },
-    primaryType: "PermitBatchWitnessTransferFrom",
-    message: {
-      permitted: tokenPermissions,
-      spender,
-      nonce,
-      deadline: expires,
-      mandate: {
-        target: {
-          recipient: mandate.recipient,
-          tokenOut: mandate.tokenOut.map((token) => ({
-            token: toToken(BigInt(token[0])),
-            amount: BigInt(token[1]),
-          })),
-          targetChain: BigInt(mandate.destinationChainId),
-          fillExpiry: BigInt(mandate.fillDeadline),
-        },
-        minGas: BigInt(mandate.minGas),
-        originOps: mandate.preClaimOps,
-        destOps: mandate.destinationOps,
-        q: keccak256(mandate.qualifier.encodedVal),
-      },
-    },
-  } as const;
-}
+const originSignatures = await Promise.all(
+  signData.origin.map((typedData) =>
+    walletClient.signTypedData(typedData),
+  ),
+);
 ```
 
-## Signing each element
+## Destination signature
 
-One signature per element, in order:
+`signData.destination` is a single typed-data object. It's used when the recipient differs from the sender (a smart account receiving tokens, for example, or destination executions that touch the recipient's account).
 
 ```ts
-const signatures: Hex[] = [];
-
-for (const element of intentOp.elements) {
-  const typedData = getTypedData(
-    element,
-    BigInt(intentOp.nonce),
-    BigInt(intentOp.expires),
-  );
-
-  const signature = await signTypedData(wagmiConfig, { ...typedData });
-  signatures.push(signature);
-}
-
-const originSignatures = signatures;
-const destinationSignature = signatures.at(-1); // last signature doubles as destination
+const destinationSignature = await walletClient.signTypedData(
+  signData.destination,
+);
 ```
+
+If the destination doesn't require a signature, this slot can still be sent — the orchestrator ignores it.
 
 ## Next steps
 

--- a/intents/guides/submitting-the-intent.mdx
+++ b/intents/guides/submitting-the-intent.mdx
@@ -1,49 +1,40 @@
 ---
 title: "Submitting the intent"
-description: "Submit the signed operations to the Orchestrator"
+description: "Submit the signed intent to the Orchestrator"
 ---
 
-Once you've [signed](./signing) the intent operations, you can submit them to the Orchestrator for execution.
+Once you've [signed](./signing) the intent, submit it to the Orchestrator for execution.
 
-Use the `/intent-operations` endpoint:
+Use the `/intents` endpoint. Pass the `intentId` from the quote and the signatures you collected:
 
-```ts Submit Intent
+```ts
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
-const endpoint = `${baseUrl}/intent-operations`;
 const apiKey = "YOUR_RHINESTONE_API_KEY";
 
-const payload = {
-  signedIntentOp: {
-    ...intentOp,
-    originSignatures,
-    destinationSignature,
-  },
-};
-
-const res = await fetch(endpoint, {
+const res = await fetch(`${baseUrl}/intents`, {
   method: "POST",
   headers: {
     "Content-Type": "application/json",
     "x-api-key": apiKey,
-    Accept: "application/json",
+    "x-api-version": "2026-04.blanc",
   },
-  body: JSON.stringify(payload, (_, value) =>
-    typeof value === "bigint" ? value.toString() : value,
-  ),
+  body: JSON.stringify({
+    intentId,
+    signatures: {
+      origin: originSignatures,
+      destination: destinationSignature,
+    },
+  }),
 });
 
-if (!res.ok) {
-  const errorBody = await res.text().catch(() => "");
-  throw new Error(
-    `Request failed: ${res.status} ${res.statusText}${errorBody ? ` - ${errorBody}` : ""}`
-  );
-}
-
-const data = await res.json();
-console.log("Result:", data);
+const { intentId: submittedId } = await res.json();
 ```
 
-The response includes an operation ID. Use it to track execution status.
+The response contains only the `intentId` — use it to poll for execution status.
+
+<Note>
+If the quote has expired before you submit, `POST /intents` returns 404. Re-quote and re-sign — don't retry the submit.
+</Note>
 
 <Card title="Tracking intents" icon="radar" href="./tracking-intents">
   Poll for status and understand the full intent lifecycle.

--- a/intents/guides/token-requirements.mdx
+++ b/intents/guides/token-requirements.mdx
@@ -19,7 +19,7 @@ If `tokenRequirements` is present in the quote response, the user must complete 
 
 ```json
 {
-  "8453": {
+  "eip155:8453": {
     "0x0000000000000000000000000000000000000000": {
       "type": "wrap",
       "amount": "102656447694688542"
@@ -80,18 +80,19 @@ await writeContract(wagmiConfig, {
   Approvals are always to [Permit2](https://github.com/Uniswap/permit2) — one of the most widely deployed and audited contracts in the ecosystem. Setting max approval here does not grant Rhinestone any direct access to your funds.
 </Info>
 
-If you prefer exact approvals, inspect the `tokensSpent` field in the quote response. This shows the exact amount that will be used, so approving that amount will be sufficient:
+If you prefer exact approvals, inspect `cost.input` on the route. It lists each token spent with its exact amount:
 
 ```ts
-// Use tokensSpent amount instead of maxUint256 for exact approvals
-const chainSpend = intentCost.tokensSpent[chainId];
-const tokenAmount = chainSpend[tokenAddress]?.unlocked;
+// Use cost.input amount instead of maxUint256 for exact approvals
+const entry = route.cost.input.find(
+  (i) => i.chainId === chainId && i.tokenAddress === tokenAddress,
+);
 
 await writeContract(wagmiConfig, {
   address: tokenAddress,
   abi: erc20Abi,
   functionName: "approve",
-  args: [requirement.spender, BigInt(tokenAmount)],
+  args: [requirement.spender, BigInt(entry.amount)],
 });
 ```
 

--- a/intents/guides/tracking-intents.mdx
+++ b/intents/guides/tracking-intents.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Tracking intents"
 description: "Poll for intent status and understand the intent lifecycle."
 ---
 
-After [submitting an intent](./submitting-the-intent), you receive an operation ID. Use it to poll the Orchestrator until the intent reaches a terminal state.
+After [submitting an intent](./submitting-the-intent), you receive an `intentId`. Use it to poll the Orchestrator until the intent reaches a terminal state.
 
 ## Poll for status
 
@@ -12,11 +12,11 @@ After [submitting an intent](./submitting-the-intent), you receive an operation 
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
 const apiKey = "YOUR_RHINESTONE_API_KEY";
 
-async function getIntentStatus(operationId: string) {
-  const res = await fetch(`${baseUrl}/intent-operation/${operationId}`, {
+async function getIntentStatus(intentId: string) {
+  const res = await fetch(`${baseUrl}/intents/${intentId}`, {
     headers: {
       "x-api-key": apiKey,
-      Accept: "application/json",
+      "x-api-version": "2026-04.blanc",
     },
   });
 
@@ -31,11 +31,11 @@ async function getIntentStatus(operationId: string) {
 }
 
 // Poll every 2 seconds until terminal
-async function waitForCompletion(operationId: string) {
+async function waitForCompletion(intentId: string) {
   const terminal = new Set(["COMPLETED", "FAILED", "EXPIRED"]);
 
   while (true) {
-    const data = await getIntentStatus(operationId);
+    const data = await getIntentStatus(intentId);
     console.log("Status:", data.status);
 
     if (terminal.has(data.status)) return data;
@@ -64,8 +64,8 @@ An intent moves through the following statuses:
 If you're using the Rhinestone SDK, `waitForExecution` handles polling internally and resolves when the intent completes:
 
 ```ts
-const result = await rhinestoneAccount.submitTransaction(signed);
-const status = await rhinestoneAccount.waitForExecution(result);
+const transaction = await rhinestoneAccount.submitTransaction(signed);
+const status = await rhinestoneAccount.waitForExecution(transaction);
 // resolves only after COMPLETED
 ```
 

--- a/intents/guides/tracking-intents.mdx
+++ b/intents/guides/tracking-intents.mdx
@@ -51,7 +51,6 @@ An intent moves through the following statuses:
 | Status | Meaning |
 |---|---|
 | `PENDING` | Submitted and in progress |
-| `PRECONFIRMED` | Accepted by a solver, waiting for onchain execution |
 | `CLAIMED` | Source funds claimed by the solver, destination execution pending |
 | `FILLED` | Executed on the destination chain, source funds not yet claimed |
 | `COMPLETED` | Fully executed and settled onchain |
@@ -62,10 +61,11 @@ An intent moves through the following statuses:
 
 ## SDK shorthand
 
-If you're using the Rhinestone SDK, `sendTransaction` handles polling internally and resolves when the intent completes:
+If you're using the Rhinestone SDK, `waitForExecution` handles polling internally and resolves when the intent completes:
 
 ```ts
-const result = await rhinestone.sendTransaction({ ... });
+const result = await rhinestoneAccount.submitTransaction(signed);
+const status = await rhinestoneAccount.waitForExecution(result);
 // resolves only after COMPLETED
 ```
 

--- a/intents/guides/using-the-api.mdx
+++ b/intents/guides/using-the-api.mdx
@@ -4,34 +4,51 @@ sidebarTitle: "Using the API"
 description: "How the Rhinestone Orchestrator API works and what to keep in mind when integrating."
 ---
 
-The Rhinestone Orchestrator API follows a quote-sign-submit flow. Each step is covered in the API guides section, but there are a few key rules that apply across the entire integration.
+The Rhinestone Orchestrator API follows a quote-sign-submit flow. Each step is covered in the API guides section, but there are a few rules that apply across the entire integration.
 
-## Submit the full path response
+## Pin a version
 
-When you call `/intents/route` you receive a full `intentOp` object. This object is HMAC signed by the Orchestrator. When you submit the signed intent to `/intent-operations`, you must include the **complete, unmodified** `intentOp` alongside your signatures.
-
-Any modification or omission of fields from the original response will produce an invalid HMAC error and the submission will be rejected.
+Send `x-api-version: 2026-04.blanc` on every request:
 
 ```ts
-// Correct: spread the full intentOp, then add signatures
-const body = {
-  signedIntentOp: {
-    ...freshIntentOp,         // full unmodified response
-    originSignatures,         // your signatures
-    destinationSignature,
-  },
+const headers = {
+  "Content-Type": "application/json",
+  "x-api-key": apiKey,
+  "x-api-version": "2026-04.blanc",
 };
 ```
 
-Do not cherry-pick fields from the response or reconstruct the object manually.
+Requests without the header fall back to the deprecated `2026-01.alps` shape. See [API versioning](./api-versioning) for the full versioning policy.
 
-## Refresh before signing
+## Server-stored intents
 
-Quotes expire. Always fetch a fresh quote immediately before asking the user to sign. Submitting a signed intent built from a stale quote will result in an expiry error.
+Quote responses are stored server-side. `POST /quotes` returns an `intentId` and the typed data needed for signing — you don't round-trip the full intent through the client. Submit by id:
+
+```ts
+const { routes } = await post("/quotes", body);
+const { intentId, signData } = routes[0];
+
+const signatures = {
+  origin: await Promise.all(signData.origin.map(signTypedData)),
+  destination: await signTypedData(signData.destination),
+};
+
+await post("/intents", { intentId, signatures });
+```
+
+Pick `routes[0]` unless you have your own ranking — the array is server-ranked by a cost/speed tradeoff.
+
+## Quote expiry
+
+Quotes have a short server-side TTL. If a quote expires (or the quote store restarts) before you submit, `POST /intents` returns a 404. Re-quote and re-sign — don't retry the submit.
 
 ## One signature per origin chain
 
-The `intentOp.elements` array contains one element per source chain involved. Each element requires a separate signature. The index of each signature must match the index of the element it signs.
+`signData.origin` is one entry per source chain. Sign each one in order. If the recipient differs from the sender and the destination has executions, sign `signData.destination` too — this slot is used for ownership of any received tokens.
+
+## Forward typed data verbatim
+
+Don't reconstruct EIP-712 types client-side. Forward the server's typed data directly to `wallet.signTypedData()`. Hand-rolled type libraries break on additive schema changes.
 
 ## Next steps
 

--- a/intents/quickstart.mdx
+++ b/intents/quickstart.mdx
@@ -22,26 +22,28 @@ This guide walks through the full intent flow for **EOA users**: get a quote, fu
 
 <Step title="Get a quote">
 
-Submit a meta intent to the `/intents/route` endpoint. Specify your destination chain, the token and amount you want on that chain, and your account:
+Submit a meta intent to the `/quotes` endpoint. Specify your destination chain, the token and amount you want on that chain, and your account:
 
 ```ts
 const BASE_URL = "https://v1.orchestrator.rhinestone.dev";
 const API_KEY = "YOUR_RHINESTONE_API_KEY";
 const EOA_ADDRESS = "0xYourEOAAddress";
 
-const res = await fetch(`${BASE_URL}/intents/route`, {
+const headers = {
+  "Content-Type": "application/json",
+  "x-api-key": API_KEY,
+  "x-api-version": "2026-04.blanc",
+};
+
+const res = await fetch(`${BASE_URL}/quotes`, {
   method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "x-api-key": API_KEY,
-    Accept: "application/json",
-  },
+  headers,
   body: JSON.stringify({
     account: {
       address: EOA_ADDRESS,
       accountType: "EOA",
     },
-    destinationChainId: 8453, // Base
+    destinationChainId: "eip155:8453", // Base
     tokenRequests: [
       {
         tokenAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC on Base
@@ -51,19 +53,22 @@ const res = await fetch(`${BASE_URL}/intents/route`, {
   }),
 });
 
-const { intentOp, intentCost, tokenRequirements } = await res.json();
+const { routes } = await res.json();
+const route = routes[0];
+const { intentId, signData, tokenRequirements } = route;
 ```
 
-The response includes:
-- `intentOp`: the intent elements for the user to sign
-- `intentCost`: the total cost in input tokens
-- `tokenRequirements`: any approvals or wrapping the user needs to complete before signing
+The response is a server-ranked `routes` array. Use `routes[0]` unless you have your own ranking. Each route carries:
+- `intentId`: server-stored handle, used to submit
+- `cost`: input/output amounts and fee breakdown
+- `signData`: EIP-712 typed data to sign
+- `tokenRequirements`: approvals or wrapping the user must complete before signing
 
 </Step>
 
 <Step title="Fulfill token requirements">
 
-Before signing, the user must fulfill any `tokenRequirements` returned in the quote. There are two types:
+Before signing, the user must fulfill any `tokenRequirements` returned in the quote. Keys are CAIP-2 chain ids (`eip155:8453`):
 
 **ERC-20 approvals** — approve tokens to the Permit2 contract:
 
@@ -109,84 +114,60 @@ Use max approvals to the [Permit2](https://github.com/Uniswap/permit2) contract.
 
 <Step title="Sign the intent">
 
-Get a fresh quote (to avoid stale pricing), then sign each intent element using EIP-712. You need one signature per input chain. The last signature also doubles as the destination signature.
+Forward `signData.origin[]` and `signData.destination` directly to `signTypedData`. One signature per source chain, plus the destination signature:
 
 ```ts
-import { signTypedData } from "@wagmi/core";
-
-// Refresh the quote before signing
-const { intentOp: freshIntentOp } = await fetch(`${BASE_URL}/intents/route`, {
-  method: "POST",
-  headers: { "Content-Type": "application/json", "x-api-key": API_KEY },
-  body: JSON.stringify({ /* same payload as before */ }),
-}).then((r) => r.json());
-
-const signatures = [];
-
-for (const element of freshIntentOp.elements) {
-  const typedData = getTypedData(
-    element,
-    BigInt(freshIntentOp.nonce),
-    BigInt(freshIntentOp.expires),
-  );
-
-  const signature = await signTypedData(wagmiConfig, typedData);
-  signatures.push(signature);
-}
-
-const originSignatures = signatures;
-const destinationSignature = signatures.at(-1);
+const originSignatures = await Promise.all(
+  signData.origin.map((typedData) =>
+    walletClient.signTypedData(typedData),
+  ),
+);
+const destinationSignature = await walletClient.signTypedData(
+  signData.destination,
+);
 ```
 
 <Card title="Signing guide" icon="signature" href="./guides/signing">
-  Full `getTypedData` implementation and type definitions
+  Smart account signing and validator wrapping.
 </Card>
 
 </Step>
 
 <Step title="Submit the intent">
 
-Post the signed intent to `/intent-operations`:
+Post the signed intent to `/intents`:
 
 ```ts
-const submitRes = await fetch(`${BASE_URL}/intent-operations`, {
+const submitRes = await fetch(`${BASE_URL}/intents`, {
   method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "x-api-key": API_KEY,
-    Accept: "application/json",
-  },
-  body: JSON.stringify(
-    {
-      signedIntentOp: {
-        ...freshIntentOp,
-        originSignatures,
-        destinationSignature,
-      },
+  headers,
+  body: JSON.stringify({
+    intentId,
+    signatures: {
+      origin: originSignatures,
+      destination: destinationSignature,
     },
-    (_, value) => (typeof value === "bigint" ? value.toString() : value),
-  ),
+  }),
 });
 
-const { bundleResults } = await submitRes.json();
-const operationId = bundleResults[0].bundleId;
+const { intentId: submittedId } = await submitRes.json();
 ```
+
+If submit returns 404, the quote TTL elapsed — re-quote and re-sign.
 
 </Step>
 
 <Step title="Poll for completion">
 
-Track execution status using the operation ID:
+Track execution status using the `intentId`:
 
 ```ts
-async function pollStatus(operationId: string) {
+async function pollStatus(intentId: string) {
   while (true) {
-    const res = await fetch(`${BASE_URL}/intent-operation/${operationId}`, {
-      headers: { "x-api-key": API_KEY },
-    });
+    const res = await fetch(`${BASE_URL}/intents/${intentId}`, { headers });
     const { status } = await res.json();
 
-    if (["COMPLETED", "FILLED", "FAILED", "EXPIRED"].includes(status)) {
+    if (["COMPLETED", "FAILED", "EXPIRED"].includes(status)) {
       console.log("Final status:", status);
       return status;
     }
@@ -195,10 +176,10 @@ async function pollStatus(operationId: string) {
   }
 }
 
-await pollStatus(operationId);
+await pollStatus(submittedId);
 ```
 
-Typical execution time is under 2 seconds. See [Submitting the Intent](/intents/guides/submitting-the-intent) for the full list of statuses.
+Typical execution time is under 2 seconds. See [Tracking intents](/intents/guides/tracking-intents) for the full lifecycle.
 
 </Step>
 

--- a/intents/tutorial/end-to-end-intent-flow.mdx
+++ b/intents/tutorial/end-to-end-intent-flow.mdx
@@ -24,6 +24,12 @@ import { privateKeyToAccount } from "viem/accounts";
 const BASE_URL = "https://v1.orchestrator.rhinestone.dev";
 const API_KEY = "YOUR_RHINESTONE_API_KEY";
 
+const headers = {
+  "Content-Type": "application/json",
+  "x-api-key": API_KEY,
+  "x-api-version": "2026-04.blanc",
+};
+
 const account = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
 
 const walletClient = createWalletClient({
@@ -48,34 +54,32 @@ const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 const ETH_ARBITRUM = "0x0000000000000000000000000000000000000000"; // native ETH
 const ETH_AMOUNT = "10000000000000000"; // 0.01 ETH (18 decimals)
 
-const quoteRes = await fetch(`${BASE_URL}/intents/route`, {
+const quoteRes = await fetch(`${BASE_URL}/quotes`, {
   method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "x-api-key": API_KEY,
-  },
+  headers,
   body: JSON.stringify({
     account: {
       address: EOA_ADDRESS,
       accountType: "EOA",
     },
-    destinationChainId: 42161, // Arbitrum
+    destinationChainId: "eip155:42161", // Arbitrum
     tokenRequests: [
       {
         tokenAddress: ETH_ARBITRUM,
         amount: ETH_AMOUNT,
       },
     ],
-    accountAccessList: [
-      {
-        chainId: 8453, // Base
-        tokenAddress: USDC_BASE,
+    accountAccessList: {
+      chainTokens: {
+        "eip155:8453": [USDC_BASE], // Base
       },
-    ],
+    },
   }),
 });
 
-const { intentOp, intentCost, tokenRequirements } = await quoteRes.json();
+const { routes } = await quoteRes.json();
+const route = routes[0];
+const { intentId, cost, signData, tokenRequirements } = route;
 ```
 
 <Info>
@@ -84,12 +88,11 @@ const { intentOp, intentCost, tokenRequirements } = await quoteRes.json();
   which can lead to unexpected gas requirements. Specify the exact source token(s) you want to use.
 </Info>
 
-Because the source token (USDC on Base) differs from the destination token (ETH on Arbitrum), `intentCost.tokensSpent` and `intentCost.tokensReceived` will show different tokens. This is how you know Warp is routing through a swap.
+Because the source token (USDC on Base) differs from the destination token (ETH on Arbitrum), `cost.input` and `cost.output` show different tokens. This is how you know Warp is routing through a swap.
 
 ```ts
-// Log what will be spent vs received
-console.log("Spending:", intentCost.tokensSpent);
-console.log("Receiving:", intentCost.tokensReceived);
+console.log("Spending:", cost.input);
+console.log("Receiving:", cost.output);
 ```
 
 </Step>
@@ -103,7 +106,7 @@ if (tokenRequirements) {
   for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
     for (const [tokenAddress, requirement] of Object.entries(tokens as Record<string, any>)) {
       if (requirement.type === "approval") {
-        console.log(`Approving ${tokenAddress} on chain ${chainId}...`);
+        console.log(`Approving ${tokenAddress} on ${chainId}...`);
 
         const { request } = await walletClient.simulateContract({
           address: tokenAddress as `0x${string}`,
@@ -128,77 +131,48 @@ if (tokenRequirements) {
 
 <Step title="Sign the intent">
 
-Refresh the quote to ensure fresh pricing, then sign each element using EIP-712. One signature per origin chain — the last signature doubles as the destination signature.
+Forward `signData.origin[]` and `signData.destination` directly to your wallet. One signature per source chain, plus the destination signature.
 
 ```ts
-// Refresh quote immediately before signing
-const refreshRes = await fetch(`${BASE_URL}/intents/route`, {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "x-api-key": API_KEY,
-  },
-  body: JSON.stringify({
-    account: { address: EOA_ADDRESS, accountType: "EOA" },
-    destinationChainId: 42161,
-    tokenRequests: [{ tokenAddress: ETH_ARBITRUM, amount: ETH_AMOUNT }],
-    accountAccessList: [{ chainId: 8453, tokenAddress: USDC_BASE }],
-  }),
-});
-
-const { intentOp: freshIntentOp } = await refreshRes.json();
-
-const signatures: string[] = [];
-
-for (const element of freshIntentOp.elements) {
-  const typedData = getTypedData(
-    element,
-    BigInt(freshIntentOp.nonce),
-    BigInt(freshIntentOp.expires),
-  );
-
-  const signature = await walletClient.signTypedData(typedData);
-  signatures.push(signature);
-}
-
-const originSignatures = signatures;
-const destinationSignature = signatures.at(-1)!;
+const originSignatures = await Promise.all(
+  signData.origin.map((typedData) =>
+    walletClient.signTypedData(typedData),
+  ),
+);
+const destinationSignature = await walletClient.signTypedData(
+  signData.destination,
+);
 ```
 
 <Card title="Signing guide" icon="signature" href="../guides/signing">
-  Full `getTypedData` implementation and type definitions.
+  Smart account signing and validator wrapping.
 </Card>
 
 </Step>
 
 <Step title="Submit the intent">
 
-Post the signed intent to `/intent-operations`:
+Post the signed intent to `/intents` using the `intentId` from the quote:
 
 ```ts
-const submitRes = await fetch(`${BASE_URL}/intent-operations`, {
+const submitRes = await fetch(`${BASE_URL}/intents`, {
   method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "x-api-key": API_KEY,
-  },
-  body: JSON.stringify(
-    {
-      signedIntentOp: {
-        ...freshIntentOp,
-        originSignatures,
-        destinationSignature,
-      },
+  headers,
+  body: JSON.stringify({
+    intentId,
+    signatures: {
+      origin: originSignatures,
+      destination: destinationSignature,
     },
-    (_, value) => (typeof value === "bigint" ? value.toString() : value),
-  ),
+  }),
 });
 
-const { result } = await submitRes.json();
-const operationId = result.id;
+const { intentId: submittedId } = await submitRes.json();
 
-console.log("Intent submitted. Operation ID:", operationId);
+console.log("Intent submitted:", submittedId);
 ```
+
+If the submit returns 404, the quote TTL elapsed — re-quote and re-sign.
 
 </Step>
 
@@ -207,19 +181,17 @@ console.log("Intent submitted. Operation ID:", operationId);
 Track the intent status until it reaches a final state:
 
 ```ts
-async function pollUntilComplete(operationId: string) {
-  const FINAL_STATUSES = ["COMPLETED", "FILLED", "FAILED", "EXPIRED"];
+async function pollUntilComplete(intentId: string) {
+  const FINAL_STATUSES = ["COMPLETED", "FAILED", "EXPIRED"];
 
   while (true) {
-    const res = await fetch(`${BASE_URL}/intent-operation/${operationId}`, {
-      headers: { "x-api-key": API_KEY },
-    });
+    const res = await fetch(`${BASE_URL}/intents/${intentId}`, { headers });
 
     const data = await res.json();
     console.log("Status:", data.status);
 
     if (FINAL_STATUSES.includes(data.status)) {
-      if (data.status === "COMPLETED" || data.status === "FILLED") {
+      if (data.status === "COMPLETED") {
         console.log("Swap complete!");
         console.log("Fill tx:", data.fillTransactionHash);
       } else {
@@ -232,10 +204,10 @@ async function pollUntilComplete(operationId: string) {
   }
 }
 
-await pollUntilComplete(operationId);
+await pollUntilComplete(submittedId);
 ```
 
-Typical execution time is under 2 seconds. `FILLED` means the relayer has delivered funds on the destination. `COMPLETED` means the claim has settled on the origin chain too.
+Typical execution time is under 2 seconds. `FILLED` is an intermediate state — the relayer has delivered funds on the destination, but the source-chain claim hasn't settled yet. `COMPLETED` means everything is settled.
 
 </Step>
 

--- a/intents/use-cases/automated-zaps.mdx
+++ b/intents/use-cases/automated-zaps.mdx
@@ -46,6 +46,7 @@ Define multi-chain sessions scoped to the vault contracts your app supports. The
 
 ```ts
 import { toSession } from "@rhinestone/sdk/smart-sessions";
+import { erc20Abi } from "viem";
 import { arbitrum, optimism } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 
@@ -60,7 +61,27 @@ const sessions = [
       accounts: [sessionOwnerAccount],
     },
     permissions: [
-      { abi: vaultAbi, address: ARBITRUM_VAULT_ADDRESS, functions: {} },
+      {
+        abi: vaultAbi,
+        address: ARBITRUM_VAULT_ADDRESS,
+        functions: { deposit: {} },
+      },
+      // Pulling USDC from the user and returning vault shares also flow
+      // through this session — scope them too.
+      {
+        abi: erc20Abi,
+        address: USDC_ADDRESS,
+        functions: {
+          // ...
+        },
+      },
+      {
+        abi: erc20Abi,
+        address: ARBITRUM_VAULT_TOKEN_ADDRESS,
+        functions: {
+          // ...
+        },
+      },
     ],
   }),
   toSession({
@@ -70,8 +91,17 @@ const sessions = [
       accounts: [sessionOwnerAccount],
     },
     permissions: [
-      { abi: vaultAbi, address: OPTIMISM_VAULT_A_ADDRESS, functions: {} },
-      { abi: vaultAbi, address: OPTIMISM_VAULT_B_ADDRESS, functions: {} },
+      {
+        abi: vaultAbi,
+        address: OPTIMISM_VAULT_A_ADDRESS,
+        functions: { deposit: {} },
+      },
+      {
+        abi: vaultAbi,
+        address: OPTIMISM_VAULT_B_ADDRESS,
+        functions: { deposit: {} },
+      },
+      // Plus the ERC-20 permissions, as above.
     ],
   }),
 ];

--- a/intents/use-cases/automated-zaps.mdx
+++ b/intents/use-cases/automated-zaps.mdx
@@ -45,35 +45,35 @@ Since the user's EOA is the sole owner, the account is fully non-custodial. Your
 Define multi-chain sessions scoped to the vault contracts your app supports. The session key is controlled by your app's service.
 
 ```ts
-import { type Session } from "@rhinestone/sdk";
+import { toSession } from "@rhinestone/sdk/smart-sessions";
 import { arbitrum, optimism } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 
 // Session key controlled by your app's service
 const sessionOwnerAccount = privateKeyToAccount(appSessionKey);
 
-const sessions: Session[] = [
-  {
+const sessions = [
+  toSession({
     chain: arbitrum,
     owners: {
       type: "ecdsa",
       accounts: [sessionOwnerAccount],
     },
-    actions: [
-      { target: ARBITRUM_VAULT_ADDRESS },
+    permissions: [
+      { abi: vaultAbi, address: ARBITRUM_VAULT_ADDRESS, functions: {} },
     ],
-  },
-  {
+  }),
+  toSession({
     chain: optimism,
     owners: {
       type: "ecdsa",
       accounts: [sessionOwnerAccount],
     },
-    actions: [
-      { target: OPTIMISM_VAULT_A_ADDRESS },
-      { target: OPTIMISM_VAULT_B_ADDRESS },
+    permissions: [
+      { abi: vaultAbi, address: OPTIMISM_VAULT_A_ADDRESS, functions: {} },
+      { abi: vaultAbi, address: OPTIMISM_VAULT_B_ADDRESS, functions: {} },
     ],
-  },
+  }),
 ];
 ```
 
@@ -133,7 +133,7 @@ Once funded, the companion account executes the crosschain intent using the sess
 ```ts
 import { encodeFunctionData, erc20Abi } from "viem";
 
-await companionAccount.sendTransaction({
+const prepared = await companionAccount.prepareTransaction({
   sourceChains: [ethereum],
   targetChain: arbitrum,
   calls: [
@@ -171,6 +171,8 @@ await companionAccount.sendTransaction({
     },
   },
 });
+const signed = await companionAccount.signTransaction(prepared);
+await companionAccount.submitTransaction(signed);
 ```
 
 <Note>
@@ -201,7 +203,7 @@ When your app is ready to execute, it pulls the funds from the user and executes
 **Pull approved tokens into the companion account** (same-chain):
 
 ```ts
-await companionAccount.sendTransaction({
+const preparedPull = await companionAccount.prepareTransaction({
   targetChain: ethereum,
   calls: [
     {
@@ -219,12 +221,14 @@ await companionAccount.sendTransaction({
     enableData: sessionEnableData,
   },
 });
+const signedPull = await companionAccount.signTransaction(preparedPull);
+await companionAccount.submitTransaction(signedPull);
 ```
 
 **Execute the crosschain intent** (bridge + vault deposit):
 
 ```ts
-await companionAccount.sendTransaction({
+const preparedExecute = await companionAccount.prepareTransaction({
   sourceChains: [ethereum],
   targetChain: arbitrum,
   calls: [
@@ -257,6 +261,8 @@ await companionAccount.sendTransaction({
     enableData: sessionEnableData,
   },
 });
+const signedExecute = await companionAccount.signTransaction(preparedExecute);
+await companionAccount.submitTransaction(signedExecute);
 ```
 
 <Note>

--- a/intents/use-cases/multi-input-bridge.mdx
+++ b/intents/use-cases/multi-input-bridge.mdx
@@ -14,7 +14,7 @@ You can also influence the routing by specifying input tokens and chains via `ac
 ```json
 {
   "accountAccessList": {
-    "chainIds": [10, 8453],
+    "chainIds": ["eip155:10", "eip155:8453"],
     "tokens": ["USDC"]
   }
 }
@@ -24,45 +24,45 @@ Learn more about choosing the inputs in the ["Getting a Quote" guide](../guides/
 
 ## Response
 
-In the case of multi-input bridging, you will get a route with multiple elements (one for each input chain) and/or multiple spent tokens.
+In the case of multi-input bridging, you will get a route whose `cost.input` lists multiple entries (one per source chain and/or token), and `signData.origin[]` carries one entry per source chain.
 
 ```json Multi-Input Intent
 {
-  "intentOp": {
-    // …
-    "elements": [
-      {
-        "chainId": "8453",
-        // …
+  "routes": [
+    {
+      "intentId": "...",
+      "cost": {
+        "input": [
+          {
+            "chainId": "eip155:8453",
+            "tokenAddress": "0x4200000000000000000000000000000000000006",
+            "symbol": "WETH",
+            "decimals": 18,
+            "price": { "usd": 2412.37 },
+            "amount": "22291303013436002"
+          },
+          {
+            "chainId": "eip155:10",
+            "tokenAddress": "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+            "symbol": "USDC",
+            "decimals": 6,
+            "price": { "usd": 0.99 },
+            "amount": "8370380"
+          }
+        ]
       },
-      {
-        "chainId": "10",
-        // …
-      }
-    ],
-  },
-  "intentCost": {
-    // …
-    "tokensSpent": {
-      "8453": {
-        "0x4200000000000000000000000000000000000006": {
-          "locked": "0",
-          "unlocked": "22291303013436002",
-          "version": 0
-        }
-      },
-      "10": {
-        "0x0b2c639c533813f4aa9d7837caf62653d097ff85": {
-          "locked": "0",
-          "unlocked": "8370380",
-          "version": 0
-        }
+      "signData": {
+        "origin": [
+          { /* typed data for eip155:8453 */ },
+          { /* typed data for eip155:10 */ }
+        ],
+        "destination": { /* typed data for the destination */ }
       }
     }
-  }
+  ]
 }
 ```
 
 If the user doesn't have outstanding Permit2 approvals, they will need to approve multiple input tokens.
 
-The user will also need to sign each element separately, i.e., one signature per input chain.
+The user will also need to sign each entry in `signData.origin[]` separately — one signature per input chain.

--- a/intents/use-cases/vault-deposit.mdx
+++ b/intents/use-cases/vault-deposit.mdx
@@ -119,7 +119,7 @@ const destinationExecutions = [
 
 ```ts
 const metaIntent = {
-  destinationChainId: 42161, // e.g. Arbitrum
+  destinationChainId: "eip155:42161", // e.g. Arbitrum
   tokenRequests: [
     {
       tokenAddress: DEPOSIT_TOKEN,
@@ -139,7 +139,7 @@ const metaIntent = {
 
 ```ts
 const metaIntent = {
-  destinationChainId: 42161, // e.g. Arbitrum
+  destinationChainId: "eip155:42161", // e.g. Arbitrum
   tokenRequests: [
     {
       tokenAddress: DEPOSIT_TOKEN,
@@ -160,33 +160,35 @@ const metaIntent = {
 
 ## Getting a Quote
 
-Submit the meta intent to the `/intents/route` endpoint to get a quote:
+Submit the meta intent to the `/quotes` endpoint:
 
 ```ts
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
 const apiKey = "YOUR_RHINESTONE_API_KEY";
 
-const res = await fetch(`${baseUrl}/intents/route`, {
+const headers = {
+  "Content-Type": "application/json",
+  "x-api-key": apiKey,
+  "x-api-version": "2026-04.blanc",
+};
+
+const res = await fetch(`${baseUrl}/quotes`, {
   method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "x-api-key": apiKey,
-    Accept: "application/json",
-  },
-  body: JSON.stringify(metaIntent, (_, value) =>
-    typeof value === "bigint" ? value.toString() : value,
-  ),
+  headers,
+  body: JSON.stringify(metaIntent),
 });
 
-const data = await res.json();
-const { intentOp, intentCost, tokenRequirements } = data;
+const { routes } = await res.json();
+const route = routes[0];
+const { intentId, cost, signData, tokenRequirements } = route;
 ```
 
-The response includes:
+The response is a server-ranked `routes` array. Each route carries:
 
-- `intentOp`: the intent operation elements to sign
-- `intentCost`: the cost of the intent in input tokens
-- `tokenRequirements`: any prerequisite token operations (EOA only)
+- `intentId`: server-stored handle, used to submit
+- `cost`: input/output amounts and fee breakdown
+- `signData`: EIP-712 typed data to sign
+- `tokenRequirements`: prerequisite token operations (EOA only)
 
 <Card
   title="Getting a Quote"
@@ -238,7 +240,7 @@ const hash = await walletClient.writeContract({
 ```
 
 <Info>
-Approvals are only ever to the [Permit2](https://github.com/Uniswap/permit2) contract. We recommend using max approvals for the best UX. Alternatively, inspect the `tokensSpent` field on the intent elements for the exact amount needed.
+Approvals are only ever to the [Permit2](https://github.com/Uniswap/permit2) contract. We recommend using max approvals for the best UX. Alternatively, inspect `cost.input` for the exact amount needed.
 </Info>
 
 </Tab>
@@ -262,131 +264,62 @@ Smart Accounts handle token approvals and wrapping automatically via pre-claim o
 <Tabs>
 <Tab title="EOA">
 
-EOAs sign each intent element using EIP-712 typed data via Permit2. You need one signature per input chain. The last origin signature doubles as the destination signature.
+Forward `signData.origin[]` and `signData.destination` directly to your wallet. One signature per source chain, plus the destination signature.
 
 ```ts
-import { type Hex } from "viem";
-
-const signatures: Hex[] = [];
-
-for (const element of intentOp.elements) {
-  const typedData = getTypedData(
-    element,
-    BigInt(intentOp.nonce),
-    BigInt(intentOp.expires),
-  );
-
-  const signature = await walletClient.signTypedData({
-    domain: typedData.domain,
-    types: typedData.types,
-    primaryType: typedData.primaryType,
-    message: typedData.message,
-  });
-
-  signatures.push(signature);
-}
-
-const originSignatures = signatures;
-const destinationSignature = signatures.at(-1)!;
+const originSignatures = await Promise.all(
+  signData.origin.map((typedData) =>
+    walletClient.signTypedData(typedData),
+  ),
+);
+const destinationSignature = await walletClient.signTypedData(
+  signData.destination,
+);
 ```
-
-<Card
-  title="Signing"
-  icon="signature"
-  href="../guides/signing"
->
-  See the full signing guide for the `getTypedData` implementation and type definitions
-</Card>
 
 </Tab>
 <Tab title="Smart Account">
 
-Smart Accounts compute a digest over the intent bundle and sign it, then encode the signature with the ownable validator.
+Smart account signing wraps the signature with the installed validator's encoding. The Rhinestone SDK handles this automatically — use it for smart account flows rather than driving the raw API by hand.
 
-```ts
-import {
-  type Hex,
-  type Address,
-  hashTypedData,
-  keccak256,
-  encodePacked,
-} from "viem";
-import { privateKeyToAccount } from "viem/accounts";
-import { getOwnableValidator } from "@rhinestone/module-sdk";
-
-const account = privateKeyToAccount(OWNER_PRIVATE_KEY);
-
-// Compute the digest for each element
-const digest = getCompactDigest(intentOp);
-
-// Sign the digest
-const signature = await account.signMessage({
-  message: { raw: digest },
-});
-
-// Encode with the ownable validator
-const ownableValidator = getOwnableValidator({
-  owners: [account.address],
-  threshold: 1,
-});
-
-const encodedSignature: Hex = encodePacked(
-  ["address", "uint8", "bytes"],
-  [
-    ownableValidator.address,
-    0, // config ID
-    signature,
-  ],
-);
-
-const originSignatures = Array(intentOp.elements.length).fill(
-  encodedSignature,
-);
-const destinationSignature = encodedSignature;
-```
-
-<Note>
-The `getCompactDigest` function routes to the appropriate digest computation based on the settlement layer. See the [signing guide](../guides/signing) for details on the underlying typed data structure.
-</Note>
+<Card
+  title="Smart Wallet quickstart"
+  icon="bolt"
+  href="/smart-wallet/quickstart"
+>
+  Send a crosschain intent from a smart account using the SDK
+</Card>
 
 </Tab>
 </Tabs>
 
 ## Submitting and Polling
 
-Submit the signed intent to the `/intent-operations` endpoint:
+Submit the signed intent to `/intents` using the `intentId` from the quote:
 
 ```ts
-const res = await fetch(`${baseUrl}/intent-operations`, {
+const res = await fetch(`${baseUrl}/intents`, {
   method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    "x-api-key": apiKey,
-    Accept: "application/json",
-  },
-  body: JSON.stringify(
-    {
-      intentOp,
-      originSignatures,
-      destinationSignature,
+  headers,
+  body: JSON.stringify({
+    intentId,
+    signatures: {
+      origin: originSignatures,
+      destination: destinationSignature,
     },
-    (_, value) => (typeof value === "bigint" ? value.toString() : value),
-  ),
+  }),
 });
 
-const { bundleResults } = await res.json();
-const operationId = bundleResults[0].bundleId;
+const { intentId: submittedId } = await res.json();
 ```
 
-Poll for status using the operation ID:
+Poll for status using the `intentId`:
 
 ```ts
-const poll = async (operationId: string) => {
-  const res = await fetch(`${baseUrl}/intent-operation/${operationId}`, {
-    headers: { "x-api-key": apiKey },
-  });
+const poll = async (intentId: string) => {
+  const res = await fetch(`${baseUrl}/intents/${intentId}`, { headers });
   return res.json();
 };
 ```
 
-See the [submitting guide](../guides/submitting-the-intent) for the full list of intent statuses.
+See the [tracking intents guide](../guides/tracking-intents) for the full list of intent statuses.

--- a/smart-wallet/advanced/batch-transactions.mdx
+++ b/smart-wallet/advanced/batch-transactions.mdx
@@ -5,20 +5,18 @@ title: "Batch transactions"
 You can make multiple calls in a single transaction:
 
 ```ts
-import { getTokenAddress } from '@rhinestone/sdk/orchestrator'
 import { baseSepolia } from 'viem/chains'
 
 const chain = baseSepolia
-const usdcAddress = getTokenAddress('USDC', chain.id)
 const usdcAmount = 1n
 const ethAmount = 2n
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
     {
-      to: usdcAddress,
+      to: 'USDC',
       data: encodeFunctionData({
         abi: erc20Abi,
         functionName: 'transfer',
@@ -31,5 +29,4 @@ const transaction = await rhinestoneAccount.sendTransaction({
     },
   ]
 })
-console.log('Transaction', transaction)
 ```

--- a/smart-wallet/advanced/batch-transactions.mdx
+++ b/smart-wallet/advanced/batch-transactions.mdx
@@ -12,7 +12,7 @@ const usdcAmount = 1n
 const ethAmount = 2n
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
     {

--- a/smart-wallet/advanced/custom-modules.mdx
+++ b/smart-wallet/advanced/custom-modules.mdx
@@ -14,9 +14,10 @@ To create a custom module, use the [ModuleKit](https://github.com/rhinestonewtf/
 You can install custom modules during account deployment by passing them in the `modules` field when creating the account:
 
 ```ts
-import { createRhinestoneAccount } from '@rhinestone/sdk'
+import { RhinestoneSDK } from '@rhinestone/sdk'
 
-const rhinestoneAccount = await createRhinestoneAccount({
+const rhinestone = new RhinestoneSDK({ apiKey })
+const rhinestoneAccount = await rhinestone.createAccount({
   owners: {
     type: 'ecdsa',
     accounts: [owner],
@@ -41,7 +42,7 @@ You can install and use custom validators, executors, and hooks.
 ```ts
 import { installModule, uninstallModule } from '@rhinestone/sdk/actions'
 
-const transactionData = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   targetChain: base,
   calls: [
     installModule({
@@ -59,7 +60,7 @@ const transactionData = await rhinestoneAccount.sendTransaction({
 You can also remove any module from the account:
 
 ```ts
-const result2 = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   targetChain: base,
   calls: [
     uninstallModule({

--- a/smart-wallet/advanced/custom-modules.mdx
+++ b/smart-wallet/advanced/custom-modules.mdx
@@ -42,7 +42,7 @@ You can install and use custom validators, executors, and hooks.
 ```ts
 import { installModule, uninstallModule } from '@rhinestone/sdk/actions'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   targetChain: base,
   calls: [
     installModule({
@@ -60,7 +60,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 You can also remove any module from the account:
 
 ```ts
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   targetChain: base,
   calls: [
     uninstallModule({

--- a/smart-wallet/advanced/custom-signing.mdx
+++ b/smart-wallet/advanced/custom-signing.mdx
@@ -15,27 +15,22 @@ const transactionData = await rhinestoneAccount.prepareTransaction({
   // …
 });
 
-// 2. Pick a quote (default: the best one)
-const quote = transactionData.quotes.best;
-
-// 3. Extract messages
+// 2. Extract messages
 const { origin, destination } =
   rhinestoneAccount.getTransactionMessages(transactionData);
 
-// 4. Sign each message
+// 3. Sign each message
 const originSignatures = await Promise.all(
   origin.map((message) => sign(message)),
 );
 const destinationSignature = await sign(destination);
 
-// 5. Submit the transaction
+// 4. Submit the transaction
 const transaction = await rhinestoneAccount.submitTransaction({
   ...transactionData,
-  quote,
+  quote: transactionData.quotes.best,
   originSignatures,
   destinationSignature,
   targetExecutionSignature: undefined,
 });
 ```
-
-To sign a non-default quote, pass the chosen quote's `intentId` to `getTransactionMessages` and use the matching entry from `transactionData.quotes.all` as the `quote` field.

--- a/smart-wallet/advanced/custom-signing.mdx
+++ b/smart-wallet/advanced/custom-signing.mdx
@@ -10,27 +10,32 @@ Custom signing is useful when you need to implement custom signing flows (e.g. s
 ## Example
 
 ```ts
-import { signTypedData } from "viem/accounts";
-
 // 1. Prepare the transaction
 const transactionData = await rhinestoneAccount.prepareTransaction({
   // …
 });
 
-// 2. Extract messages
+// 2. Pick a quote (default: the best one)
+const quote = transactionData.quotes.best;
+
+// 3. Extract messages
 const { origin, destination } =
   rhinestoneAccount.getTransactionMessages(transactionData);
 
-// 3. Sign each message
+// 4. Sign each message
 const originSignatures = await Promise.all(
   origin.map((message) => sign(message)),
 );
 const destinationSignature = await sign(destination);
 
-// 4. Submit the transaction
+// 5. Submit the transaction
 const transaction = await rhinestoneAccount.submitTransaction({
   ...transactionData,
+  quote,
   originSignatures,
   destinationSignature,
+  targetExecutionSignature: undefined,
 });
 ```
+
+To sign a non-default quote, pass the chosen quote's `intentId` to `getTransactionMessages` and use the matching entry from `transactionData.quotes.all` as the `quote` field.

--- a/smart-wallet/advanced/erc4337.mdx
+++ b/smart-wallet/advanced/erc4337.mdx
@@ -79,12 +79,10 @@ const rhinestone = new RhinestoneSDK({
 
 ## Usage
 
-ERC-4337 has a separate transaction API: `sendUserOperation` (or the granular `prepareUserOperation` → `signUserOperation` → `submitUserOperation` flow). Use it when a module requires the user-op flow — intent flows continue to use `prepareTransaction`.
-
-### Send a UserOperation
+ERC-4337 has a separate transaction API. Use it when a module requires the user-op flow — intent flows continue to use `prepareTransaction`.
 
 ```ts
-const result = await rhinestoneAccount.sendUserOperation({
+const prepared = await rhinestoneAccount.prepareUserOperation({
   chain: base,
   calls: [
     {
@@ -94,21 +92,8 @@ const result = await rhinestoneAccount.sendUserOperation({
     },
   ],
 })
+const signed = await rhinestoneAccount.signUserOperation(prepared)
+const result = await rhinestoneAccount.submitUserOperation(signed)
 
-const status = await rhinestoneAccount.waitForExecution(result)
-```
-
-### Granular API
-
-Use the lower-level API to separate preparation, signing, and submission:
-
-```ts
-const transactionData = await rhinestoneAccount.prepareUserOperation({
-  chain: base,
-  calls: [...],
-})
-
-const signedData = await rhinestoneAccount.signUserOperation(transactionData)
-const result = await rhinestoneAccount.submitUserOperation(signedData)
 const status = await rhinestoneAccount.waitForExecution(result)
 ```

--- a/smart-wallet/advanced/erc4337.mdx
+++ b/smart-wallet/advanced/erc4337.mdx
@@ -79,12 +79,12 @@ const rhinestone = new RhinestoneSDK({
 
 ## Usage
 
+ERC-4337 has a separate transaction API: `sendUserOperation` (or the granular `prepareUserOperation` → `signUserOperation` → `submitUserOperation` flow). Use it when a module requires the user-op flow — intent flows continue to use `prepareTransaction`.
+
 ### Send a UserOperation
 
-Once configured, `sendTransaction` automatically routes through ERC-4337 when required:
-
 ```ts
-const result = await rhinestoneAccount.sendTransaction({
+const result = await rhinestoneAccount.sendUserOperation({
   chain: base,
   calls: [
     {

--- a/smart-wallet/advanced/multi-factor-authentication.mdx
+++ b/smart-wallet/advanced/multi-factor-authentication.mdx
@@ -50,7 +50,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
   // …
 });
 
-const enableMfaTx = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: sourceChain,
   calls: [
     enableMultiFactor([
@@ -65,7 +65,6 @@ const enableMfaTx = await rhinestoneAccount.sendTransaction({
     ]),
   ],
 })
-await rhinestoneAccount.waitForExecution(enableMfaTx)
 ```
 
 ## Usage
@@ -111,7 +110,7 @@ const transactionData = await rhinestoneAccount.prepareTransaction({
 ```ts
 const validatorId = 2;
 
-const addSubValidatorTx = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: sourceChain,
   calls: [
     setSubValidator(validatorId, {
@@ -120,7 +119,6 @@ const addSubValidatorTx = await rhinestoneAccount.sendTransaction({
     }),
   ],
 })
-await rhinestoneAccount.waitForExecution(addSubValidatorTx)
 ```
 
 ### Removing a validator
@@ -128,7 +126,7 @@ await rhinestoneAccount.waitForExecution(addSubValidatorTx)
 ```ts
 const validatorId = 2;
 
-const removeSubValidatorTx = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: sourceChain,
   calls: [
     removeSubValidator(validatorId, {
@@ -137,5 +135,4 @@ const removeSubValidatorTx = await rhinestoneAccount.sendTransaction({
     }),
   ],
 })
-await rhinestoneAccount.waitForExecution(removeSubValidatorTx)
 ```

--- a/smart-wallet/advanced/multi-factor-authentication.mdx
+++ b/smart-wallet/advanced/multi-factor-authentication.mdx
@@ -50,7 +50,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
   // …
 });
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: sourceChain,
   calls: [
     enableMultiFactor([
@@ -110,7 +110,7 @@ const transactionData = await rhinestoneAccount.prepareTransaction({
 ```ts
 const validatorId = 2;
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: sourceChain,
   calls: [
     setSubValidator(validatorId, {
@@ -126,7 +126,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 ```ts
 const validatorId = 2;
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: sourceChain,
   calls: [
     removeSubValidator(validatorId, {

--- a/smart-wallet/advanced/security.mdx
+++ b/smart-wallet/advanced/security.mdx
@@ -46,9 +46,7 @@ const getApiKey = () => {
 const validateDestinationOps = (body: any): boolean => {
   if (ALLOW_ALL_CONTRACTS) return true;
 
-  const destinationOps =
-    body?.signedIntentOp?.signedMetadata?.account?.accountContext?.destinationExecutions;
-
+  const destinationOps = body?.destinationExecutions;
   if (!destinationOps) return true; // nothing to validate
 
   for (const op of destinationOps) {
@@ -72,6 +70,7 @@ async function handleRequest(request: NextRequest, params: { path: string[] }) {
     const headers: HeadersInit = {
       "Content-Type": "application/json",
       "x-api-key": apiKey,
+      "x-api-version": "2026-04.blanc",
     };
 
     const fetchOptions: RequestInit = {
@@ -82,8 +81,9 @@ async function handleRequest(request: NextRequest, params: { path: string[] }) {
     if (request.method !== "GET" && request.method !== "HEAD") {
       const body = await request.text();
       if (body) {
-        // Validate intent operations
-        if (path.includes("intent-operations")) {
+        // Validate destinationExecutions on quote requests, before the intent
+        // is stored server-side and bound to an intentId.
+        if (path === "quotes") {
           const parsedBody = JSON.parse(body);
           if (!validateDestinationOps(parsedBody)) {
             return NextResponse.json(

--- a/smart-wallet/advanced/security.mdx
+++ b/smart-wallet/advanced/security.mdx
@@ -139,7 +139,7 @@ Set `RHINESTONE_API_KEY` only on the server (e.g., in `.env` without `NEXT_PUBLI
 Point the SDK to your proxy URL so user traffic never touches the Orchestrator directly:
 
 ```ts
-import { RhinestoneSDK, walletClientToAccount } from "@rhinestone/sdk";
+import { RhinestoneSDK } from "@rhinestone/sdk";
 
 const baseUrl = typeof window !== "undefined" ? window.location.origin : process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 

--- a/smart-wallet/chain-abstraction/account-deployment.mdx
+++ b/smart-wallet/chain-abstraction/account-deployment.mdx
@@ -61,7 +61,7 @@ const newAccount = await rhinestone.createAccount({
   owners: { type: 'ecdsa', accounts: [newOwner] },
 })
 
-const prepared = await sponsorAccount.prepareTransaction({
+const transaction = await sponsorAccount.prepareTransaction({
   chain,
   calls: [deploy(newAccount)],
 })

--- a/smart-wallet/chain-abstraction/account-deployment.mdx
+++ b/smart-wallet/chain-abstraction/account-deployment.mdx
@@ -6,7 +6,7 @@ The SDK handles the account deployments for you. When transacting on a new chain
 
 ## How deployment works
 
-Deployment is per-chain. When you call `sendTransaction` targeting a chain where the account is not deployed yet, the Orchestrator bundles the deployment into the intent automatically. The account is only deployed on that specific chain, not on all supported chains at once.
+Deployment is per-chain. When you submit a transaction targeting a chain where the account is not deployed yet, the Orchestrator bundles the deployment into the intent automatically. The account is only deployed on that specific chain, not on all supported chains at once.
 
 Receiving tokens at the counterfactual address does not trigger deployment. Only an outbound transaction submitted through the SDK does.
 
@@ -61,7 +61,7 @@ const newAccount = await rhinestone.createAccount({
   owners: { type: 'ecdsa', accounts: [newOwner] },
 })
 
-await sponsorAccount.sendTransaction({
+const prepared = await sponsorAccount.prepareTransaction({
   chain,
   calls: [deploy(newAccount)],
 })

--- a/smart-wallet/chain-abstraction/custom-recipient.mdx
+++ b/smart-wallet/chain-abstraction/custom-recipient.mdx
@@ -10,7 +10,7 @@ By default, the destination funds are sent to the sender's account. You can over
 Pass a plain address to send funds to an arbitrary address:
 
 ```ts {4}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism],
   targetChain: base,
   recipient: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
@@ -28,7 +28,7 @@ const transaction = await rhinestoneAccount.sendTransaction({
 You can also pass a `RhinestoneAccountConfig` to send funds to a smart account:
 
 ```ts {4-9}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism],
   targetChain: base,
   recipient: {

--- a/smart-wallet/chain-abstraction/custom-recipient.mdx
+++ b/smart-wallet/chain-abstraction/custom-recipient.mdx
@@ -10,7 +10,7 @@ By default, the destination funds are sent to the sender's account. You can over
 Pass a plain address to send funds to an arbitrary address:
 
 ```ts {4}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism],
   targetChain: base,
   recipient: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
@@ -28,7 +28,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 You can also pass a `RhinestoneAccountConfig` to send funds to a smart account:
 
 ```ts {4-9}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism],
   targetChain: base,
   recipient: {

--- a/smart-wallet/chain-abstraction/error-handling.mdx
+++ b/smart-wallet/chain-abstraction/error-handling.mdx
@@ -23,14 +23,14 @@ title: "Error handling"
 
 ## Orchestrator errors
 
-* `InsufficientBalanceError`: the account doesn't have enough funds. See [Insufficient Balance](/intents/guides/error-handling#insufficient-balance).
-* `UnsupportedChainIdError`: this chain is not supported. See [Unsupported chain id](/intents/guides/error-handling#unsupported-chain-id).
-* `UnsupportedChainError`: the target or the source chain is not supported. See [Unsupported chain id](/intents/guides/error-handling#unsupported-chain-id).
-* `UnsupportedTokenError`: the token you're requesting is not supported. Make sure you're only using supported tokens when setting `tokenRequests`. See [Unsupported token addresses](/intents/guides/error-handling#unsupported-token-addresses).
-* `TokenNotSupportedError`: the token you're requesting is not supported. See [Unsupported token addresses](/intents/guides/error-handling#unsupported-token-addresses).
-* `AuthenticationRequiredError`: make sure you're providing an API key when using mainnets by passing `rhinestoneApiKey` param. See [Authentication is required](/intents/guides/error-handling#authentication-is-required).
-* `InvalidApiKeyError`: the API key you're using has expired or is invalid. See [Invalid API key](/intents/guides/error-handling#invalid-api-key).
-* `InvalidIntentSignatureError`: [Invalid bundle signature](/intents/guides/error-handling#invalid-bundle-signature).
+* `InsufficientBalanceError`: the account doesn't have enough funds. See [Error handling](/intents/guides/error-handling).
+* `UnsupportedChainIdError`: this chain is not supported. See [Error handling](/intents/guides/error-handling).
+* `UnsupportedChainError`: the target or the source chain is not supported. See [Error handling](/intents/guides/error-handling).
+* `UnsupportedTokenError`: the token you're requesting is not supported. Make sure you're only using supported tokens when setting `tokenRequests`. See [Error handling](/intents/guides/error-handling).
+* `TokenNotSupportedError`: the token you're requesting is not supported. See [Error handling](/intents/guides/error-handling).
+* `AuthenticationRequiredError`: make sure you're providing an API key when using mainnets by passing `rhinestoneApiKey` param. See [Error handling](/intents/guides/error-handling).
+* `InvalidApiKeyError`: the API key you're using has expired or is invalid. See [Error handling](/intents/guides/error-handling).
+* `InvalidIntentSignatureError`: see [Error handling](/intents/guides/error-handling).
 * `OnlyOneTargetTokenAmountCanBeUnsetError`: when specifying `tokenRequests`, you need to provide the exact token amounts for all except one token.
 * `NoPathFoundError`: we couldn't find a path for the intent you've provided. Try using a different set of token requests on the target chain.
 * `IntentNotFoundError`: can't find the intent in the system. Please try again or use different input parameters.

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -57,7 +57,7 @@ If you already have an account deployed on one or more source chains, you can om
 You can override the default gas limit for the target chain execution with `gasLimit`. Doing this will make the intent better priced, because we can more accurately calculate the fee that a solver needs to be reimbursed with for paying the gas. If this is not provided, we calculate using a gas limit of `1_000_000`.
 
 ```ts {10}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
@@ -75,7 +75,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 You can specify what token (or tokens) to use as an input asset:
 
 ```ts {10}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
@@ -91,7 +91,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 You can also specify source assets on a per-chain basis:
 
 ```ts {9-12}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   targetChain: arbitrum,
   calls: [
     // …
@@ -113,7 +113,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
 
 ```ts {9-14}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   targetChain: arbitrum,
   calls: [
     // …
@@ -168,23 +168,23 @@ const splits = await rhinestone.splitIntents({
 Then, send each split as a separate transaction:
 
 ```ts
-const transactions = await Promise.all(
-  splits.map(async (split) => {
-    const prepared = await rhinestoneAccount.prepareTransaction({
-      sourceChains: [optimism],
-      targetChain: base,
-      tokenRequests: Object.entries(split.tokens).map(([address, amount]) => ({
-        address,
-        amount,
-      })),
-      calls: [
-        // …
-      ],
-    })
-    const signed = await rhinestoneAccount.signTransaction(prepared)
-    return rhinestoneAccount.submitTransaction(signed)
-  }),
-)
+async function sendIntent(split) {
+  const prepared = await rhinestoneAccount.prepareTransaction({
+    sourceChains: [optimism],
+    targetChain: base,
+    tokenRequests: Object.entries(split.tokens).map(([address, amount]) => ({
+      address,
+      amount,
+    })),
+    calls: [
+      // …
+    ],
+  })
+  const signed = await rhinestoneAccount.signTransaction(prepared)
+  return rhinestoneAccount.submitTransaction(signed)
+}
+
+const transactions = await Promise.all(splits.map(sendIntent))
 ```
 
 You can optionally filter which settlement layers to use:

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -18,7 +18,7 @@ We will make a cross-chain token transfer using multi-chain intents.
 ```tsx
 const amount = parseUnits('100', 6) // 100 USDC
 
-const transferTransaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
@@ -38,6 +38,8 @@ const transferTransaction = await rhinestoneAccount.sendTransaction({
     },
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transferTransaction = await rhinestoneAccount.submitTransaction(signed)
 ```
 
 ## Source Chain
@@ -55,7 +57,7 @@ If you already have an account deployed on one or more source chains, you can om
 You can override the default gas limit for the target chain execution with `gasLimit`. Doing this will make the intent better priced, because we can more accurately calculate the fee that a solver needs to be reimbursed with for paying the gas. If this is not provided, we calculate using a gas limit of `1_000_000`.
 
 ```ts {10}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
@@ -73,7 +75,7 @@ const transaction = await rhinestoneAccount.sendTransaction({
 You can specify what token (or tokens) to use as an input asset:
 
 ```ts {10}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
@@ -89,7 +91,7 @@ const transaction = await rhinestoneAccount.sendTransaction({
 You can also specify source assets on a per-chain basis:
 
 ```ts {9-12}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   targetChain: arbitrum,
   calls: [
     // …
@@ -111,7 +113,7 @@ const transaction = await rhinestoneAccount.sendTransaction({
 In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
 
 ```ts {9-14}
-const transaction = await rhinestoneAccount.prepareTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   targetChain: arbitrum,
   calls: [
     // …
@@ -132,20 +134,11 @@ This lets you get a quote before getting the funds ready on the account.
 
 ## Wait for Execution
 
-`sendTransaction` returns a pending intent. To wait until it gets executed, use `waitForExecution`:
+`submitTransaction` returns once the intent has been accepted by the orchestrator. To wait until it actually settles onchain, use `waitForExecution`:
 
 ```ts
-const transaction = await rhinestoneAccount.sendTransaction({
-  // …
-})
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 const transactionResult = await rhinestoneAccount.waitForExecution(transaction)
-```
-
-By default, intents are pre-confirmed by a relayer to be executed before they actually land onchain. You can opt out of this by waiting for onchain execution:
-
-```ts
-const acceptPreconfirmations = false;
-const transactionResult = await rhinestoneAccount.waitForExecution(transaction, acceptPreconfirmations)
 ```
 
 ## Get Intent Status
@@ -153,9 +146,7 @@ const transactionResult = await rhinestoneAccount.waitForExecution(transaction, 
 You can also fetch the intent status directly to implement a custom polling logic:
 
 ```ts
-const transaction = await rhinestoneAccount.sendTransaction({
-  // …
-})
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 const transactionResult = await rhinestone.getIntentStatus(transaction.id)
 ```
 
@@ -178,8 +169,8 @@ Then, send each split as a separate transaction:
 
 ```ts
 const transactions = await Promise.all(
-  splits.map((split) =>
-    rhinestoneAccount.sendTransaction({
+  splits.map(async (split) => {
+    const prepared = await rhinestoneAccount.prepareTransaction({
       sourceChains: [optimism],
       targetChain: base,
       tokenRequests: Object.entries(split.tokens).map(([address, amount]) => ({
@@ -189,8 +180,10 @@ const transactions = await Promise.all(
       calls: [
         // …
       ],
-    }),
-  ),
+    })
+    const signed = await rhinestoneAccount.signTransaction(prepared)
+    return rhinestoneAccount.submitTransaction(signed)
+  }),
 )
 ```
 

--- a/smart-wallet/chain-abstraction/single-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/single-chain-intent.mdx
@@ -14,7 +14,7 @@ Relayers execute single-chain intents through the intent executor module. For a 
 Here's how you can make a token transfer:
 
 ```ts
-const singleChainTx = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     {
@@ -27,6 +27,8 @@ const singleChainTx = await rhinestoneAccount.sendTransaction({
     },
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 ```
 
 ## Gas Limit
@@ -34,7 +36,7 @@ const singleChainTx = await rhinestoneAccount.sendTransaction({
 You can override the default gas limit for the target chain execution with `gasLimit`. Doing this will make the intent better priced, because we can more accurately calculate the fee that a solver needs to be reimbursed with for paying the gas. If this is not provided, we calculate using a gas limit of `1_000_000`.
 
 ```ts {9}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     // …
@@ -51,7 +53,7 @@ const transaction = await rhinestoneAccount.sendTransaction({
 You can specify what token (or tokens) to use as an input asset:
 
 ```ts {9}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     // …
@@ -68,7 +70,7 @@ const transaction = await rhinestoneAccount.sendTransaction({
 In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
 
 ```ts {9-14}
-const transaction = await rhinestoneAccount.prepareTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     // …
@@ -89,20 +91,11 @@ This lets you get a quote before getting the funds ready on the account.
 
 ## Wait for Execution
 
-`sendTransaction` returns a pending intent. To wait until it gets executed, use `waitForExecution`:
+`submitTransaction` returns once the intent has been accepted by the orchestrator. To wait until it actually settles onchain, use `waitForExecution`:
 
 ```ts
-const transaction = await rhinestoneAccount.sendTransaction({
-  // …
-})
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 const transactionResult = await rhinestoneAccount.waitForExecution(transaction)
-```
-
-By default, intents are pre-confirmed by a relayer to be executed before they actually land onchain. You can opt out of this by waiting for onchain execution:
-
-```ts
-const acceptPreconfirmations = false;
-const transactionResult = await rhinestoneAccount.waitForExecution(transaction, acceptPreconfirmations)
 ```
 
 ## Get Intent Status
@@ -110,8 +103,6 @@ const transactionResult = await rhinestoneAccount.waitForExecution(transaction, 
 You can also fetch the intent status directly to implement a custom polling logic:
 
 ```ts
-const transaction = await rhinestoneAccount.sendTransaction({
-  // …
-})
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 const transactionResult = await rhinestone.getIntentStatus(transaction.id)
 ```

--- a/smart-wallet/chain-abstraction/single-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/single-chain-intent.mdx
@@ -36,7 +36,7 @@ const transaction = await rhinestoneAccount.submitTransaction(signed)
 You can override the default gas limit for the target chain execution with `gasLimit`. Doing this will make the intent better priced, because we can more accurately calculate the fee that a solver needs to be reimbursed with for paying the gas. If this is not provided, we calculate using a gas limit of `1_000_000`.
 
 ```ts {9}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     // …
@@ -53,7 +53,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 You can specify what token (or tokens) to use as an input asset:
 
 ```ts {9}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     // …
@@ -70,7 +70,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
 
 ```ts {9-14}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     // …

--- a/smart-wallet/chain-abstraction/source-token-amount.mdx
+++ b/smart-wallet/chain-abstraction/source-token-amount.mdx
@@ -9,7 +9,7 @@ This can be helpful if you want to limit the amount of tokens to bridge, or if y
 To bridge a specific amount of tokens:
 
 ```ts  {4-10}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism],
   targetChain: base,
   sourceAssets: [
@@ -50,7 +50,7 @@ const usdcBalance = await publicClient.readContract({
   args: [address],
 })
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [sourceChain],
   targetChain,
   sourceAssets: [
@@ -75,7 +75,7 @@ This will sweep the user's USDC balance on Optimism to Base.
 You can specify exact source amounts from multiple source chains:
 
 ```ts {4-15}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism, base],
   targetChain: arbitrum,
   sourceAssets: [

--- a/smart-wallet/chain-abstraction/source-token-amount.mdx
+++ b/smart-wallet/chain-abstraction/source-token-amount.mdx
@@ -9,7 +9,7 @@ This can be helpful if you want to limit the amount of tokens to bridge, or if y
 To bridge a specific amount of tokens:
 
 ```ts  {4-10}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism],
   targetChain: base,
   sourceAssets: [
@@ -34,24 +34,23 @@ This will bridge 10 USDC from Optimism to Base.
 
 To bridge the entire balance of a token:
 
-```ts {10-15,24}
-import { getTokenAddress } from '@rhinestone/sdk'
-
+```ts {8-13,22}
 const sourceChain = optimism
 const targetChain = base
+const usdcOnOptimism = '0x0b2c639c533813F4AA9D7837CAF62653d097Ff85'
 
 const publicClient = createPublicClient({
   chain: sourceChain,
   transport: http(),
 })
 const usdcBalance = await publicClient.readContract({
-  address: getTokenAddress('USDC', sourceChain.id),
+  address: usdcOnOptimism,
   abi: erc20Abi,
   functionName: 'balanceOf',
   args: [address],
 })
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [sourceChain],
   targetChain,
   sourceAssets: [
@@ -76,7 +75,7 @@ This will sweep the user's USDC balance on Optimism to Base.
 You can specify exact source amounts from multiple source chains:
 
 ```ts {4-15}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism, base],
   targetChain: arbitrum,
   sourceAssets: [

--- a/smart-wallet/chain-abstraction/swaps.mdx
+++ b/smart-wallet/chain-abstraction/swaps.mdx
@@ -98,7 +98,7 @@ const swapTx = await call1inchAPI<TxResponse>('/swap', {
 **3. Submit as a crosschain transaction:**
 
 ```ts
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [arbitrum],
   targetChain: base,
   calls: [

--- a/smart-wallet/chain-abstraction/swaps.mdx
+++ b/smart-wallet/chain-abstraction/swaps.mdx
@@ -17,14 +17,12 @@ Rhinestone supports two swap modes:
 Specify the token you want on the destination chain. If it differs from what the user holds, Warp handles the bridge and swap automatically.
 
 ```ts
-import { getTokenAddress } from '@rhinestone/sdk'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
-const ethTarget = getTokenAddress('ETH', arbitrumSepolia.id)
 const ethAmount = 2n
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [baseSepolia],
   targetChain: arbitrumSepolia,
   calls: [
@@ -35,11 +33,13 @@ const transaction = await rhinestoneAccount.sendTransaction({
   ],
   tokenRequests: [
     {
-      address: ethTarget,
+      address: 'ETH',
       amount: ethAmount,
     },
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 ```
 
 If the user has USDC on Base Sepolia, Warp will swap it to ETH, bridge to Arbitrum Sepolia, and execute the transfer.
@@ -98,7 +98,7 @@ const swapTx = await call1inchAPI<TxResponse>('/swap', {
 **3. Submit as a crosschain transaction:**
 
 ```ts
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [arbitrum],
   targetChain: base,
   calls: [

--- a/smart-wallet/chain-abstraction/swaps.mdx
+++ b/smart-wallet/chain-abstraction/swaps.mdx
@@ -121,34 +121,44 @@ This bridges from Arbitrum to get 0.1 WETH on Base, then executes the 1inch swap
 
 When you request a token on the destination chain that differs from the user's source token, Warp routes through the solver market to bridge and swap in a single operation. No additional parameters are required — the quote response tells you what will be spent and what will be received.
 
-In a swap, the `tokensSpent` and `tokensReceived` will show different tokens:
+In a swap, `cost.input` and `cost.output` show different tokens:
 
 ```json
 {
-  "intentCost": {
-    "tokensReceived": [
+  "cost": {
+    "input": [
       {
-        "tokenAddress": "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
-        "hasFulfilled": true,
-        "amountSpent": "81032981",
-        "destinationAmount": "81029468",
-        "fee": "3513"
+        "chainId": "eip155:8453",
+        "tokenAddress": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "decimals": 18,
+        "price": { "usd": 2412.37 },
+        "amount": "959454558006521"
       }
     ],
-    "tokensSpent": {
-      "8453": {
-        "0x4200000000000000000000000000000000000006": {
-          "locked": "0",
-          "unlocked": "22291303013436002",
-          "version": 0
-        }
+    "output": [
+      {
+        "chainId": "eip155:10",
+        "tokenAddress": "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+        "symbol": "USDC",
+        "decimals": 6,
+        "price": { "usd": 0.99 },
+        "amount": "2000000"
+      }
+    ],
+    "fees": {
+      "total": { "usd": 0.31 },
+      "breakdown": {
+        "gas": { "usd": 0.30, "sponsored": false },
+        "swap": { "usd": 0.01, "sponsored": false },
+        "bridge": { "usd": 0.0004, "sponsored": false }
       }
     }
   }
 }
 ```
 
-Here the user is spending WETH on Base (chain 8453) to receive USDC on Optimism. The fee is deducted from the received amount (`amountSpent` minus `destinationAmount`).
+Here the user spends WETH on Base (`eip155:8453`) to receive USDC on Optimism. `output.amount` matches the requested amount exactly — fees are paid in input tokens and surfaced via `cost.fees.breakdown`.
 
 For the full quote and submission flow, see the [API Quickstart](../../intents/quickstart).
 

--- a/smart-wallet/core/create-account.mdx
+++ b/smart-wallet/core/create-account.mdx
@@ -10,7 +10,8 @@ A Rhinestone smart account is a smart contract wallet. It doesn't hold keys. Ins
 Pass the owner signer when calling `createAccount`. Here's an example using an external wallet (MetaMask) via Viem:
 
 ```ts
-import { RhinestoneSDK, walletClientToAccount } from '@rhinestone/sdk'
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { walletClientToAccount } from '@rhinestone/sdk/utils'
 import { createWalletClient, custom } from 'viem'
 import { sepolia } from 'viem/chains'
 

--- a/smart-wallet/core/create-first-transaction.mdx
+++ b/smart-wallet/core/create-first-transaction.mdx
@@ -3,9 +3,11 @@ title: "Send a transaction"
 description: "Send single-chain and cross-chain transactions from a Rhinestone smart account."
 ---
 
+Sending a transaction is a three-step flow: `prepareTransaction` fetches a quote, `signTransaction` signs it, `submitTransaction` sends it to the orchestrator. Splitting the steps lets you show the user a quote before they approve, fetch on a backend and sign on a mobile frontend, or pick a non-default route.
+
 ## Send a single-chain transaction
 
-Call `sendTransaction` with a `chain` and a list of `calls`. The example below transfers USDC on Base Sepolia:
+Pass a `chain` and a list of `calls`. The example below transfers USDC on Base Sepolia:
 
 ```ts
 import { encodeFunctionData, erc20Abi } from 'viem'
@@ -14,7 +16,7 @@ import { baseSepolia } from 'viem/chains'
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 const usdcAmount = 1n
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: baseSepolia,
   calls: [
     {
@@ -28,6 +30,8 @@ const transaction = await rhinestoneAccount.sendTransaction({
     },
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 
 const result = await rhinestoneAccount.waitForExecution(transaction)
 console.log('Result', result)
@@ -40,7 +44,7 @@ Swap `chain` for `sourceChains` + `targetChain`. The SDK handles bridging and ro
 ```ts
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [baseSepolia],
   targetChain: arbitrumSepolia,
   calls: [
@@ -61,31 +65,13 @@ const transaction = await rhinestoneAccount.sendTransaction({
     },
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 
 const result = await rhinestoneAccount.waitForExecution(transaction)
 ```
 
-## Use the granular API
-
-Use `prepareTransaction` → `signTransaction` → `submitTransaction` when you need to separate fetching from signing. For example, to show the user transaction details before they approve, or to fetch intent data on a backend and sign on a mobile frontend:
-
-```ts
-// Fetch intent data (can be done server-side)
-const transactionData = await rhinestoneAccount.prepareTransaction({
-  chain: baseSepolia,
-  calls: [...],
-})
-
-// Sign: prompts account owners
-const signedData = await rhinestoneAccount.signTransaction(transactionData)
-
-// Submit
-const transaction = await rhinestoneAccount.submitTransaction(signedData)
-```
-
-<Note>To deploy the account on a specific chain before transacting, call `await rhinestoneAccount.deploy(chain)` first.</Note>
-
-<Note>Any `sendTransaction` call triggers deployment if the account is not yet deployed on that chain. It does not have to be a token transfer. Contract calls, approvals, or any other action will deploy the account as part of the intent.</Note>
+<Note>To deploy the account on a specific chain before transacting, call `await rhinestoneAccount.deploy(chain)` first. Otherwise, any transaction triggers deployment as part of the intent — token transfers, contract calls, approvals, anything.</Note>
 
 ## Next steps
 

--- a/smart-wallet/core/ecdsa-signer.mdx
+++ b/smart-wallet/core/ecdsa-signer.mdx
@@ -52,7 +52,7 @@ By default, `threshold` is `1`, meaning any single owner can sign.
 For m-of-n setups, specify which signers to use when sending a transaction:
 
 ```ts
-const result = await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [
     // …
@@ -72,7 +72,7 @@ const result = await account.sendTransaction({
 ```ts
 import { addOwner } from '@rhinestone/sdk/actions/ecdsa'
 
-await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [addOwner(newSigner.address)],
 })
@@ -83,7 +83,7 @@ await account.sendTransaction({
 ```ts
 import { removeOwner } from '@rhinestone/sdk/actions/ecdsa'
 
-await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [removeOwner(signerC.address)],
 })
@@ -94,7 +94,7 @@ await account.sendTransaction({
 ```ts
 import { changeThreshold } from '@rhinestone/sdk/actions/ecdsa'
 
-await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [changeThreshold(2)],
 })
@@ -114,7 +114,7 @@ If you need to enable the ECDSA module on an existing account rather than at cre
 ```ts
 import { enable as enableEcdsa } from '@rhinestone/sdk/actions/ecdsa'
 
-await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [enableEcdsa([signer.address])],
   tokenRequests: [],

--- a/smart-wallet/core/ecdsa-signer.mdx
+++ b/smart-wallet/core/ecdsa-signer.mdx
@@ -52,7 +52,7 @@ By default, `threshold` is `1`, meaning any single owner can sign.
 For m-of-n setups, specify which signers to use when sending a transaction:
 
 ```ts
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [
     // …
@@ -72,7 +72,7 @@ const prepared = await account.prepareTransaction({
 ```ts
 import { addOwner } from '@rhinestone/sdk/actions/ecdsa'
 
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [addOwner(newSigner.address)],
 })
@@ -83,7 +83,7 @@ const prepared = await account.prepareTransaction({
 ```ts
 import { removeOwner } from '@rhinestone/sdk/actions/ecdsa'
 
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [removeOwner(signerC.address)],
 })
@@ -94,7 +94,7 @@ const prepared = await account.prepareTransaction({
 ```ts
 import { changeThreshold } from '@rhinestone/sdk/actions/ecdsa'
 
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [changeThreshold(2)],
 })
@@ -114,7 +114,7 @@ If you need to enable the ECDSA module on an existing account rather than at cre
 ```ts
 import { enable as enableEcdsa } from '@rhinestone/sdk/actions/ecdsa'
 
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [enableEcdsa([signer.address])],
   tokenRequests: [],

--- a/smart-wallet/core/eip-7702.mdx
+++ b/smart-wallet/core/eip-7702.mdx
@@ -104,7 +104,7 @@ Sending a transaction with an EIP-7702 account requires two additional signing s
   </Step>
   <Step title="Submit and wait">
     ```ts
-    const result = await account.submitTransaction(signedTx, authorizations)
+    const result = await account.submitTransaction(signedTx, { authorizations })
     const status = await account.waitForExecution(result)
     ```
   </Step>

--- a/smart-wallet/core/eoa.mdx
+++ b/smart-wallet/core/eoa.mdx
@@ -5,7 +5,7 @@ description: "Use a plain EOA with the Rhinestone SDK to send intents without de
 
 If your users already have an EOA, you can connect it directly to the Rhinestone SDK and start sending intents straight away. No deployment, no migration, no smart account setup required.
 
-The SDK handles the orchestration layer for you — you write the same `sendTransaction` call as any other account type, and the Rhinestone Orchestrator takes care of routing, bridging, and settlement. The result is significantly better DX than calling the raw API yourself.
+The SDK handles the orchestration layer for you — the transaction API is identical to any other account type, and the Rhinestone Orchestrator takes care of routing, bridging, and settlement. The result is significantly better DX than calling the raw API yourself.
 
 This is the right choice when:
 - Your users have existing EOAs with assets they want to keep at their current address
@@ -45,7 +45,7 @@ Once the account is created, the transaction API is identical to any other accou
 ```ts
 const recipientAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
-const result = await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   sourceChains: [arbitrum],
   targetChain: base,
   calls: [
@@ -65,6 +65,8 @@ const result = await account.sendTransaction({
     },
   ],
 })
+const signed = await account.signTransaction(prepared)
+const result = await account.submitTransaction(signed)
 
 const status = await account.waitForExecution(result)
 ```

--- a/smart-wallet/core/multisig.mdx
+++ b/smart-wallet/core/multisig.mdx
@@ -88,7 +88,7 @@ By default, the `threshold` is 1 (any multisig owner can sign any transaction).
 For 1-of-n and m-of-n multisigs, you usually want to sign the transaction with a subset of owners instead of using all of them. You can choose which signers to use with `signers`:
 
 ```ts {6-10}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
     // …
@@ -116,7 +116,7 @@ To add a new signer to your multisig:
 import { addOwner } from '@rhinestone/sdk/actions/ecdsa'
 
 // Add a new owner
-const addOwnerTransaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [addOwner(accountD.address)],
 })
@@ -133,7 +133,7 @@ const pubKeyY = BigInt(slice(passkeyAccountC.publicKey, 32))
 const requiresUV = false;
 
 // Add a new owner
-const addOwnerTransaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [addOwner(pubKeyX, pubKeyY, requiresUV)],
 })
@@ -153,7 +153,7 @@ To remove an existing signer from your multisig:
 import { removeOwner } from '@rhinestone/sdk/actions/ecdsa'
 
 // Remove an owner
-const removeOwnerTransaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [removeOwner(accountC.address)],
 })
@@ -166,7 +166,7 @@ const removeOwnerTransaction = await rhinestoneAccount.sendTransaction({
 import { removeOwner } from '@rhinestone/sdk/actions/passkeys'
 
 // Remove an owner
-const removeOwnerTransaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [removeOwner(pubKeyX, pubKeyY)],
 })
@@ -186,7 +186,7 @@ To update the signature threshold for your multisig:
 import { changeThreshold } from '@rhinestone/sdk/actions/ecdsa'
 
 // Change threshold to 2-of-N
-const changeThresholdTransaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [changeThreshold(2)],
 })
@@ -199,7 +199,7 @@ const changeThresholdTransaction = await rhinestoneAccount.sendTransaction({
 import { changeThreshold } from '@rhinestone/sdk/actions/passkeys'
 
 // Change threshold to 2-of-N
-const changeThresholdTransaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [changeThreshold(2)],
 })

--- a/smart-wallet/core/multisig.mdx
+++ b/smart-wallet/core/multisig.mdx
@@ -88,7 +88,7 @@ By default, the `threshold` is 1 (any multisig owner can sign any transaction).
 For 1-of-n and m-of-n multisigs, you usually want to sign the transaction with a subset of owners instead of using all of them. You can choose which signers to use with `signers`:
 
 ```ts {6-10}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
     // …
@@ -116,7 +116,7 @@ To add a new signer to your multisig:
 import { addOwner } from '@rhinestone/sdk/actions/ecdsa'
 
 // Add a new owner
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [addOwner(accountD.address)],
 })
@@ -133,7 +133,7 @@ const pubKeyY = BigInt(slice(passkeyAccountC.publicKey, 32))
 const requiresUV = false;
 
 // Add a new owner
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [addOwner(pubKeyX, pubKeyY, requiresUV)],
 })
@@ -153,7 +153,7 @@ To remove an existing signer from your multisig:
 import { removeOwner } from '@rhinestone/sdk/actions/ecdsa'
 
 // Remove an owner
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [removeOwner(accountC.address)],
 })
@@ -166,7 +166,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 import { removeOwner } from '@rhinestone/sdk/actions/passkeys'
 
 // Remove an owner
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [removeOwner(pubKeyX, pubKeyY)],
 })
@@ -186,7 +186,7 @@ To update the signature threshold for your multisig:
 import { changeThreshold } from '@rhinestone/sdk/actions/ecdsa'
 
 // Change threshold to 2-of-N
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [changeThreshold(2)],
 })
@@ -199,7 +199,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 import { changeThreshold } from '@rhinestone/sdk/actions/passkeys'
 
 // Change threshold to 2-of-N
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [changeThreshold(2)],
 })

--- a/smart-wallet/core/passkeys.mdx
+++ b/smart-wallet/core/passkeys.mdx
@@ -52,7 +52,7 @@ By default, `threshold` is `1`, meaning any single passkey can sign.
 For m-of-n setups, specify which passkeys to use when sending a transaction:
 
 ```ts
-const result = await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [
     // …
@@ -77,7 +77,7 @@ const pubKeyX = BigInt(slice(newPasskeyAccount.publicKey, 0, 32))
 const pubKeyY = BigInt(slice(newPasskeyAccount.publicKey, 32))
 const requiresUV = false
 
-await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [addOwner(pubKeyX, pubKeyY, requiresUV)],
 })
@@ -88,7 +88,7 @@ await account.sendTransaction({
 ```ts
 import { removeOwner } from '@rhinestone/sdk/actions/passkeys'
 
-await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [removeOwner(pubKeyX, pubKeyY)],
 })
@@ -99,7 +99,7 @@ await account.sendTransaction({
 ```ts
 import { changeThreshold } from '@rhinestone/sdk/actions/passkeys'
 
-await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [changeThreshold(2)],
 })
@@ -119,7 +119,7 @@ If you need to enable the passkey module on an existing account rather than at c
 ```ts
 import { enable as enablePasskeys } from '@rhinestone/sdk/actions/passkeys'
 
-await account.sendTransaction({
+const prepared = await account.prepareTransaction({
   chain,
   calls: [enablePasskeys(passkeyAccount.publicKey, passkeyAccount.id)],
   tokenRequests: [],

--- a/smart-wallet/core/passkeys.mdx
+++ b/smart-wallet/core/passkeys.mdx
@@ -52,7 +52,7 @@ By default, `threshold` is `1`, meaning any single passkey can sign.
 For m-of-n setups, specify which passkeys to use when sending a transaction:
 
 ```ts
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [
     // …
@@ -77,7 +77,7 @@ const pubKeyX = BigInt(slice(newPasskeyAccount.publicKey, 0, 32))
 const pubKeyY = BigInt(slice(newPasskeyAccount.publicKey, 32))
 const requiresUV = false
 
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [addOwner(pubKeyX, pubKeyY, requiresUV)],
 })
@@ -88,7 +88,7 @@ const prepared = await account.prepareTransaction({
 ```ts
 import { removeOwner } from '@rhinestone/sdk/actions/passkeys'
 
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [removeOwner(pubKeyX, pubKeyY)],
 })
@@ -99,7 +99,7 @@ const prepared = await account.prepareTransaction({
 ```ts
 import { changeThreshold } from '@rhinestone/sdk/actions/passkeys'
 
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [changeThreshold(2)],
 })
@@ -119,7 +119,7 @@ If you need to enable the passkey module on an existing account rather than at c
 ```ts
 import { enable as enablePasskeys } from '@rhinestone/sdk/actions/passkeys'
 
-const prepared = await account.prepareTransaction({
+const transaction = await account.prepareTransaction({
   chain,
   calls: [enablePasskeys(passkeyAccount.publicKey, passkeyAccount.id)],
   tokenRequests: [],

--- a/smart-wallet/core/signers/dynamic.mdx
+++ b/smart-wallet/core/signers/dynamic.mdx
@@ -93,7 +93,8 @@ Create a production-ready hook that integrates Dynamic wallets with Rhinestone a
 ```tsx
 import { useState, useEffect } from 'react'
 import { useAccount, useWalletClient } from "wagmi"
-import { RhinestoneSDK, walletClientToAccount } from "@rhinestone/sdk"
+import { RhinestoneSDK } from "@rhinestone/sdk"
+import { walletClientToAccount } from "@rhinestone/sdk/utils"
 
 interface GlobalWalletState {
   rhinestoneAccount: any | null
@@ -287,7 +288,7 @@ function CrossChainTransfer({ rhinestoneAccount }) {
     setTxResult(null)
 
     try {
-      const transaction = await rhinestoneAccount.sendTransaction({
+      const prepared = await rhinestoneAccount.prepareTransaction({
         sourceChains: [baseSepolia],
         targetChain: arbitrumSepolia,
         calls: [
@@ -307,6 +308,8 @@ function CrossChainTransfer({ rhinestoneAccount }) {
           },
         ],
       })
+      const signed = await rhinestoneAccount.signTransaction(prepared)
+      const transaction = await rhinestoneAccount.submitTransaction(signed)
 
       // Wait for transaction execution
       const result = await rhinestoneAccount.waitForExecution(transaction)

--- a/smart-wallet/core/signers/external-wallet-signer.mdx
+++ b/smart-wallet/core/signers/external-wallet-signer.mdx
@@ -47,7 +47,8 @@ npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
 import { createAppKit } from '@reown/appkit'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { mainnet, arbitrum, base } from '@reown/appkit/networks'
-import { RhinestoneSDK, walletClientToAccount } from '@rhinestone/sdk'
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { walletClientToAccount } from '@rhinestone/sdk/utils'
 import { useAccount, useWalletClient } from 'wagmi'
 
 // 1. Get projectId from https://dashboard.reown.com
@@ -120,7 +121,7 @@ export function WalletConnector() {
 
 ```tsx
 async function sendCrossChainTransaction(rhinestoneAccount) {
-  const transaction = await rhinestoneAccount.sendTransaction({
+  const prepared = await rhinestoneAccount.prepareTransaction({
     sourceChains: [arbitrumSepolia],
     targetChain: baseSepolia,
     calls: [
@@ -140,7 +141,9 @@ async function sendCrossChainTransaction(rhinestoneAccount) {
       },
     ],
   })
-  
+  const signed = await rhinestoneAccount.signTransaction(prepared)
+  const transaction = await rhinestoneAccount.submitTransaction(signed)
+
   console.log('Transaction submitted:', transaction.id)
 }
 ```

--- a/smart-wallet/core/signers/magic.mdx
+++ b/smart-wallet/core/signers/magic.mdx
@@ -78,7 +78,8 @@ Magic also supports SMS, social login, WebAuthn, and more. See [Magic's authenti
 Create a viem account from Magic's provider and pass it to Rhinestone:
 
 ```tsx
-import { RhinestoneSDK, walletClientToAccount } from "@rhinestone/sdk"
+import { RhinestoneSDK } from "@rhinestone/sdk"
+import { walletClientToAccount } from "@rhinestone/sdk/utils"
 import { createWalletClient, custom } from "viem"
 import { toAccount } from "viem/accounts"
 import type { SignableMessage, TypedDataDefinition } from "viem"
@@ -349,7 +350,7 @@ import { encodeFunctionData, parseUnits, erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
 async function handleCrossChainTransfer(rhinestoneAccount) {
-  const transaction = await rhinestoneAccount.sendTransaction({
+  const prepared = await rhinestoneAccount.prepareTransaction({
     sourceChains: [baseSepolia],
     targetChain: arbitrumSepolia,
     calls: [
@@ -369,6 +370,8 @@ async function handleCrossChainTransfer(rhinestoneAccount) {
       },
     ],
   })
+  const signed = await rhinestoneAccount.signTransaction(prepared)
+  const transaction = await rhinestoneAccount.submitTransaction(signed)
 }
 ```
 

--- a/smart-wallet/core/signers/openfort.mdx
+++ b/smart-wallet/core/signers/openfort.mdx
@@ -98,7 +98,8 @@ import { useState, useEffect, useCallback } from 'react'
 import { useUser, useWallets, useOpenfort } from '@openfort/react'
 import { createWalletClient, custom } from 'viem'
 import { sepolia } from 'viem/chains'
-import { RhinestoneSDK, walletClientToAccount } from '@rhinestone/sdk'
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { walletClientToAccount } from '@rhinestone/sdk/utils'
 
 interface OpenfortWalletState {
   rhinestoneAccount: any | null
@@ -300,7 +301,7 @@ function CrossChainTransfer({ rhinestoneAccount }) {
     setTxResult(null)
 
     try {
-      const transaction = await rhinestoneAccount.sendTransaction({
+      const prepared = await rhinestoneAccount.prepareTransaction({
         sourceChains: [baseSepolia],
         targetChain: arbitrumSepolia,
         calls: [
@@ -320,6 +321,8 @@ function CrossChainTransfer({ rhinestoneAccount }) {
           },
         ],
       })
+      const signed = await rhinestoneAccount.signTransaction(prepared)
+      const transaction = await rhinestoneAccount.submitTransaction(signed)
 
       // Wait for transaction execution
       const result = await rhinestoneAccount.waitForExecution(transaction)

--- a/smart-wallet/core/signers/para.mdx
+++ b/smart-wallet/core/signers/para.mdx
@@ -126,7 +126,8 @@ The key is to wrap the Para viem account with `wrapParaAccount` before passing i
 import { useEffect } from "react"
 import { useWallet } from "@getpara/react-sdk"
 import { useViemAccount } from "@getpara/react-sdk/evm/hooks"
-import { RhinestoneSDK, wrapParaAccount } from "@rhinestone/sdk"
+import { RhinestoneSDK } from "@rhinestone/sdk"
+import { wrapParaAccount } from "@rhinestone/sdk/utils"
 import type { Account } from "viem"
 
 export function useRhinestoneAccount() {
@@ -176,7 +177,7 @@ Once initialized, use the Rhinestone account for cross-chain transactions:
 import { encodeFunctionData, parseUnits, erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [baseSepolia],
   targetChain: arbitrumSepolia,
   calls: [{
@@ -193,6 +194,8 @@ const transaction = await rhinestoneAccount.sendTransaction({
   }],
   sponsored: true,
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 
 const result = await rhinestoneAccount.waitForExecution(transaction)
 ```

--- a/smart-wallet/core/signers/privy.mdx
+++ b/smart-wallet/core/signers/privy.mdx
@@ -102,7 +102,8 @@ Create a custom hook that integrates Privy authentication with Rhinestone accoun
 import { useState, useEffect } from 'react'
 import { usePrivy, useWallets } from "@privy-io/react-auth"
 import { useWalletClient, useAccount } from "wagmi"
-import { RhinestoneSDK, walletClientToAccount } from "@rhinestone/sdk"
+import { RhinestoneSDK } from "@rhinestone/sdk"
+import { walletClientToAccount } from "@rhinestone/sdk/utils"
 
 interface PrivyWalletState {
   rhinestoneAccount: any | null
@@ -228,7 +229,7 @@ import { erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
 async function handleCrossChainTransfer(rhinestoneAccount) {
-  const transaction = await rhinestoneAccount.sendTransaction({
+  const prepared = await rhinestoneAccount.prepareTransaction({
     sourceChains: [baseSepolia],
     targetChain: arbitrumSepolia,
     calls: [
@@ -248,6 +249,8 @@ async function handleCrossChainTransfer(rhinestoneAccount) {
       },
     ],
   })
+  const signed = await rhinestoneAccount.signTransaction(prepared)
+  const transaction = await rhinestoneAccount.submitTransaction(signed)
 }
 ```
 

--- a/smart-wallet/core/signers/turnkey.mdx
+++ b/smart-wallet/core/signers/turnkey.mdx
@@ -105,7 +105,7 @@ The Rhinestone account will automatically use the Turnkey signer for all transac
 import { encodeFunctionData, parseUnits, erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [baseSepolia],
   targetChain: arbitrumSepolia,
   calls: [
@@ -125,6 +125,8 @@ const transaction = await rhinestoneAccount.sendTransaction({
     },
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 ```
 
 <Note>Don't forget to fund the account before making any transactions.</Note>

--- a/smart-wallet/gas-sponsorship/pay-gas-with-erc20.mdx
+++ b/smart-wallet/gas-sponsorship/pay-gas-with-erc20.mdx
@@ -6,7 +6,7 @@ description: "Let your users pas for gas with ERC-20 tokens"
 You can choose what asset to use as a fee token (i.e., to cover gas and bridging fees):
 
 ```ts {10}
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [

--- a/smart-wallet/gas-sponsorship/pay-gas-with-erc20.mdx
+++ b/smart-wallet/gas-sponsorship/pay-gas-with-erc20.mdx
@@ -6,7 +6,7 @@ description: "Let your users pas for gas with ERC-20 tokens"
 You can choose what asset to use as a fee token (i.e., to cover gas and bridging fees):
 
 ```ts {10}
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [

--- a/smart-wallet/quickstart.mdx
+++ b/smart-wallet/quickstart.mdx
@@ -15,15 +15,15 @@ Install the Rhinestone SDK:
 <CodeGroup>
 
 ```bash npm
-npm install viem @rhinestone/sdk
+npm install viem @rhinestone/sdk@beta
 ```
 
 ```bash pnpm
-pnpm add viem @rhinestone/sdk
+pnpm add viem @rhinestone/sdk@beta
 ```
 
 ```bash bun
-bun install viem @rhinestone/sdk
+bun install viem @rhinestone/sdk@beta
 ```
 
 </CodeGroup>
@@ -108,7 +108,7 @@ Finally, let's make a cross-chain token transfer:
 ```ts
 const usdcAmount = 1n
 
-const transaction = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [sourceChain],
   targetChain,
   calls: [
@@ -129,6 +129,8 @@ const transaction = await rhinestoneAccount.sendTransaction({
     },
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
 console.log('Transaction', transaction)
 
 const transactionResult = await rhinestoneAccount.waitForExecution(transaction)

--- a/smart-wallet/security.mdx
+++ b/smart-wallet/security.mdx
@@ -141,7 +141,7 @@ Set `RHINESTONE_API_KEY` only on the server (e.g., in `.env` without `NEXT_PUBLI
 Point the SDK to your proxy URL so user traffic never touches the Orchestrator directly:
 
 ```ts
-import { RhinestoneSDK, walletClientToAccount } from "@rhinestone/sdk";
+import { RhinestoneSDK } from "@rhinestone/sdk";
 
 const baseUrl = typeof window !== "undefined" ? window.location.origin : process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 

--- a/smart-wallet/security.mdx
+++ b/smart-wallet/security.mdx
@@ -48,9 +48,7 @@ const getApiKey = () => {
 const validateDestinationOps = (body: any): boolean => {
   if (ALLOW_ALL_CONTRACTS) return true;
 
-  const destinationOps =
-    body?.signedIntentOp?.signedMetadata?.account?.accountContext?.destinationExecutions;
-
+  const destinationOps = body?.destinationExecutions;
   if (!destinationOps) return true; // nothing to validate
 
   for (const op of destinationOps) {
@@ -74,6 +72,7 @@ async function handleRequest(request: NextRequest, params: { path: string[] }) {
     const headers: HeadersInit = {
       "Content-Type": "application/json",
       "x-api-key": apiKey,
+      "x-api-version": "2026-04.blanc",
     };
 
     const fetchOptions: RequestInit = {
@@ -84,8 +83,9 @@ async function handleRequest(request: NextRequest, params: { path: string[] }) {
     if (request.method !== "GET" && request.method !== "HEAD") {
       const body = await request.text();
       if (body) {
-        // Validate intent operations
-        if (path.includes("intent-operations")) {
+        // Validate destinationExecutions on quote requests, before the intent
+        // is stored server-side and bound to an intentId.
+        if (path === "quotes") {
           const parsedBody = JSON.parse(body);
           if (!validateDestinationOps(parsedBody)) {
             return NextResponse.json(

--- a/smart-wallet/smart-sessions/multi-session-signature.mdx
+++ b/smart-wallet/smart-sessions/multi-session-signature.mdx
@@ -21,35 +21,35 @@ While this guide focuses on multi-chain usage, you can also use this pattern on 
 <Steps>
 <Step title="Create the Sessions">
 
-First, define your sessions for different chains. Each session can have different owners, policies, and actions depending on your use case:
+First, define your sessions for different chains. Each session can have different owners, policies, and permissions depending on your use case:
 
 ```ts
 import { baseSepolia, optimismSepolia } from 'viem/chains'
-import { Session } from '@rhinestone/sdk'
+import { toSession } from '@rhinestone/sdk/smart-sessions'
 
-const sessions: Session[] = [
-  {
+const sessions = [
+  toSession({
     chain: baseSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccountA],
     },
-    // Add specific policies and actions as needed
-  },
-  {
+    // Add specific policies and permissions as needed
+  }),
+  toSession({
     chain: baseSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccountB],
     },
-  },
-  {
+  }),
+  toSession({
     chain: optimismSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccountB],
     },
-  },
+  }),
 ]
 ```
 
@@ -118,10 +118,8 @@ await rhinestoneAccount.submitTransaction(signedData)
 Here's a complete working example that demonstrates the full multi-chain session workflow:
 
 ```ts
-import {
-  RhinestoneSDK,
-  type Session
-} from '@rhinestone/sdk'
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { toSession } from '@rhinestone/sdk/smart-sessions'
 import { zeroAddress } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { baseSepolia, optimismSepolia } from 'viem/chains'
@@ -140,21 +138,21 @@ const rhinestoneAccount = await rhinestone.createAccount({
 })
 
 // Define the sessions, one per chain
-const sessions: Session[] = [
-  {
+const sessions = [
+  toSession({
     chain: baseSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccount],
     },
-  },
-  {
+  }),
+  toSession({
     chain: optimismSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccount],
     },
-  },
+  }),
 ]
 
 // Get the session details and sign once

--- a/smart-wallet/smart-sessions/overview.mdx
+++ b/smart-wallet/smart-sessions/overview.mdx
@@ -85,7 +85,7 @@ You can also install it when the account is already deployed:
 ```ts
 import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [experimental_enable()],
 })
@@ -96,7 +96,7 @@ To uninstall the validator:
 ```ts
 import { experimental_disable } from '@rhinestone/sdk/actions/smart-sessions'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [experimental_disable()],
 })
@@ -179,7 +179,7 @@ const enableSignature =
   await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
 const sessionIndex = 0
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
     experimental_enableSession(

--- a/smart-wallet/smart-sessions/overview.mdx
+++ b/smart-wallet/smart-sessions/overview.mdx
@@ -23,7 +23,7 @@ Key example use cases include:
 
 ## How it works
 
-[Smart Sessions](https://github.com/erc7579/smartsessions) is built around three concepts: **owners** (who can sign), **actions** (what they can do), and **policies** (under what conditions).
+[Smart Sessions](https://github.com/erc7579/smartsessions) is built around three concepts: **owners** (who can sign), **permissions** (what they can do), and **policies** (under what conditions).
 
 ## Owners
 
@@ -35,17 +35,17 @@ Smart Sessions support a wide range of signing mechanisms out of the box:
 
 You can also use custom validators to validate sessions, as long as they are [ERC-7780](https://eips.ethereum.org/EIPS/eip-7780) compatible.
 
-## Actions
+## Permissions
 
-Actions define what transactions (calls) you can make within a session. An action is defined by the _target address_ and the _function selector_.
+Permissions define what calls a session is allowed to make. A permission is defined by an _ABI_ and a target _address_, and lists the _functions_ on that contract the session can call. The SDK derives selectors and parameter offsets from the ABI and checks parameter value types against ABI input types.
 
-When defining multiple actions within a session, a transaction that matches **any** specified action is considered valid. If no actions are specified, **any** transaction will pass.
+When defining multiple permissions within a session, a transaction that matches **any** specified permission is considered valid. If no permissions are specified, **any** transaction will pass.
 
-<Info>When using smart contracts directly, you need to explicitly provide a list of valid actions.</Info>
+<Info>When using smart contracts directly, you need to explicitly provide a list of valid permissions.</Info>
 
 ## Policies
 
-Policies let you restrict the session to hit specific conditions. You can define policies at the _session_ (affects the entire session) or _action_ (affects a single action within a session) level.
+Policies let you restrict the session to hit specific conditions. You can define policies at the _session_ (affects the entire session) or _function_ (affects a single function within a permission) level.
 
 Supported policies include:
 
@@ -56,9 +56,9 @@ Supported policies include:
 - [Usage limit](./policies/usage-limit): allows a limited number of transactions
 - Value limit: allows a limited ETH value transferred
 
-When defining multiple policies within an action, a transaction that passes **every** specified policy is considered valid. If no policies are specified, **any** transaction will pass (i.e., the sudo policy is applied).
+When defining multiple policies within a function, a transaction that passes **every** specified policy is considered valid. If no policies are specified, **any** transaction will pass (i.e., the sudo policy is applied).
 
-<Info>Policies work like a logical AND. If an action has two policies, the transaction must pass both policies to be valid.</Info>
+<Info>Policies work like a logical AND. If a function has two policies, the transaction must pass both policies to be valid.</Info>
 
 ## Usage
 
@@ -85,7 +85,7 @@ You can also install it when the account is already deployed:
 ```ts
 import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
 
-const transactionData = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [experimental_enable()],
 })
@@ -96,7 +96,7 @@ To uninstall the validator:
 ```ts
 import { experimental_disable } from '@rhinestone/sdk/actions/smart-sessions'
 
-const transactionData = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [experimental_disable()],
 })
@@ -104,71 +104,65 @@ const transactionData = await rhinestoneAccount.sendTransaction({
 
 ### Creating Sessions
 
-To create an account with a session key:
+To create a session, use `toSession`:
 
 ```ts
-const session: Session = {
+import { toSession } from '@rhinestone/sdk/smart-sessions'
+
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-}
+})
 ```
 
-You can also limit the session to specific allowed actions:
+You can also limit the session to specific allowed permissions:
 
-```ts {6-16}
-const session: Session = {
+```ts {7-13}
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-  actions: [
+  permissions: [
     {
-      target: usdcAddress,
-      selector: toFunctionSelector(
-        getAbiItem({
-          abi: erc20Abi,
-          name: 'transfer',
-        }),
-      ),
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: { transfer: {} },
     },
   ],
-}
+})
 ```
 
-Finally, you can specify action-level policies:
+Finally, you can constrain function parameters. The SDK derives the selector and parameter offsets from the ABI, so you reference parameters by name:
 
-```ts {15-26}
-const session: Session = {
+```ts {12-16}
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-  actions: [
+  permissions: [
     {
-      target: usdcAddress,
-      selector: toFunctionSelector(
-        getAbiItem({
-          abi: erc20Abi,
-          name: 'transfer',
-        }),
-      ),
-      policies: [
-        {
-          type: 'universal-action',
-          rules: [
-            {
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: {
+        transfer: {
+          params: {
+            recipient: {
               condition: 'equal',
-              calldataOffset: 0n,
-              referenceValue: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+              value: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
             },
-          ],
+          },
         },
-      ],
+      },
     },
   ],
-}
+})
 ```
 
 ### Installing sessions
@@ -185,7 +179,7 @@ const enableSignature =
   await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
 const sessionIndex = 0
 
-const transactionResult = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
     experimental_enableSession(
@@ -213,7 +207,7 @@ const isEnabled = await rhinestoneAccount.experimental_isSessionEnabled(session)
 To authorize a transaction with a session key you've enabled before:
 
 ```ts {13-16}
-const transactionResult = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
     {
@@ -230,6 +224,8 @@ const transactionResult = await rhinestoneAccount.sendTransaction({
     session,
   },
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transactionResult = await rhinestoneAccount.submitTransaction(signed)
 ```
 
 This will prompt the signature request from the session owner(s) and submit the transaction on their behalf.
@@ -245,6 +241,6 @@ Smart Sessions is a powerful tool that unlocks a bunch of new opportunities and 
 * Guard your smart session with granular policies (e.g., restrict the amount of ETH that can be transacted through the session)  
 * If possible, timebox your session (e.g., make it valid for only 1 week)
 
-<Warning>By default, the SDK creates a session that allows any transaction. Make sure you restrict it with relevant actions and policies.</Warning>
+<Warning>By default, the SDK creates a session that allows any transaction. Make sure you restrict it with relevant permissions and policies.</Warning>
 
 [Reach out to us](http://t.me/kurt_larsen) if you need any help!

--- a/smart-wallet/smart-sessions/policies/call.mdx
+++ b/smart-wallet/smart-sessions/policies/call.mdx
@@ -3,15 +3,11 @@ title: "Call"
 sidebarTitle: "Call"
 ---
 
-Call policy allows you to filter out transactions based on the call data and ether value.
-
-Within a policy, you can set up to 16 rules. Each rule consists of a condition, the calldata offset, and a reference value to compare.
-
-When checking a transaction, the policy checks it against every rule. For a policy to accept a transaction, *every* rule of that policy should pass.
+The call policy filters transactions by calldata and ETH value. In v2 sessions, you express it as ABI-driven _parameter rules_ on a permission's function — the SDK reads the function selector and parameter offsets from the ABI for you.
 
 ## Conditions
 
-Available conditions are:
+Available conditions:
 
 * equal ($x = A$)
 * greater than ($x > A$)
@@ -21,127 +17,79 @@ Available conditions are:
 * not equal ($x \neq A$)
 * in range ($A \leq x \leq B$)
 
-## Calldata Offset
-
-The number of bytes to offset from the start (excluding the function selector).
-
-The resulting value is a hex string of 32 bytes.
-
-In other words, if the offset is 10, the compared value will be formed from the calldata with the starting index of `4 + 10 = 14` and an end index of `4 + 10 + 32 = 46`.
-
-## Reference Value
-
-Value to compare the calldata against.
-
-The reference value is a hex string of 32 bytes. For convenience, you can pass the hex string of a smaller length or a bigint, and the SDK will convert it for you.
-
 ## Usage
 
-To enable a call policy:
+To restrict an ERC20 transfer to a single recipient:
 
-```ts {8-31}
+```ts {15}
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
-const session: Session = {
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-  actions: [
+  permissions: [
     {
-      // ERC20 transfer action
-      target: usdcAddress,
-      selector: toFunctionSelector(
-        getAbiItem({
-          abi: erc20,
-          name: 'transfer',
-        }),
-      ),
-      policies: [
-        {
-          type: 'universal-action',
-          rules: [
-            {
-              condition: 'equal',
-              calldataOffset: 0n,
-              referenceValue: receiver,
-            },
-          ],
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { condition: 'equal', value: receiver },
+          },
         },
-      ],
+      },
     },
   ],
-}
+})
 ```
 
-Together with an ERC20 transfer action, this policy will only allow USDC transfers to a single receiver address.
+Reference parameters by name — the SDK looks them up in the ABI. Only static types are supported (`address`, `bool`, `uint*`, `int*`, `bytes1`–`bytes32`).
 
-### Param Accumulator
+### Param accumulator
 
-You can limit the total accumulated value of a param across all session uses.
+Cap the total accumulated value of a param across all session uses with `usageLimit`. Useful for capping cumulative spend across calls.
 
-This can be helpful if you want to e.g. limit the total value of tokens passed through the session.
-
-```ts {17}
-const session: Session = {
-  owners: {
-    type: 'ecdsa',
-    accounts: [sessionOwnerAccount],
+```ts {8-12}
+permissions: [
+  {
+    abi: erc20Abi,
+    address: usdcAddress,
+    functions: {
+      transfer: {
+        params: {
+          amount: {
+            condition: 'lessThan',
+            value: parseUnits('10', 6),
+            usageLimit: parseUnits('50', 6),
+          },
+        },
+      },
+    },
   },
-  actions: [
-    {
-      // ERC20 transfer action
-      policies: [
-        {
-          type: 'universal-action',
-          rules: [
-            {
-              condition: 'lessThan',
-              calldataOffset: 20n,
-              referenceValue: parseUnits('10', 6),
-              usageLimit: parseUnits('50', 6),
-            },
-          ],
-        },
-      ],
-    },
-  ],
-}
+],
 ```
 
-Together with an ERC20 transfer action, this will limit the token transferred to 10 USDC per session use, and 50 USDC for a total lifespan of the session.
+This caps each transfer at 10 USDC and the total across the session lifetime at 50 USDC.
 
-### Value Limit
+### Value limit
 
-To limit the maximum value to pass for a single session use:
+To cap the ETH value sent on a single call, use `valueLimitPerUse` at the function level:
 
-```ts {14}
-const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
-
-const session: Session = {
-  owners: {
-    type: 'ecdsa',
-    accounts: [sessionOwnerAccount],
+```ts {7}
+permissions: [
+  {
+    abi: vaultAbi,
+    address: vaultAddress,
+    functions: {
+      depositEth: {
+        valueLimitPerUse: parseUnits('0.1', 18),
+      },
+    },
   },
-  actions: [
-    {
-      // ERC20 transfer action
-      policies: [
-        {
-          type: 'universal-action',
-          valueLimitPerUse: parseUnits('0.1', 18),
-          rules: [
-            {
-              condition: 'equal',
-              calldataOffset: 0n,
-              referenceValue: receiver,
-            },
-          ],
-        },
-      ],
-    },
-  ],
-}
+],
 ```
 
-This will limit the value per session use to 0.1 ETH.
+This limits the value per call to 0.1 ETH.

--- a/smart-wallet/smart-sessions/policies/spending-limit.mdx
+++ b/smart-wallet/smart-sessions/policies/spending-limit.mdx
@@ -3,36 +3,41 @@ title: "Spending limit"
 sidebarTitle: "Spending limit"
 ---
 
-You can limit the amount of ERC20 tokens transferable with the policy.
+You can limit the amount of ERC20 tokens transferable through a session function. Attach the policy at the function level — it caps the cumulative amount across all uses of that function.
 
-To enable the policy:
-
-```ts {6-24}
-const session: Session = {
+```ts {15-23}
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-  actions: [
+  permissions: [
     {
-      policies: [
-        {
-          type: 'spending-limits',
-          limits: [
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: {
+        transfer: {
+          policies: [
             {
-              token: usdcAddress,
-              amount: parseUnits('10', 6),
-            },
-            {
-              token: wethAddress,
-              amount: parseUnits('0.1', 18),
+              type: 'spending-limits',
+              limits: [
+                {
+                  token: usdcAddress,
+                  amount: parseUnits('10', 6),
+                },
+                {
+                  token: wethAddress,
+                  amount: parseUnits('0.1', 18),
+                },
+              ],
             },
           ],
         },
-      ],
+      },
     },
   ],
-}
+})
 ```
 
-This will cap all transfers within the session to 10 USDC and 0.1 WETH in total.
+This caps total transfers within the session to 10 USDC and 0.1 WETH combined.

--- a/smart-wallet/smart-sessions/policies/sudo.mdx
+++ b/smart-wallet/smart-sessions/policies/sudo.mdx
@@ -3,24 +3,16 @@ title: "Sudo"
 sidebarTitle: "Sudo"
 ---
 
-Sudo policy allows any transaction to pass. It is the default session.
+Sudo allows any transaction to pass. It's the default — a session with no `permissions` accepts everything.
 
-To enable a sudo policy:
-
-```ts {6-14}
-const session: Session = {
+```ts
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-  actions: [
-    {
-      policies: [
-        {
-          type: 'sudo',
-        },
-      ],
-    },
-  ],
-}
+})
 ```
+
+<Warning>Always restrict sessions to the minimum permissions you need. A sudo session has the same authority as the account owner.</Warning>

--- a/smart-wallet/smart-sessions/policies/timeframe.mdx
+++ b/smart-wallet/smart-sessions/policies/timeframe.mdx
@@ -3,28 +3,33 @@ title: "Timeframe"
 sidebarTitle: "Timeframe"
 ---
 
-You can set the valid timeframe for the transactions, by defining the timebound in which the transaction remains valid.
+Restrict when a session function can be called. Attach the policy at the function level.
 
-To enable the policy:
-
-```ts {6-16}
-const session: Session = {
+```ts {14-18}
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-  actions: [
+  permissions: [
     {
-      policies: [
-        {
-          type: 'time-frame',
-          validAfter: Date.now(),
-          validUntil: Date.now() + 1000 * 60 * 60 * 24,
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: {
+        transfer: {
+          policies: [
+            {
+              type: 'time-frame',
+              validAfter: Date.now(),
+              validUntil: Date.now() + 1000 * 60 * 60 * 24,
+            },
+          ],
         },
-      ],
+      },
     },
   ],
-}
+})
 ```
 
-This will create a session that will be valid for 24 hours.
+This limits the function to a 24-hour window.

--- a/smart-wallet/smart-sessions/policies/usage-limit.mdx
+++ b/smart-wallet/smart-sessions/policies/usage-limit.mdx
@@ -3,27 +3,32 @@ title: "Usage limit"
 sidebarTitle: "Usage limit"
 ---
 
-You can limit the number of times the session can be used.
+Limit how many times a session function can be called.
 
-To enable the policy:
-
-```ts {6-15}
-const session: Session = {
+```ts {14-17}
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-  actions: [
+  permissions: [
     {
-      policies: [
-        {
-          type: 'usage-limit',
-          limit: 10n,
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: {
+        transfer: {
+          policies: [
+            {
+              type: 'usage-limit',
+              limit: 10n,
+            },
+          ],
         },
-      ],
+      },
     },
   ],
-}
+})
 ```
 
-This will create a session that can only be used 10 times.
+This caps the function at 10 calls.

--- a/smart-wallet/tutorials/session-keys.mdx
+++ b/smart-wallet/tutorials/session-keys.mdx
@@ -47,7 +47,7 @@ If the account is already deployed, you can install the module in a separate tra
 ```ts
 import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [experimental_enable()],
 })
@@ -124,7 +124,7 @@ const sessionDetails = await rhinestoneAccount.experimental_getSessionDetails(se
 const enableSignature = await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
 const sessionIndex = 0
 
-const prepared = await rhinestoneAccount.prepareTransaction({
+const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     experimental_enableSession(

--- a/smart-wallet/tutorials/session-keys.mdx
+++ b/smart-wallet/tutorials/session-keys.mdx
@@ -47,7 +47,7 @@ If the account is already deployed, you can install the module in a separate tra
 ```ts
 import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
 
-await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [experimental_enable()],
 })
@@ -73,35 +73,41 @@ const sessionOwnerAccount = privateKeyToAccount(sessionPrivateKey)
 Specify what the session key is allowed to do. Here we restrict it to USDC transfers only, with a 100 USDC spending limit:
 
 ```ts
-import { type Session, toFunctionSelector, getAbiItem, erc20Abi } from '@rhinestone/sdk'
-import { parseUnits } from 'viem'
+import { toSession } from '@rhinestone/sdk/smart-sessions'
+import { erc20Abi, parseUnits } from 'viem'
+import { base } from 'viem/chains'
 
 const usdcAddress = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // USDC on Base
 
-const session: Session = {
+const session = toSession({
+  chain: base,
   owners: {
     type: 'ecdsa',
     accounts: [sessionOwnerAccount],
   },
-  actions: [
+  permissions: [
     {
-      target: usdcAddress,
-      selector: toFunctionSelector(
-        getAbiItem({ abi: erc20Abi, name: 'transfer' }),
-      ),
-      policies: [
-        {
-          type: 'spending-limit',
-          limit: parseUnits('100', 6), // 100 USDC
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: {
+        transfer: {
+          policies: [
+            {
+              type: 'spending-limits',
+              limits: [
+                { token: usdcAddress, amount: parseUnits('100', 6) }, // 100 USDC
+              ],
+            },
+          ],
         },
-      ],
+      },
     },
   ],
-}
+})
 ```
 
 <Note>
-  By default, a session with no actions allows **any** transaction. Always restrict sessions to the minimum necessary permissions.
+  By default, a session with no permissions allows **any** transaction. Always restrict sessions to the minimum necessary permissions.
 </Note>
 
 </Step>
@@ -118,7 +124,7 @@ const sessionDetails = await rhinestoneAccount.experimental_getSessionDetails(se
 const enableSignature = await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
 const sessionIndex = 0
 
-await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     experimental_enableSession(
@@ -143,7 +149,7 @@ import { encodeFunctionData, erc20Abi } from 'viem'
 const recipient = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 const amount = parseUnits('10', 6) // 10 USDC
 
-const result = await rhinestoneAccount.sendTransaction({
+const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     {
@@ -160,6 +166,8 @@ const result = await rhinestoneAccount.sendTransaction({
     session,
   },
 })
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const result = await rhinestoneAccount.submitTransaction(signed)
 
 const status = await rhinestoneAccount.waitForExecution(result)
 console.log('Executed without user prompt:', status)

--- a/smart-wallet/tutorials/session-keys.mdx
+++ b/smart-wallet/tutorials/session-keys.mdx
@@ -51,6 +51,9 @@ const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [experimental_enable()],
 })
+const signed = await rhinestoneAccount.signTransaction(transaction)
+const result = await rhinestoneAccount.submitTransaction(signed)
+await rhinestoneAccount.waitForExecution(result)
 ```
 
 </Step>
@@ -135,6 +138,9 @@ const transaction = await rhinestoneAccount.prepareTransaction({
     ),
   ],
 })
+const signed = await rhinestoneAccount.signTransaction(transaction)
+const result = await rhinestoneAccount.submitTransaction(signed)
+await rhinestoneAccount.waitForExecution(result)
 ```
 
 </Step>

--- a/smart-wallet/tutorials/sponsor-fees.mdx
+++ b/smart-wallet/tutorials/sponsor-fees.mdx
@@ -59,7 +59,7 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
     You can choose which fee types to cover:
 
     ```ts
-    const prepared = await account.prepareTransaction({
+    const transaction = await account.prepareTransaction({
       sourceChains: [arbitrum],
       targetChain: base,
       calls: [...],
@@ -81,7 +81,7 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
 
     const calls = [{ to: '0xYourContractAddress', value: 0n, data: encodedCalldata }]
 
-    const prepared = await account.prepareTransaction({
+    const transaction = await account.prepareTransaction({
       sourceChains: [arbitrum],
       targetChain: base,
       calls,

--- a/smart-wallet/tutorials/sponsor-fees.mdx
+++ b/smart-wallet/tutorials/sponsor-fees.mdx
@@ -28,10 +28,10 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
 
   <Step title="Send a sponsored transaction">
 
-    Add `sponsored: true` to your `sendTransaction` call:
+    Add `sponsored: true` when preparing the transaction:
 
     ```ts
-    const result = await account.sendTransaction({
+    const prepared = await account.prepareTransaction({
       sourceChains: [arbitrum],
       targetChain: base,
       calls: [
@@ -43,6 +43,8 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
       ],
       sponsored: true,
     })
+    const signed = await account.signTransaction(prepared)
+    const result = await account.submitTransaction(signed)
 
     const status = await account.waitForExecution(result)
     console.log('Transaction settled:', status)
@@ -57,7 +59,7 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
     You can choose which fee types to cover:
 
     ```ts
-    const result = await account.sendTransaction({
+    const prepared = await account.prepareTransaction({
       sourceChains: [arbitrum],
       targetChain: base,
       calls: [...],
@@ -79,7 +81,7 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
 
     const calls = [{ to: '0xYourContractAddress', value: 0n, data: encodedCalldata }]
 
-    const result = await account.sendTransaction({
+    const prepared = await account.prepareTransaction({
       sourceChains: [arbitrum],
       targetChain: base,
       calls,


### PR DESCRIPTION
## Summary

Two coordinated rewrites of the docs snippets across the site:

**SDK → v2** (`1afa7d3`, `7d751b2`)
- Switch all SDK code samples to the v2 `prepare` / `sign` / `submit` transaction flow.
- Move smart sessions to ABI-driven `toSession` and adopt the new subpath exports (`@rhinestone/sdk/utils`, `@rhinestone/sdk/smart-sessions`).
- Drop preconfirmation status and `sendTransaction` shortcut references.
- Quickstart pins `@beta` until v2 ships stable.
- Trim trailing sign/submit lines from snippets meant to showcase a single action or option, and rename their result variable to `transaction`.
- Collapse the ERC-4337 page to a single granular flow without `sendUserOperation`.

**Intents API → blanc** (`37442e2`, `9480641`)
- Switch every raw-API snippet from the alps shape to blanc: `/quotes` + `/intents` resource endpoints, server-stored intents (submit by `intentId`), CAIP-2 chain ids.
- Flattened `cost` shape with `fees.breakdown.{gas,swap,bridge}` carrying `{ usd, sponsored }`.
- Server-provided EIP-712 typed data forwarded directly to `signTypedData`.
- Unified `{ code, message, traceId, details }` error envelope and flat `sponsorSettings` rename.
- Drop `@rhinestone/module-sdk` usage from API guides and remove the stale staging URL row in the quick reference.
- Verified `/quotes`, `/accounts/:addr/portfolio`, sponsorship, and `accountAccessList.chainTokens` shapes against the prod orchestrator.

Together these bring every snippet across the docs site in line with the v2 SDK + blanc API releases.

Closes [RHI-3708](https://linear.app/rhinestone/issue/RHI-3708)