### PR TITLE
feat: add new deposit modal version and migration

### DIFF
--- a/deposits/overview.mdx
+++ b/deposits/overview.mdx
@@ -25,7 +25,7 @@ A headless backend service for programmatic deposit handling. You register accou
 </Tab>
 <Tab title="Deposit Widget">
 
-A drop-in React modal that handles wallet connection, chain selection, and deposit execution out of the box. Minimal frontend effort for a polished deposit experience.
+A drop-in React modal that handles wallet connection, chain selection, and deposit execution out of the box. Minimal frontend effort for a polished deposit experience. It can also [import balances from other apps](/deposits/widget/deposit-modal#import-from-other-apps) (e.g. Polymarket) so users fund a deposit without transferring first.
 
 <Frame caption="Widget UI">
   <video src="/images/deposits_widget_ui.mp4" muted loop controls className="rounded-2xl" style={{ maxHeight: "500px", margin: "0 auto" }} />

--- a/deposits/widget/customization.mdx
+++ b/deposits/widget/customization.mdx
@@ -3,7 +3,7 @@ title: "Customization"
 description: "Theme, brand, and configure the deposit widget to match your app."
 ---
 
-The deposit and withdraw modals accept `theme`, `branding`, and `uiConfig` props to control appearance and behavior.
+The deposit and withdraw modals accept `theme` and `uiConfig` props to control appearance and behavior.
 
 ## Theme
 
@@ -36,40 +36,19 @@ Pass a `theme` object to control the modal's visual style.
 
 All color values accept any CSS color string (hex, rgb, hsl, etc.). Omitted properties use the design system defaults for the selected `mode`.
 
-## Branding
-
-Replace the modal header logo and title with your own.
-
-```tsx
-<DepositModal
-  // ...required props
-  branding={{
-    logoUrl: "https://your-app.com/logo.png",
-    title: "My App",
-  }}
-/>
-```
-
-### Properties
-
-| Property | Type | Default | Description |
-|---|---|---|---|
-| `logoUrl` | `string` | Rhinestone logo | Image URL for the modal header |
-| `title` | `string` | `"Deposit"` / `"Withdraw"` | Header title text |
-
 ## UI configuration
 
-Toggle UI elements and set deposit constraints via `uiConfig`.
+Toggle UI elements, set deposit constraints, and control fee display via `uiConfig`.
 
 ```tsx
 <DepositModal
   // ...required props
   uiConfig={{
-    showLogo: true,
-    showStepper: true,
-    balance: { title: "Wallet balance" },
+    showBackButton: true,
+    showHistoryButton: true,
     minDepositUsd: 1,
     maxDepositUsd: 10000,
+    feeSponsored: true,
   }}
 />
 ```
@@ -78,9 +57,9 @@ Toggle UI elements and set deposit constraints via `uiConfig`.
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `showLogo` | `boolean` | `false` | Show the branding logo in the header |
-| `showStepper` | `boolean` | `false` | Show the progress stepper |
 | `showBackButton` | `boolean` | `true` | Show the back button in the header |
-| `balance` | `{ title: string, amount?: string }` | — | Custom balance display. `title` sets the label, `amount` optionally overrides the displayed value. |
-| `maxDepositUsd` | `number` | — | Maximum deposit amount in USD |
+| `showHistoryButton` | `boolean` | `false` | Show the deposit history button in the header |
 | `minDepositUsd` | `number` | — | Minimum deposit amount in USD |
+| `maxDepositUsd` | `number` | — | Maximum deposit amount in USD |
+| `feeSponsored` | `boolean` | `false` | When `true`, the network/protocol fee renders struck-through on the review, processing, and result screens, with a tooltip explaining the sponsorship |
+| `feeTooltip` | `string` | — | Custom copy for the fee info tooltip. Defaults to a generic message based on `feeSponsored`. |

--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -33,7 +33,7 @@ import "@rhinestone/deposit-modal/styles.css";
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
   reownAppId="YOUR_REOWN_PROJECT_ID"
-  onDepositComplete={(data) => console.log(data)}
+  onLifecycle={(event) => event.type === "complete" && console.log(event)}
 />
 ```
 
@@ -55,7 +55,7 @@ import "@rhinestone/deposit-modal/styles.css";
   recipient="0xYOUR_RECIPIENT_ADDRESS"
   dappAddress={embeddedWalletAddress}
   onRequestConnect={() => login()}
-  onDepositComplete={(data) => console.log(data)}
+  onLifecycle={(event) => event.type === "complete" && console.log(event)}
 />
 ```
 
@@ -76,7 +76,7 @@ import "@rhinestone/deposit-modal/styles.css";
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
   dappAddress={ownerAddress}
-  onDepositComplete={(data) => console.log(data)}
+  onLifecycle={(event) => event.type === "complete" && console.log(event)}
 />
 ```
 
@@ -86,15 +86,16 @@ Control the deposit destination and optionally pre-fill source parameters.
 
 | Prop | Type | Required | Description |
 |---|---|---|---|
-| `targetChain` | `Chain \| number` | Yes | Destination chain (viem `Chain` object or chain ID) |
-| `targetToken` | `Address` | Yes | Token address on the destination chain |
-| `recipient` | `Address` | Yes | Where funds are delivered on the target chain |
-| `defaultAmount` | `string` | No | Pre-filled deposit amount |
+| `targetChain` | `Chain \| number \| "solana"` | Yes | Destination chain (viem `Chain` object, chain ID, or `"solana"`) |
+| `targetToken` | `Address \| string` | Yes | Token address on the destination chain (base58 mint for Solana) |
+| `recipient` | `Address \| string` | Yes | Where funds are delivered on the target chain (base58 address for Solana) |
+| `defaultAmount` | `string` | No | Pre-filled deposit amount. A USD number string (e.g. `"25"`) or the sentinel `"max"` to fill the full available balance. |
 | `sourceChain` | `Chain \| number` | No | Pre-selected source chain |
 | `sourceToken` | `Address` | No | Pre-selected source token |
 | `allowedRoutes` | `RouteConfig` | No | Restrict available source chains and tokens |
 | `outputTokenRules` | `OutputTokenRule[]` | No | Route the deposit to a different final token based on what the user deposited |
 | `rejectUnmapped` | `boolean` | No | Reject deposits that don't match any routing rule instead of falling back to `targetToken` |
+| `appBalanceUsd` | `number` | No | The user's current in-app balance (USD). When set, the amount screen shows a "Balance after deposit" row (`appBalanceUsd + amount`). |
 
 The `allowedRoutes` prop accepts `{ sourceChains?: number[], sourceTokens?: string[] }` to limit what the user can select. For supported chains and tokens, see [supported chains](/deposits/overview#supported-chains-and-tokens).
 
@@ -106,7 +107,6 @@ Sessions allow the widget to execute bridging on behalf of the user's smart acco
 |---|---|---|---|
 | `sessionChainIds` | `number[]` | All supported chains | Restrict which chains get session keys |
 | `forceRegister` | `boolean` | `false` | Force session re-creation even if the account is already registered |
-| `waitForFinalTx` | `boolean` | `true` | Wait for destination chain confirmation before firing `onDepositComplete`. When `false`, resolves after the bridge is submitted. |
 
 ## Destination token routing
 
@@ -150,6 +150,36 @@ Execute actions on the destination chain after bridging completes. Use this for 
 
 The flow becomes: deposit on source chain → bridge to target chain → swap into the output token → deliver to the recipient.
 
+## Import from other apps
+
+The modal can pull balances a user already holds in a supported third-party app
+and fund the deposit from there — no manual transfer first. Each source is
+**off by default**; opt in per source via `dappImports`.
+
+```tsx
+<DepositModal
+  // ...required props
+  dappImports={{ polymarket: true }}
+/>
+```
+
+When enabled and the connected wallet has a balance in that app, a new row
+(e.g. "Transfer from Polymarket") appears on the deposit entry screen. The
+user picks it, and the modal pulls the funds into their smart account and
+bridges them to `targetChain` / `targetToken` like any other source.
+
+### Polymarket
+
+Set `dappImports={{ polymarket: true }}`. The modal looks up the connected
+EOA's Polymarket proxy wallet on Polygon and surfaces any pUSD or USDC.e
+balance. pUSD is unwrapped to USDC.e on the way out; USDC.e is what lands in the
+smart account and what the orchestrator bridges from.
+
+Polymarket exposes two wallet types and the modal handles both: some transfer
+on-chain directly from the user's signed transaction, while others are relayed
+through your configured [`backendUrl`](#backend). The default Rhinestone
+backend handles both with no extra setup.
+
 ## Display modes
 
 By default, the component renders as a centered modal overlay with a backdrop. Set `inline={true}` to render it without the overlay, fitting into your page layout.
@@ -173,9 +203,9 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 |---|---|---|
 | `isOpen` | `boolean` | Controls modal visibility |
 | `onClose` | `() => void` | Called when the user closes the modal |
-| `targetChain` | `Chain \| number` | Destination chain (viem `Chain` object or chain ID) |
-| `targetToken` | `Address` | Token address on the destination chain |
-| `recipient` | `Address` | Where funds are delivered on the target chain |
+| `targetChain` | `Chain \| number \| "solana"` | Destination chain (viem `Chain` object, chain ID, or `"solana"`) |
+| `targetToken` | `Address \| string` | Token address on the destination chain |
+| `recipient` | `Address \| string` | Where funds are delivered on the target chain |
 
 ### Wallet
 
@@ -186,19 +216,20 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 | `dappWalletClient` | `WalletClient` | — | Host-provided viem wallet client for signing |
 | `dappPublicClient` | `PublicClient` | — | Host-provided viem public client |
 | `onRequestConnect` | `() => void` | — | Called when the modal needs the user to connect a wallet |
-| `connectButtonLabel` | `string` | — | Custom label for the connect button |
 
 ### Transfer
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `defaultAmount` | `string` | — | Pre-filled deposit amount |
+| `defaultAmount` | `string` | — | Pre-filled deposit amount. USD number string or the sentinel `"max"`. |
 | `sourceChain` | `Chain \| number` | — | Pre-selected source chain |
 | `sourceToken` | `Address` | — | Pre-selected source token |
+| `appBalanceUsd` | `number` | — | In-app USD balance; enables the "Balance after deposit" row |
 | `allowedRoutes` | `RouteConfig` | — | `{ sourceChains?, sourceTokens? }` to restrict selection |
 | `outputTokenRules` | `OutputTokenRule[]` | — | Per-deposit output token routing rules |
 | `rejectUnmapped` | `boolean` | `false` | Reject deposits that don't match any `outputTokenRules` entry |
 | `postBridgeActions` | `PostBridgeAction[]` | — | Actions to execute after bridging |
+| `dappImports` | `DappImportsConfig` | — | [Import balances](#import-from-other-apps) from third-party apps (e.g. `{ polymarket: true }`) |
 
 ### Session
 
@@ -206,7 +237,6 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 |---|---|---|---|
 | `sessionChainIds` | `number[]` | All supported | Chain IDs for session key creation |
 | `forceRegister` | `boolean` | `false` | Force session re-creation |
-| `waitForFinalTx` | `boolean` | `true` | Wait for destination chain confirmation |
 | `signerAddress` | `Address` | Default signer | Session signer address |
 | `rhinestoneApiKey` | `string` | — | API key for account setup |
 
@@ -224,7 +254,6 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 | `closeOnOverlayClick` | `boolean` | `true` | Close modal on backdrop click |
 | `className` | `string` | — | CSS class for the modal container |
 | `theme` | `DepositModalTheme` | — | [Theme configuration](/deposits/widget/customization#theme) |
-| `branding` | `DepositModalBranding` | — | [Branding configuration](/deposits/widget/customization#branding) |
 | `uiConfig` | `DepositModalUIConfig` | — | [UI configuration](/deposits/widget/customization#ui-configuration) |
 | `debug` | `boolean` | `false` | Enable debug logging |
 
@@ -233,14 +262,11 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 | Prop | Type | Description |
 |---|---|---|
 | `onReady` | `() => void` | Modal initialized |
-| `onConnected` | `(data: ConnectedEventData) => void` | Smart account created |
-| `onDepositSubmitted` | `(data: DepositSubmittedEventData) => void` | Deposit transaction submitted on source chain |
-| `onDepositComplete` | `(data: DepositCompleteEventData) => void` | Tokens arrived on target chain |
-| `onDepositFailed` | `(data: DepositFailedEventData) => void` | Bridge or transfer failed |
+| `onLifecycle` | `(event: DepositLifecycleEvent) => void` | [Lifecycle event](/deposits/widget/status-tracking#onlifecycle) — switch on `event.type` (`connected`, `submitted`, `complete`, `failed`, `balance-changed`, `smart-account-changed`) |
 | `onError` | `(data: ErrorEventData) => void` | Error at any stage |
-| `onEvent` | `(event: DepositEvent) => void` | [Analytics event](/deposits/widget/status-tracking#analytics) |
+| `onEvent` | `(event: DepositAnalyticsEvent) => void` | [Analytics event](/deposits/widget/status-tracking#analytics) |
 
-See [status tracking](/deposits/widget/status-tracking) for callback payload types and the deposit lifecycle.
+See [status tracking](/deposits/widget/status-tracking) for lifecycle event payloads.
 
 ### Solana
 

--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -1,0 +1,174 @@
+---
+title: "Migration guide"
+description: "Upgrade @rhinestone/deposit-modal from v0.1.x / v0.2.x to v0.3.0."
+---
+
+v0.3.0 collapses each modal's per-event callbacks into a single `onLifecycle`
+callback, renames the analytics event types, removes the `/reown` and `/safe`
+subpath entry points, and drops `connectButtonLabel`. `<DepositModal>` and
+`<WithdrawModal>` share the same callback shape, but their lifecycle payloads
+are **not identical** — see [Asymmetries](#asymmetries) below.
+
+## Callback collapse — onLifecycle
+
+Both modals replace their individual callbacks with one `onLifecycle` that
+receives a discriminated event. Switch on `event.type`; the payload fields keep
+the same names as before.
+
+| Old prop (`<DepositModal>`) | New `event.type`          | Old prop (`<WithdrawModal>`) | New `event.type` |
+| --------------------------- | ------------------------- | ---------------------------- | ---------------- |
+| `onConnected`               | `"connected"`             | `onConnected`                | `"connected"`    |
+| `onDepositSubmitted`        | `"submitted"`             | `onWithdrawSubmitted`        | `"submitted"`    |
+| `onDepositComplete`         | `"complete"`              | `onWithdrawComplete`         | `"complete"`     |
+| `onDepositFailed`           | `"failed"`                | `onWithdrawFailed`           | `"failed"`       |
+| `onTotalBalanceChange`      | `"balance-changed"`       | —                            | —                |
+| `onSmartAccountChange`      | `"smart-account-changed"` | —                            | —                |
+
+<CodeGroup dropdown>
+
+```diff DepositModal
+ <DepositModal
+   ...
+-  onConnected={({ address, smartAccount }) => trackConnected(address, smartAccount)}
+-  onDepositSubmitted={({ txHash, sourceChain, amount }) => trackSubmitted(txHash, sourceChain, amount)}
+-  onDepositComplete={({ txHash, destinationTxHash }) => trackComplete(txHash, destinationTxHash)}
+-  onDepositFailed={({ txHash, error }) => trackFailed(txHash, error)}
+-  onTotalBalanceChange={(total) => setBalance(total)}
+-  onSmartAccountChange={({ evm, solana }) => setSmartAccount({ evm, solana })}
+-  connectButtonLabel="Connect wallet"
++  onLifecycle={(event) => {
++    switch (event.type) {
++      case "connected":
++        trackConnected(event.address, event.smartAccount);
++        break;
++      case "submitted":
++        trackSubmitted(event.txHash, event.sourceChain, event.amount);
++        break;
++      case "complete":
++        trackComplete(event.txHash, event.destinationTxHash);
++        break;
++      case "failed":
++        trackFailed(event.txHash, event.error);
++        break;
++      case "balance-changed":
++        setBalance(event.totalUsd);
++        break;
++      case "smart-account-changed":
++        setSmartAccount({ evm: event.evm, solana: event.solana });
++        break;
++    }
++  }}
+ />
+```
+
+```diff WithdrawModal
+ <WithdrawModal
+   ...
+-  onConnected={({ address, smartAccount }) => trackConnected(address, smartAccount)}
+-  onWithdrawSubmitted={({ txHash, sourceChain, amount, safeAddress }) => trackSubmitted(txHash, sourceChain, amount, safeAddress)}
+-  onWithdrawComplete={({ txHash, destinationTxHash }) => trackComplete(txHash, destinationTxHash)}
+-  onWithdrawFailed={({ txHash, error }) => trackFailed(txHash, error)}
+-  connectButtonLabel="Connect wallet"
++  onLifecycle={(event) => {
++    switch (event.type) {
++      case "connected":
++        trackConnected(event.address, event.smartAccount);
++        break;
++      case "submitted":
++        trackSubmitted(event.txHash, event.sourceChain, event.amount, event.safeAddress);
++        break;
++      case "complete":
++        trackComplete(event.txHash, event.destinationTxHash);
++        break;
++      case "failed":
++        trackFailed(event.txHash, event.error);
++        break;
++    }
++  }}
+ />
+```
+
+</CodeGroup>
+
+See [status tracking](/deposits/widget/status-tracking) for the full event
+payloads.
+
+## Asymmetries
+
+The two unions look alike but differ — don't assume one helper typechecks
+against both.
+
+| Aspect                            | `DepositLifecycleEvent`  | `WithdrawLifecycleEvent` |
+| --------------------------------- | ------------------------ | ------------------------ |
+| `txHash` type                     | `string`                 | `Hex`                    |
+| `sourceChain` on submit/complete  | `ChainId \| "unknown"`   | `number`                 |
+| `sourceToken` on complete         | `string`, optional       | `Address`, required      |
+| `targetChain` on complete         | `number \| "solana"`     | `number`                 |
+| `targetToken` on complete         | `string`                 | `Address`                |
+| `safeAddress` on submit           | not present              | `Address`                |
+| `"balance-changed"` variant       | yes                      | no                       |
+| `"smart-account-changed"` variant | yes                      | no                       |
+
+<Warning>
+`sourceChain: "unknown"` is deposit-only. A webhook-detected deposit can arrive
+without chain or token info, in which case deposit events carry
+`sourceChain: "unknown"` and `sourceToken: undefined`. Handle this branch in
+your deposit `onLifecycle` switch — the wrong branch picks the wrong explorer
+URL. Withdraw flows always know the source chain.
+</Warning>
+
+## Analytics type rename
+
+The `onEvent` prop name is unchanged on both modals, but its parameter type was
+renamed. The payload shape is unchanged.
+
+```diff
+- import type { DepositEvent, WithdrawEvent, ModalEvent } from "@rhinestone/deposit-modal";
++ import type {
++   DepositAnalyticsEvent,
++   WithdrawAnalyticsEvent,
++   ModalAnalyticsEvent,
++ } from "@rhinestone/deposit-modal";
+```
+
+## Removed
+
+- **`connectButtonLabel`** — gone from both modals. The connect-step copy is
+  controlled internally; delete any consumer-side label, there is no
+  replacement.
+- **`/reown` and `/safe` subpath imports** — they re-exported nothing that
+  isn't already on the root entry point.
+
+  ```diff
+  - import { DepositModal, disconnectWallet } from "@rhinestone/deposit-modal/reown";
+  + import { DepositModal, disconnectWallet } from "@rhinestone/deposit-modal";
+
+  - import type { SafeTransactionRequest } from "@rhinestone/deposit-modal/safe";
+  + import type { SafeTransactionRequest } from "@rhinestone/deposit-modal";
+  ```
+
+  The `./deposit`, `./withdraw`, `./constants`, and `./styles.css` subpaths
+  remain for tree-shaking.
+
+## Additive — no action required
+
+New in v0.3.0; existing code keeps working:
+
+- **`appBalanceUsd?: number`** on `<DepositModal>` — renders a "Balance after
+  deposit" row (`appBalanceUsd + amount`) instead of fetching a portfolio
+  balance.
+- **`dappImports?: DappImportsConfig`** on `<DepositModal>` — pull balances from
+  third-party apps. See [import from other apps](/deposits/widget/deposit-modal#import-from-other-apps).
+- **`defaultAmount: "max"`** — defaults the input to the user's full
+  source-token balance.
+- **Solana destinations** — `targetChain: Chain | number | "solana"`,
+  `targetToken: Address | string`, `recipient: Address | string`.
+- **New root exports** — `DepositLifecycleEvent`, `WithdrawLifecycleEvent`,
+  `DappImportsConfig`, `OutputTokenRule`, plus the renamed analytics types.
+
+## Unchanged
+
+`onError`, `onReady`, `onRequestConnect`, the `onEvent` prop name,
+`dappWalletClient` / `dappPublicClient` / `reownAppId`, `<WithdrawModal>`'s
+`onSignTransaction`, and the `@rhinestone/deposit-modal/styles.css` export all
+keep their names and signatures.

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -61,9 +61,9 @@ This renders a modal where the user connects their wallet, picks a source chain 
 
 <Step title="Handle completion">
 
-Add the `onDepositComplete` callback to react when tokens arrive on the target chain.
+Add the `onLifecycle` callback and react to the `"complete"` event when tokens arrive on the target chain.
 
-```tsx {8-11}
+```tsx {8-13}
 <DepositModal
   isOpen={isOpen}
   onClose={() => setIsOpen(false)}
@@ -71,14 +71,16 @@ Add the `onDepositComplete` callback to react when tokens arrive on the target c
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
   reownAppId={process.env.NEXT_PUBLIC_REOWN_PROJECT_ID!}
-  onDepositComplete={(data) => {
-    console.log("Deposit complete:", data.destinationTxHash);
-    setIsOpen(false);
+  onLifecycle={(event) => {
+    if (event.type === "complete") {
+      console.log("Deposit complete:", event.destinationTxHash);
+      setIsOpen(false);
+    }
   }}
 />
 ```
 
-See [`onDepositComplete`](/deposits/widget/status-tracking#ondepositcomplete) for the full `data` payload shape, and [status tracking](/deposits/widget/status-tracking) for all available callbacks.
+`onLifecycle` is a single callback that emits every state transition as a discriminated event — switch on `event.type`. See [status tracking](/deposits/widget/status-tracking#onlifecycle) for all event variants and payloads.
 
 </Step>
 
@@ -91,7 +93,7 @@ See [`onDepositComplete`](/deposits/widget/status-tracking#ondepositcomplete) fo
     Integration modes, transfer configuration, and full props reference.
   </Card>
   <Card title="Customization" icon="palette" href="/deposits/widget/customization">
-    Theme, branding, and UI configuration.
+    Theme and UI configuration.
   </Card>
   <Card title="Status tracking" icon="activity" href="/deposits/widget/status-tracking">
     Lifecycle events, callbacks, and error handling.

--- a/deposits/widget/status-tracking.mdx
+++ b/deposits/widget/status-tracking.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Status tracking"
-description: "Track deposit progress and react to state changes using widget callbacks."
+description: "Track deposit progress and react to state changes via the onLifecycle callback."
 ---
 
-The deposit modal fires callbacks at each stage of the deposit lifecycle. Use these to update your UI, trigger backend processes, or log analytics.
+The modal emits every state transition through a single `onLifecycle` callback.
+You switch on `event.type` to update your UI, trigger backend processes, or log
+analytics. New event variants can be added without changing the prop surface.
 
 ## Deposit lifecycle
 
@@ -15,111 +17,108 @@ sequenceDiagram
 
     Modal->>App: onReady
     Note over Modal: User connects wallet
-    Modal->>App: onConnected
+    Modal->>App: onLifecycle "connected"
     Note over Modal: User selects chain, token, amount
     Modal->>Chain: Submit deposit tx
-    Modal->>App: onDepositSubmitted
+    Modal->>App: onLifecycle "submitted"
     Note over Chain: Bridge in progress
     Chain-->>Modal: Funds arrive on target chain
-    Modal->>App: onDepositComplete
+    Modal->>App: onLifecycle "complete"
 ```
 
 1. The modal initializes and fires `onReady`
-2. The user connects a wallet (or is connected via embedded wallet). The modal creates a smart account and fires `onConnected` with the EOA `address` and `smartAccount` address.
-3. The user selects a source chain, token, and amount, then confirms the deposit
-4. The modal submits the transaction on the source chain and fires `onDepositSubmitted`
-5. The bridge routes funds to the target chain. When `waitForFinalTx` is `true` (default), the modal waits for destination chain confirmation before firing `onDepositComplete`
+2. The user connects a wallet (or is connected via an embedded wallet). The
+   modal creates a smart account and emits `"connected"` with the EOA `address`
+   and `smartAccount` address.
+3. The user selects a source chain, token, and amount, then confirms
+4. The modal submits the transaction on the source chain and emits `"submitted"`
+5. The bridge routes funds to the target chain. Once they arrive, the modal
+   emits `"complete"`
 
-If the bridge fails after submission, `onDepositFailed` fires instead of `onDepositComplete`.
+If the bridge fails after submission, `"failed"` is emitted instead of
+`"complete"`.
 
-## Event callbacks
+## onLifecycle
 
-### onReady
-
-Fires when the modal is initialized and ready for interaction. No payload.
-
-```tsx
-onReady={() => {
-  console.log("Modal ready");
-}}
-```
-
-### onConnected
-
-Fires when a smart account has been created for the deposit.
+`onLifecycle` receives a discriminated union — `DepositLifecycleEvent` on
+`<DepositModal>`, `WithdrawLifecycleEvent` on `<WithdrawModal>`. The two are
+similar but not identical; see [withdraw events](#withdraw-events) for the
+differences.
 
 ```tsx
-onConnected={(data) => {
-  console.log("EOA:", data.address);
-  console.log("Smart account:", data.smartAccount);
-}}
+import type { DepositLifecycleEvent } from "@rhinestone/deposit-modal";
+
+<DepositModal
+  // ...required props
+  onLifecycle={(event: DepositLifecycleEvent) => {
+    switch (event.type) {
+      case "connected":
+        console.log("smart account", event.smartAccount);
+        break;
+      case "submitted":
+        console.log("source tx", event.txHash, "on", event.sourceChain);
+        break;
+      case "complete":
+        console.log("done", event.destinationTxHash, event.amount);
+        break;
+      case "failed":
+        console.error("failed", event.txHash, event.error);
+        break;
+      case "balance-changed":
+        setBalance(event.totalUsd);
+        break;
+      case "smart-account-changed":
+        setSmartAccount({ evm: event.evm, solana: event.solana });
+        break;
+    }
+  }}
+/>
 ```
 
-| Field | Type | Description |
+### Deposit events
+
+| `event.type` | Fields | Description |
 |---|---|---|
-| `address` | `Address` | The user's EOA or owner address |
-| `smartAccount` | `Address` | The smart account address that receives deposits |
+| `"connected"` | `address: Address`, `smartAccount: Address` | Smart account created for the deposit |
+| `"submitted"` | `txHash: string`, `sourceChain: ChainId \| "unknown"`, `amount: string` | Deposit transaction submitted on the source chain |
+| `"complete"` | `txHash: string`, `destinationTxHash?: string`, `amount: string`, `sourceChain: ChainId \| "unknown"`, `sourceToken?: string`, `targetChain: number \| "solana"`, `targetToken: string` | Tokens arrived on the target chain |
+| `"failed"` | `txHash: string`, `error?: string` | Bridge or transfer failed after submission |
+| `"balance-changed"` | `totalUsd: number` | The user's total portfolio balance (USD) changed |
+| `"smart-account-changed"` | `evm: Address \| null`, `solana: string \| null` | The resolved smart account addresses changed |
 
-### onDepositSubmitted
+`amount` is the deposit amount in the token's smallest unit.
 
-Fires when the user signs and submits the deposit transaction on the source chain.
+<Warning>
+`sourceChain: "unknown"` is deposit-only. When a webhook-detected deposit
+arrives without chain or token information, `sourceChain` is `"unknown"` and
+`sourceToken` is `undefined` — handle this branch so you don't pick the wrong
+explorer URL.
+</Warning>
+
+### Withdraw events
+
+`WithdrawLifecycleEvent` carries the same `type` values minus `"balance-changed"`
+and `"smart-account-changed"`. Its `txHash` is `Hex`, `sourceChain` is always a
+`number`, `sourceToken` / `targetToken` are `Address`, and `"submitted"` adds a
+`safeAddress: Address` field.
+
+## onReady
+
+Fires once when the modal is initialized and ready for interaction. No payload.
 
 ```tsx
-onDepositSubmitted={(data) => {
-  console.log("Submitted:", data.txHash, "on chain", data.sourceChain);
-}}
+onReady={() => console.log("modal ready")}
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| `txHash` | `string` | Source chain transaction hash |
-| `sourceChain` | `number \| "solana"` | Source chain ID |
-| `amount` | `string` | Deposit amount in the token's smallest unit |
+## onError
 
-### onDepositComplete
-
-Fires when tokens arrive on the target chain (or when the bridge is submitted, if `waitForFinalTx` is `false`).
+Fires on errors at any stage — wallet connection, transaction signing, bridge
+setup — that prevent the deposit from being submitted. Distinct from the
+`"failed"` lifecycle event, which covers failures after the source transaction
+confirms.
 
 ```tsx
-onDepositComplete={(data) => {
-  console.log("Completed:", data.destinationTxHash);
-  console.log("Amount:", data.amount);
-}}
-```
-
-| Field | Type | Description |
-|---|---|---|
-| `txHash` | `string` | Source chain transaction hash |
-| `destinationTxHash` | `string \| undefined` | Target chain transaction hash. Absent when `waitForFinalTx` is `false`. |
-| `amount` | `string` | Amount transferred |
-| `sourceChain` | `number \| "solana"` | Source chain ID |
-| `sourceToken` | `string` | Source token address |
-| `targetChain` | `number` | Target chain ID |
-| `targetToken` | `string` | Target token address |
-
-### onDepositFailed
-
-Fires when the bridge fails after the deposit was submitted.
-
-```tsx
-onDepositFailed={(data) => {
-  console.log("Failed:", data.txHash, data.error);
-}}
-```
-
-| Field | Type | Description |
-|---|---|---|
-| `txHash` | `string` | Source chain transaction hash |
-| `error` | `string \| undefined` | Error message, if available |
-
-### onError
-
-Fires on errors at any stage — wallet connection, transaction signing, bridge setup, etc.
-
-```tsx
-onError={(data) => {
-  console.error(`[${data.code}] ${data.message}`);
-}}
+onError={(data) => console.error(`[${data.code}] ${data.message}`)}
 ```
 
 | Field | Type | Description |
@@ -131,25 +130,31 @@ For bridge-level error codes, see [deposit processing error codes](/deposits/api
 
 ## Error handling
 
-Errors can occur at different stages:
-
-| Stage | Callback | Typical causes |
+| Stage | Signal | Typical causes |
 |---|---|---|
 | Wallet connection | `onError` | User rejected connection, network error |
 | Transaction signing | `onError` | User rejected transaction, insufficient gas |
-| After submission | `onDepositFailed` | Bridge failure, timeout, price deviation |
+| After submission | `onLifecycle` `"failed"` | Bridge failure, timeout, price deviation |
 | Any stage | `onError` | Unexpected errors |
 
-`onError` fires for errors that prevent the deposit from being submitted. `onDepositFailed` fires for failures that happen after the source chain transaction is confirmed — at that point, the deposit service may [retry automatically](/deposits/api/deposit-processing#retries).
+After the source chain transaction confirms, the deposit service may
+[retry automatically](/deposits/api/deposit-processing#retries) before the
+`"failed"` event fires.
 
 ## Analytics
 
-The `onEvent` callback fires on granular user interactions for integration with your analytics pipeline.
+The `onEvent` callback fires on granular user interactions for your analytics
+pipeline. Its payload type is `DepositAnalyticsEvent` (or
+`WithdrawAnalyticsEvent`).
 
 ```tsx
-onEvent={(event) => {
+import type { DepositAnalyticsEvent } from "@rhinestone/deposit-modal";
+
+onEvent={(event: DepositAnalyticsEvent) => {
   analytics.track(event.type, event);
 }}
 ```
 
-Events include modal views (`*_open`) and CTA clicks (`*_cta_click`) at each step of the flow, with contextual properties like selected token, chain, and amount.
+Events include modal views (`*_open`) and CTA clicks (`*_cta_click`) at each
+step of the flow, with contextual properties like selected token, chain, and
+amount.

--- a/deposits/widget/withdraw-modal.mdx
+++ b/deposits/widget/withdraw-modal.mdx
@@ -24,8 +24,10 @@ import "@rhinestone/deposit-modal/styles.css";
   targetChain={10}
   targetToken="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
   reownAppId="YOUR_REOWN_PROJECT_ID"
-  onWithdrawComplete={(data) => {
-    console.log("Withdrawal complete:", data.destinationTxHash);
+  onLifecycle={(event) => {
+    if (event.type === "complete") {
+      console.log("Withdrawal complete:", event.destinationTxHash);
+    }
   }}
 />
 ```
@@ -86,7 +88,6 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 | `dappPublicClient` | `PublicClient` | — | Host-provided viem public client |
 | `onSignTransaction` | `(request: SafeTransactionRequest) => Promise<{ signature: Hex }>` | — | Custom Safe transaction signer |
 | `onRequestConnect` | `() => void` | — | Called when wallet connection needed |
-| `connectButtonLabel` | `string` | — | Custom connect button label |
 
 ### Transfer
 
@@ -102,7 +103,6 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 |---|---|---|---|
 | `sessionChainIds` | `number[]` | All supported | Chain IDs for session key creation |
 | `forceRegister` | `boolean` | `false` | Force session re-creation |
-| `waitForFinalTx` | `boolean` | `true` | Wait for destination chain confirmation |
 | `signerAddress` | `Address` | Default signer | Session signer address |
 | `rhinestoneApiKey` | `string` | — | API key for account setup |
 
@@ -120,7 +120,6 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 | `closeOnOverlayClick` | `boolean` | `true` | Close modal on backdrop click |
 | `className` | `string` | — | CSS class for the modal container |
 | `theme` | `DepositModalTheme` | — | [Theme configuration](/deposits/widget/customization#theme) |
-| `branding` | `DepositModalBranding` | — | [Branding configuration](/deposits/widget/customization#branding) |
 | `uiConfig` | `DepositModalUIConfig` | — | [UI configuration](/deposits/widget/customization#ui-configuration) |
 | `debug` | `boolean` | `false` | Enable debug logging |
 
@@ -129,9 +128,8 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 | Prop | Type | Description |
 |---|---|---|
 | `onReady` | `() => void` | Modal initialized |
-| `onConnected` | `(data: ConnectedEventData) => void` | Smart account created |
-| `onWithdrawSubmitted` | `(data: WithdrawSubmittedEventData) => void` | Withdrawal transaction submitted |
-| `onWithdrawComplete` | `(data: WithdrawCompleteEventData) => void` | Tokens arrived on target chain |
-| `onWithdrawFailed` | `(data: WithdrawFailedEventData) => void` | Withdrawal failed |
+| `onLifecycle` | `(event: WithdrawLifecycleEvent) => void` | [Lifecycle event](/deposits/widget/status-tracking#onlifecycle) — switch on `event.type` (`connected`, `submitted`, `complete`, `failed`) |
 | `onError` | `(data: ErrorEventData) => void` | Error at any stage |
-| `onEvent` | `(event: WithdrawEvent) => void` | Analytics event |
+| `onEvent` | `(event: WithdrawAnalyticsEvent) => void` | [Analytics event](/deposits/widget/status-tracking#analytics) |
+
+`WithdrawLifecycleEvent` has no `balance-changed` or `smart-account-changed` variants, and its payload types differ from the deposit union: `txHash` is `Hex`, `sourceChain` is always a `number`, `sourceToken` / `targetToken` are `Address`, and `"submitted"` carries a `safeAddress`.

--- a/docs.json
+++ b/docs.json
@@ -263,7 +263,8 @@
               "deposits/widget/deposit-modal",
               "deposits/widget/withdraw-modal",
               "deposits/widget/customization",
-              "deposits/widget/status-tracking"
+              "deposits/widget/status-tracking",
+              "deposits/widget/migration"
             ]
           }
         ]


### PR DESCRIPTION
Aligns the deposit widget docs with `@rhinestone/deposit-modal` v0.3.0.

- Add a compact widget **migration page** (per-event callbacks → `onLifecycle`, analytics type rename, removed `connectButtonLabel` + `/reown` `/safe` subpaths).
- Update the widget pages to `onLifecycle` and drop props that no longer exist (`connectButtonLabel`, `branding`, `waitForFinalTx`, stale `uiConfig` fields).
- Document `dappImports` — importing balances from other apps (e.g. Polymarket).
- Add the new page to `docs.json` nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)