### PR TITLE
feat: add deposit reject webhooks

### DIFF
--- a/deposits/api/deposit-processing.mdx
+++ b/deposits/api/deposit-processing.mdx
@@ -9,7 +9,8 @@ Once an account is registered, the deposit service handles everything from detec
 
 ```mermaid actions={false}
 flowchart LR
-    D[Detection] --> B[Bridging]
+    D[Detection] -- valid --> B[Bridging]
+    D -- whitelist/min --> X[Rejected]
     B -- success --> S[Settlement]
     B -- failure --> R[Retry]
     R --> B
@@ -22,6 +23,7 @@ The service monitors registered accounts via chain indexer webhooks. When a toke
 - The token and amount are checked against your [deposit whitelist](/deposits/api/initial-setup#restrict-accepted-deposits) (if configured)
 - The transfer is deduplicated by chain, transaction hash, account, and token
 - If valid, the deposit enters the pipeline with status `processing`
+- If the token isn't allowed or the amount is outside your configured min/max, the deposit is **rejected** (not bridged) and a [`deposit-rejected`](/deposits/api/status-tracking#deposit-rejected) webhook is sent after `deposit-received`
 
 ### Bridging
 
@@ -92,11 +94,16 @@ These indicate a configuration or input problem. Check account registration, dep
 | Code | Description |
 |---|---|
 | `BALANCE-1` | Account balance too low for bridging |
-| `BALANCE-3` | Deposit amount outside whitelist range |
+| `BALANCE-3` | Deposit amount above the configured maximum |
+| `BALANCE-4` | Deposit amount below the configured minimum |
 | `TOKEN-1` | Token not supported on this chain |
 | `TOKEN-3` | Token not in deposit whitelist |
 | `ACCOUNT-1` | Account not registered |
 
 <Note>
 Failed deposits with non-retryable errors will not be retried automatically. Resolve the underlying issue (e.g. update your deposit whitelist or register the account) before triggering a manual retry.
+</Note>
+
+<Note>
+Whitelist and minimum rejections (`BALANCE-4`, `BALANCE-3`, `TOKEN-3`) are deposits the service deliberately won't bridge per your configuration. These are surfaced via the [`deposit-rejected`](/deposits/api/status-tracking#deposit-rejected) webhook — not `bridge-failed` — and no bridging is attempted.
 </Note>

--- a/deposits/api/status-tracking.mdx
+++ b/deposits/api/status-tracking.mdx
@@ -129,6 +129,7 @@ Every webhook request body follows the same envelope structure:
 | Type                                                      | Trigger                                                                       |
 | --------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | [`deposit-received`](#deposit-received)                   | Token transfer detected on a registered account                               |
+| [`deposit-rejected`](#deposit-rejected)                   | Detected deposit will not be bridged — deposit whitelist or minimum violation  |
 | [`bridge-started`](#bridge-started)                       | Bridging intent created and submitted to the Orchestrator                     |
 | [`bridge-complete`](#bridge-complete)                     | Tokens arrived on the target chain                                            |
 | [`bridge-delayed`](#bridge-delayed)                       | Bridge provider did not fill within the expected window; a refund is expected |
@@ -163,6 +164,49 @@ Sent when an incoming token transfer is detected on a registered account.
         "account": "0x1234567890abcdef1234567890abcdef12345678",
         "transactionHash": "0xabc123...",
         "sender": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    }
+}
+```
+
+#### `deposit-rejected`
+
+Sent when a detected deposit will **not** be bridged because it violates the account's [deposit whitelist](/deposits/api/initial-setup#restrict-accepted-deposits) — the token isn't allowed, or the amount is outside the configured minimum/maximum. It always follows a [`deposit-received`](#deposit-received) event for the same deposit and is terminal: no bridging is attempted and there is no retry. This is a deliberate rejection, not a processing failure — use it to record the outcome on your side. See [error codes](/deposits/api/deposit-processing#error-codes) for the full list.
+
+| Field                     | Type                  | Description                                                                                  |
+| ------------------------- | --------------------- | -------------------------------------------------------------------------------------------- |
+| `errorCode`               | `string`              | Reason — `"BALANCE-4"` (below minimum), `"BALANCE-3"` (above maximum), or `"TOKEN-3"` (token not allowed) |
+| `account`                 | `string`              | Account address                                                                              |
+| `message`                 | `string \| undefined` | Human-readable explanation                                                                   |
+| `limits.minAmount`        | `string \| undefined` | Configured minimum in raw token units — present for `BALANCE-4`                              |
+| `limits.maxAmount`        | `string \| undefined` | Configured maximum in raw token units — present for `BALANCE-3`                              |
+| `deposit.transactionHash` | `string`              | Deposit transaction hash                                                                     |
+| `deposit.chain`           | `string`              | Deposit chain (CAIP-2)                                                                        |
+| `deposit.token`           | `string`              | Deposit token address                                                                        |
+| `deposit.amount`          | `string`              | Actual deposited amount in raw token units                                                   |
+| `deposit.sender`          | `string`              | Sender address                                                                               |
+
+Compare `deposit.amount` (what was deposited) against `limits` (the configured bound) to surface the shortfall or overage to your users.
+
+```json
+{
+    "version": "1.0",
+    "type": "deposit-rejected",
+    "eventId": "12347",
+    "time": "2025-01-15T12:00:01.000Z",
+    "data": {
+        "errorCode": "BALANCE-4",
+        "account": "0x1234567890abcdef1234567890abcdef12345678",
+        "message": "Amount 500000 is below configured minimum 1000000",
+        "limits": {
+            "minAmount": "1000000"
+        },
+        "deposit": {
+            "transactionHash": "0xabc123...",
+            "chain": "eip155:8453",
+            "token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+            "amount": "500000",
+            "sender": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        }
     }
 }
 ```
@@ -376,7 +420,7 @@ function verifyWebhookSignature(
 ### Delivery behavior
 
 - **Retries** — failed deliveries are retried multiple times before the event is marked `failed`. Events that exhaust their retries can still be replayed on demand via [`POST /webhooks/events/{id}/resend`](/api-reference/deposit-service/webhooks/re-attempt-delivery-of-a-stored-webhook-event), which reuses the original `eventId`.
-- **Ordering** — events for a single deposit are sent in lifecycle order (`deposit-received` → `bridge-started` → `bridge-complete`), but there is no global ordering guarantee across deposits.
+- **Ordering** — events for a single deposit are sent in lifecycle order: `deposit-received` → `bridge-started` → `bridge-complete` when it proceeds, or `deposit-received` → `deposit-rejected` when it won't be bridged. There is no global ordering guarantee across deposits.
 - **URL validation** — the webhook URL must use HTTPS and must not target internal or private network addresses.
 - **Idempotency** — use `eventId` from the envelope as the canonical dedupe key.
 


### PR DESCRIPTION
Documents the new **`deposit-rejected`** webhook (implemented in [deposit-service-processor#377](https://github.com/rhinestonewtf/deposit-service-processor/pull/377)) so integrators know about the event, its payload, and the flow.

## What

**`deposits/api/status-tracking.mdx`**
- Adds `deposit-rejected` to the event-types table (right after `deposit-received`).
- New `#### deposit-rejected` section: payload table (`errorCode`, `account`, `message`, `limits.minAmount`/`maxAmount`, `deposit.*`), a JSON example, and a note that it always follows `deposit-received`, is terminal (no bridging, no retry), and is a deliberate rejection — not a `bridge-failed`.
- Updates the delivery-ordering note: `deposit-received → bridge-started → bridge-complete`, or `deposit-received → deposit-rejected`.

**`deposits/api/deposit-processing.mdx`**
- Adds `BALANCE-4` (below minimum) and splits `BALANCE-3` to "above the configured maximum" in the error-codes table.
- Notes that `BALANCE-4` / `BALANCE-3` / `TOKEN-3` surface via `deposit-rejected` rather than `bridge-failed`.
- Adds a "rejected" branch to the lifecycle diagram and Detection prose.

## Flow

`deposit-received` (the entry event clients index on) → `deposit-rejected` (the terminal status, with the reason + violated limit). Rejection reasons: `BALANCE-4` below-min, `BALANCE-3` above-max, `TOKEN-3` token-not-allowed.
