### PR TITLE
docs: cover SDK v2 features (quote selection, source calls, non-EVM destinations)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -201,6 +201,7 @@
               "smart-wallet/chain-abstraction/unified-balance",
               "smart-wallet/chain-abstraction/swaps",
               "intents/features/execute-crosschain-calls",
+              "intents/features/non-evm-destinations",
               "smart-wallet/chain-abstraction/source-token-amount",
               "smart-wallet/chain-abstraction/custom-recipient",
               "smart-wallet/chain-abstraction/account-deployment"

--- a/intents/features/execute-crosschain-calls.mdx
+++ b/intents/features/execute-crosschain-calls.mdx
@@ -106,6 +106,61 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 })
 ```
 
+## Source calls
+
+You can also run executions on the source side, *before* the claim. Source calls are bundled into the intent at routing time and covered by the user's mandate signature.
+
+Use them for pre-bridge actions on the source chain — ERC-20 approvals, ETH→WETH wraps, unstaking, or pulling funds out of a vault you need to spend.
+
+```ts
+import { base, arbitrum } from 'viem/chains'
+import { encodeFunctionData, parseUnits } from 'viem'
+
+const prepared = await rhinestoneAccount.prepareTransaction({
+  sourceChains: [base],
+  targetChain: arbitrum,
+  tokenRequests: [
+    { address: usdcArbitrum, amount: parseUnits('100', 6) },
+  ],
+  sourceCalls: {
+    [base.id]: [
+      {
+        to: USDC_BASE,
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: 'approve',
+          args: [VAULT_BASE, parseUnits('100', 6)],
+        }),
+      },
+    ],
+  },
+})
+```
+
+### Declaring tokens the source call provides
+
+If the source call hands over tokens (an unwrap, an unstake, withdrawing from a vault), declare them via `provides`. Routing then treats those tokens as available, the same way `auxiliaryFunds` does:
+
+```ts {7-9}
+sourceCalls: {
+  [base.id]: [
+    {
+      to: VAULT_BASE,
+      data: encodeFunctionData({ abi: vaultAbi, functionName: 'withdraw', args: [shares] }),
+      provides: [
+        { token: USDC_BASE, amount: parseUnits('100', 6) },
+      ],
+    },
+  ],
+},
+```
+
+### Caveats
+
+- Source calls only fire when the orchestrator creates an element on that chain. Sponsored or no-op fills with no source movement skip the source element entirely, and the `sourceCalls` keyed on that chain are silently dropped.
+- The chain id must appear in `sourceChains` (cross-chain intents) or equal the same-chain `chain`.
+- For same-chain intents, source calls run before the destination `calls` on the same chain.
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/intents/features/non-evm-destinations.mdx
+++ b/intents/features/non-evm-destinations.mdx
@@ -1,0 +1,57 @@
+---
+title: "Non-EVM destinations"
+description: "Send intents to Solana and Tron destination chains."
+---
+
+Warp intents can settle on Solana and Tron, alongside every supported EVM chain. The source side stays the same — origin chains, signing, and submission are unchanged. What differs is the destination shape: the recipient is a base58 or T-prefix string, token addresses are SPL mints or TRC-20 contracts, and there are no destination executions.
+
+## What changes vs. EVM destinations
+
+| | EVM destination | Non-EVM destination |
+|---|---|---|
+| `targetChain` | viem `Chain` | `solanaMainnet` / `tronMainnet` |
+| `recipient` | `Address` | base58 (Solana) / Tron T-prefix string |
+| `tokenRequests[].address` | EVM `Address` or `TokenSymbol` | SPL mint / TRC-20 contract string |
+| Destination `calls` | supported | not supported (claims only) |
+| UserOp path | supported | not supported |
+| `fillTransactionHash` | `Hex` | `string` (base58 / Tron hex) |
+
+## Example: USDC from Base to Solana
+
+```ts
+import { solanaMainnet } from '@rhinestone/sdk'
+import { base } from 'viem/chains'
+
+const SOLANA_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+const recipient = 'mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN'
+
+const prepared = await rhinestoneAccount.prepareTransaction({
+  sourceChains: [base],
+  targetChain: solanaMainnet,
+  recipient,
+  tokenRequests: [
+    {
+      address: SOLANA_USDC,
+      amount: 5_000_000n, // 5 USDC, 6 decimals
+    },
+  ],
+})
+
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const result = await rhinestoneAccount.submitTransaction(signed)
+const status = await rhinestoneAccount.waitForExecution(result)
+```
+
+Swap `solanaMainnet` for `tronMainnet` and pass a Tron T-prefix recipient and a TRC-20 contract address to bridge to Tron instead.
+
+## Constraints
+
+- **No destination calls.** Solana and Tron destinations are claim-only — you can't pass a `calls` array on a non-EVM intent. If your flow needs onchain logic on the destination, route to an EVM chain.
+- **No UserOp path.** `sendUserOperation` and the UserOp transaction shape remain EVM-only.
+- **No destination-side signing.** Smart-session destination signatures are skipped on non-EVM chains — there's no validator there to verify them. Origin signing is unchanged.
+- **EIP-7702 authorization is a no-op** on non-EVM destinations.
+- **`fillTransactionHash` is a plain string.** Was `Hex` on EVM destinations; widened so base58 and Tron hex round-trip cleanly.
+
+## Tracking the intent
+
+`waitForExecution` and `getIntentStatus` work the same way as for EVM destinations. Inspect `status.operations[]` for per-chain transaction hashes — the destination entry's `fillTransactionHash` will be a base58 (Solana) or hex (Tron) string.

--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -73,6 +73,30 @@ const gasUSD = route.cost.fees.breakdown.gas.usd;
 const totalFeeUSD = route.cost.fees.total.usd;
 ```
 
