### PR TITLE
docs: document settlementLayers include/exclude filter

### DIFF
--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -121,6 +121,26 @@ const signed = await rhinestoneAccount.signTransaction(prepared, {
 
 `getTransactionMessages(prepared, { intentId })` accepts the same selection so external signers see the route `signTransaction` will sign.
 
+### Settlement layer filter
+
+`settlementLayers` is no longer a bare array. It's a discriminated union with `include` / `exclude` so you can blacklist a single layer without listing all the others:
+
+```ts
+// Before
+await rhinestoneAccount.prepareTransaction({
+  // …
+  settlementLayers: ['ACROSS', 'ECO'],
+})
+
+// After
+await rhinestoneAccount.prepareTransaction({
+  // …
+  settlementLayers: { include: ['ACROSS', 'ECO'] },
+})
+```
+
+The same shape applies to `splitIntents`. See [Settlement Layers](../chain-abstraction/multi-chain-intent#settlement-layers) for usage patterns.
+
 ### `submitTransaction` options bag
 
 `submitTransaction` now takes an options object instead of positional arguments:

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -108,6 +108,44 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 
 <Note>Chain-specific `sourceAssets` take precendence over `sourceChain` parameter.</Note>
 
+## Settlement Layers
+
+Rhinestone routes intents through a settlement layer. By default, the orchestrator picks the best one. Pass `settlementLayers` to constrain the choice — either include a specific set, or exclude one you want to avoid.
+
+Pin to a specific layer (or set of layers):
+
+```ts {10}
+const transaction = await rhinestoneAccount.prepareTransaction({
+  sourceChains: [base],
+  targetChain: arbitrum,
+  calls: [
+    // …
+  ],
+  tokenRequests: [
+    // …
+  ],
+  settlementLayers: { include: ['ACROSS'] },
+})
+```
+
+Exclude a layer (e.g. while one is degraded) and let the orchestrator pick from the rest:
+
+```ts {10}
+const transaction = await rhinestoneAccount.prepareTransaction({
+  sourceChains: [base],
+  targetChain: arbitrum,
+  calls: [
+    // …
+  ],
+  tokenRequests: [
+    // …
+  ],
+  settlementLayers: { exclude: ['RELAY'] },
+})
+```
+
+The same filter works on `splitIntents` (see [Liquidity Splitting](#liquidity-splitting)).
+
 ## Auxiliary Funds
 
 In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
@@ -195,6 +233,6 @@ const splits = await rhinestone.splitIntents({
   tokens: {
     [USDC_ADDRESS]: parseUnits('100000', 6),
   },
-  settlementLayers: ['ACROSS', 'ECO'],
+  settlementLayers: { include: ['ACROSS', 'ECO'] },
 })
 ```


### PR DESCRIPTION
## Summary

- Add a `Settlement Layers` section to the multi-chain intent page with include/exclude usage examples
- Update the existing `splitIntents` snippet from the old array shape to the new filter shape
- Add a `Settlement layer filter` v1→v2 migration note that cross-links to the usage section

Closes [RHI-3956](https://linear.app/rhinestone/issue/RHI-3956)