### PR TITLE
docs: document verifyExecutions removal in v1→v2 migration

### DIFF
--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -145,6 +145,27 @@ await rhinestoneAccount.waitForExecution(result, false)
 await rhinestoneAccount.waitForExecution(result)
 ```
 
+### `verifyExecutions` removed from session signers
+
+`SingleSessionSignerSet`, `PerChainSessionSignerSet`, and `ChainSessionConfig` no longer accept `verifyExecutions`. The SDK now derives it from the session shape — sessions with `permissions` use emissary execution validation, claim-only sessions use the EIP-1271 path — so the flag is redundant. Drop it from your signer set:
+
+```ts
+// Before
+const signers = {
+  type: 'experimental_session',
+  session,
+  verifyExecutions: true,
+  enableData,
+}
+
+// After
+const signers = {
+  type: 'experimental_session',
+  session,
+  enableData,
+}
+```
+
 ### Passport account removed
 
 `account.type: 'passport'` is no longer accepted. The `PassportAccount` type and the `passport` member of `AccountType` / `AccountProviderConfig` are removed.


### PR DESCRIPTION
Adds a migration-guide entry for the removal of `verifyExecutions` from the public session signer API (SDK PR [#477](https://github.com/rhinestonewtf/sdk/pull/477), commit [`487b93e`](https://github.com/rhinestonewtf/sdk/commit/487b93e)).

The SDK now resolves the field from the session shape: sessions with `permissions` use the emissary execution-validation path, claim-only sessions use EIP-1271. Callers who passed `verifyExecutions` on `SingleSessionSignerSet` / `PerChainSessionSignerSet` / `ChainSessionConfig` should drop the field.

No other docs referenced `verifyExecutions`, so this is migration-note-only.

Closes [RHI-3955](https://linear.app/rhinestone/issue/RHI-3955)