+## Choosing a different route
+
+`routes[]` is server-ranked, so `routes[0]` is the default pick. If you want a different one — cheaper, faster, on a specific settlement layer — iterate `routes` and submit the chosen route's `intentId`. No extra parameter is needed; the API selects the quote by `intentId`.
+
+```ts
+// Pick the fastest route under a $1 fee cap.
+const fastest = routes
+  .filter((r) => r.cost.fees.total.usd <= 1)
+  .reduce((a, b) =>
+    a.estimatedFillTime.seconds <= b.estimatedFillTime.seconds ? a : b
+  );
+
+await fetch(`${baseUrl}/intents`, {
+  method: "POST",
+  headers: { /* ... */ },
+  body: JSON.stringify({
+    intentId: fastest.intentId,
+    signatures: { /* signed against fastest.signData */ },
+  }),
+});
+```
+
+Each route carries its own `signData`, so always sign against the route you intend to submit — signatures from one route won't verify against another.
+
 ## Executions (calls)
 
 You can run executions on behalf of the EOA on the destination chain.

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -146,6 +146,28 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 
 The same filter works on `splitIntents` (see [Liquidity Splitting](#liquidity-splitting)).
 
+## Choosing a different quote
+
+`prepareTransaction` returns multiple candidate routes via `prepared.quotes`. By default, `signTransaction` picks `prepared.quotes.best` — the orchestrator's recommended route. To pick a different one, iterate `prepared.quotes.all` and pass the chosen quote's `intentId` to `signTransaction`:
+
+```ts
+const prepared = await rhinestoneAccount.prepareTransaction({ /* ... */ })
+
+// e.g. pick the fastest route under a $1 fee cap
+const fastest = prepared.quotes.all
+  .filter((q) => q.cost.fees.total.usd <= 1)
+  .reduce((a, b) =>
+    a.estimatedFillTime.seconds <= b.estimatedFillTime.seconds ? a : b
+  )
+
+const signed = await rhinestoneAccount.signTransaction(prepared, {
+  intentId: fastest.intentId,
+})
+const transaction = await rhinestoneAccount.submitTransaction(signed)
+```
+
+Each quote has its own `signData` — signatures from one quote won't verify against another. Passing `{ intentId }` tells the SDK to sign the matching quote.
+
 ## Auxiliary Funds
 
 In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:


### PR DESCRIPTION
## Summary

- New `intents/features/non-evm-destinations.mdx` page covering Solana / Tron destinations: diff vs. EVM destinations, end-to-end Base→Solana USDC walkthrough, and constraints (no destination calls, no UserOp, no destination signing, string `fillTransactionHash`).
- Quote selection documented in two places — raw-API section on `intents/guides/getting-a-quote.mdx` and SDK section on `smart-wallet/chain-abstraction/multi-chain-intent.mdx` (alongside the existing route-shaped topics like Settlement Layers).
- Source calls documented as a third top-level section on `intents/features/execute-crosschain-calls.mdx`, including the V2 `provides` field for auxiliary funds and the three caveats around element creation and chain-id placement.
- Registered the new Non-EVM page in `docs.json` under "Sending intents".

Closes [RHI-3954](https://linear.app/rhinestone/issue/RHI-3954).