### PR TITLE
docs: clarify when to use auxiliary funds

### DIFF
--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -220,6 +220,29 @@ const payload = {
 ```
 </CodeGroup>
 
+## Auxiliary funds
+
+`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or funds produced by a source call that refills the account.
+
+<CodeGroup dropdown>
+```ts Declare an Incoming Balance
+const payload = {
+  // …
+  auxiliaryFunds: {
+    "eip155:8453": {
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913": "5000000",
+    },
+  },
+};
+```
+</CodeGroup>
+
+<Warning>
+  Don't list funds the account already holds — the orchestrator picks those up automatically, and adding them via `auxiliaryFunds` double-counts the balance and inflates the input amount in the quote.
+</Warning>
+
+`auxiliaryFunds` and `accountAccessList` solve different problems: `accountAccessList` restricts which **existing** balances the router is allowed to spend, while `auxiliaryFunds` adds **expected** balances the router otherwise can't see. They can be combined.
+
 ## Swaps
 
 If the destination token differs from the user's source token, Warp handles the bridge and swap automatically. No additional parameters are needed — just specify the token you want on the destination chain.

--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -222,10 +222,9 @@ const payload = {
 
 ## Auxiliary funds
 
-`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or funds produced by a source call that refills the account.
+`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or any other balance that will arrive before fill.
 
-<CodeGroup dropdown>
-```ts Declare an Incoming Balance
+```ts
 const payload = {
   // …
   auxiliaryFunds: {
@@ -235,11 +234,12 @@ const payload = {
   },
 };
 ```
-</CodeGroup>
 
 <Warning>
   Don't list funds the account already holds — the orchestrator picks those up automatically, and adding them via `auxiliaryFunds` double-counts the balance and inflates the input amount in the quote.
 </Warning>
+
+For tokens produced by a [source call](/intents/features/execute-crosschain-calls#source-calls) (a vault exit, unwrap, unstake), declare them via `provides` on the call itself — not here.
 
 `auxiliaryFunds` and `accountAccessList` solve different problems: `accountAccessList` restricts which **existing** balances the router is allowed to spend, while `auxiliaryFunds` adds **expected** balances the router otherwise can't see. They can be combined.
 

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -170,7 +170,7 @@ Each quote has its own `signData` — signatures from one quote won't verify aga
 
 ## Auxiliary Funds
 
-`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or funds produced by `sourceCalls` (account refill, unwrap, etc.).
+`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or any other balance that will arrive before fill.
 
 ```ts {9-14}
 const transaction = await rhinestoneAccount.prepareTransaction({
@@ -194,7 +194,7 @@ const transaction = await rhinestoneAccount.prepareTransaction({
   Don't list funds the account already holds — the orchestrator picks those up automatically, and adding them via `auxiliaryFunds` double-counts the balance and inflates the input amount in the quote.
 </Warning>
 
-If you're using `sourceCalls` to refill the account (pulling from another account, exiting a vault, unwrapping), declare the resulting tokens here so routing treats them as available source liquidity.
+For tokens produced by a [source call](/intents/features/execute-crosschain-calls#source-calls) (a vault exit, unwrap, unstake), declare them via `provides` on the call itself — not here.
 
 ## Wait for Execution
 

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -170,7 +170,7 @@ Each quote has its own `signData` — signatures from one quote won't verify aga
 
 ## Auxiliary Funds
 
-In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
+`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or funds produced by `sourceCalls` (account refill, unwrap, etc.).
 
 ```ts {9-14}
 const transaction = await rhinestoneAccount.prepareTransaction({
@@ -190,7 +190,11 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 })
 ```
 
-This lets you get a quote before getting the funds ready on the account.
+<Warning>
+  Don't list funds the account already holds — the orchestrator picks those up automatically, and adding them via `auxiliaryFunds` double-counts the balance and inflates the input amount in the quote.
+</Warning>
+
+If you're using `sourceCalls` to refill the account (pulling from another account, exiting a vault, unwrapping), declare the resulting tokens here so routing treats them as available source liquidity.
 
 ## Wait for Execution
 

--- a/smart-wallet/chain-abstraction/single-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/single-chain-intent.mdx
@@ -67,7 +67,7 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 
 ## Auxiliary Funds
 
-In case you have funds not available immediately for an intent (e.g. locked in a vault or sitting in an exchange), you can specify them as auxiliary funds:
+`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or funds produced by `sourceCalls` (account refill, unwrap, etc.).
 
 ```ts {9-14}
 const transaction = await rhinestoneAccount.prepareTransaction({
@@ -87,7 +87,9 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 })
 ```
 
-This lets you get a quote before getting the funds ready on the account.
+<Warning>
+  Don't list funds the account already holds — the orchestrator picks those up automatically, and adding them via `auxiliaryFunds` double-counts the balance and inflates the input amount in the quote.
+</Warning>
 
 ## Wait for Execution
 

--- a/smart-wallet/chain-abstraction/single-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/single-chain-intent.mdx
@@ -67,7 +67,7 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 
 ## Auxiliary Funds
 
-`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or funds produced by `sourceCalls` (account refill, unwrap, etc.).
+`auxiliaryFunds` declares balances that aren't visible to the orchestrator yet but will be available by the time the intent settles. Use it to quote ahead of an inflow — a pending CEX deposit, a vault withdrawal, an unstake, or any other balance that will arrive before fill.
 
 ```ts {9-14}
 const transaction = await rhinestoneAccount.prepareTransaction({


### PR DESCRIPTION
## Summary

Reframe the `auxiliaryFunds` explanation around what the orchestrator can vs can't see, warn against double-counting balances the account already holds, and surface the source-calls / account-refill case. Adds a raw-API section in `getting-a-quote.mdx` that also calls out the distinction from `accountAccessList`.

Closes [RHI-4104](https://linear.app/rhinestone/issue/RHI-4104).