### PR TITLE
docs: document session policies in 1.x migration guide

### DIFF
--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -143,7 +143,19 @@ const session = toSession({
 })
 ```
 
-The map accepts `sudo`, `universalAction`, `argPolicy`, `spendingLimits`, `timeFrame`, `usageLimit`, and `valueLimit`. New accounts need none of this — the V2 defaults are correct.
+The singletons that changed between V1 and V2 — pin the ones your account's sessions were enabled against:
+
+| `policyAddresses` key | Policy | V1 address | V2 address (default) |
+| --- | --- | --- | --- |
+| `sudo` | [Sudo](../smart-sessions/policies/sudo) | `0x0000003111cD8e92337C100F22B7A9dbf8DEE301` | `0x0000000000FEEc8D74e3143fBaBbca515358d869` |
+| `universalAction` | [Call](../smart-sessions/policies/call) | `0x0000006DDA6c463511C4e9B05CFc34C1247fCF1F` | `0x0000000000714Cf48FcF88A0bFBa70d313415032` |
+| `argPolicy` | Arg policy | — (new in V2) | `0x0000000000167edE64D8751daACDdC0312565a73` |
+| `spendingLimits` | [Spending limit](../smart-sessions/policies/spending-limit) | `0x00000088D48cF102A8Cdb0137A9b173f957c6343` | `0x000000000033212E272655D8a22402Db819477A6` |
+| `timeFrame` | [Timeframe](../smart-sessions/policies/timeframe) | `0x8177451511dE0577b911C254E9551D981C26dc72` | `0x0000000000D30f611fA3bf652ac6879428586930` |
+| `usageLimit` | [Usage limit](../smart-sessions/policies/usage-limit) | `0x1F34eF8311345A3A4a4566aF321b313052F51493` | `0x00000000001d4479FA2A947026204d0283ceDe4B` |
+| `valueLimit` | Value limit | `0x730DA93267E7E513e932301B47F2ac7D062abC83` | `0x000000000021dC45451291BCDfc9f0B46d6f0278` |
+
+`argPolicy` is new in V2 and has no V1 equivalent — a session enabled under V1 never used it, so there's nothing to pin. New accounts need none of this; the V2 defaults are correct.
 
 ### Quote selection
 

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -127,7 +127,7 @@ Passing a raw `policies` array on a permission now throws instead of being silen
 
 ### Session policy addresses
 
-The SmartSession policy singletons were redeployed for V2, and `toSession` now bakes the new (V2) addresses into the session digest by default. If an account already enabled sessions against the **previous** deployments, re-encoding that session under the new SDK binds different policy addresses into the digest preimage — the recomputed digest diverges from the signature the user originally produced, and `_enableSession` reverts on-chain with `HashMismatch`.
+The smart session policies were redeployed, and `toSession` now bakes the new addresses into the session digest by default. If an account already enabled sessions against the previous deployments, trying to use the existing session with the new policies results in an onchain revert due to the digest mismatch.
 
 Pin the affected policies back to the addresses the account was enabled against via `SessionDefinition.policyAddresses`. It's a partial map — only override what you need; everything else falls back to the V2 default:
 

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -145,7 +145,7 @@ const session = toSession({
 
 The singletons that changed between V1 and V2 — pin the ones your account's sessions were enabled against:
 
-| Policy | `policyAddresses` key | V1 address | V2 address (default) |
+| Policy | Key | V1 address | V2 address (default) |
 | --- | --- | --- | --- |
 | [Sudo](../smart-sessions/policies/sudo) | `sudo` | `0x0000003111cD8e92337C100F22B7A9dbf8DEE301` | `0x0000000000FEEc8D74e3143fBaBbca515358d869` |
 | [Call](../smart-sessions/policies/call) | `universalAction` | `0x0000006DDA6c463511C4e9B05CFc34C1247fCF1F` | `0x0000000000714Cf48FcF88A0bFBa70d313415032` |

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -129,7 +129,7 @@ Passing a raw `policies` array on a permission now throws instead of being silen
 
 The smart session policies were redeployed, and `toSession` now bakes the new addresses into the session digest by default. If an account already enabled sessions against the previous deployments, trying to use the existing session with the new policies results in an onchain revert due to the digest mismatch.
 
-Pin the affected policies back to the addresses the account was enabled against via `SessionDefinition.policyAddresses`. It's a partial map — only override what you need; everything else falls back to the V2 default:
+Pin the affected policies back to the addresses the account was enabled against via `SessionDefinition.policyAddresses`:
 
 ```ts
 const session = toSession({

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -155,8 +155,6 @@ The singletons that changed between V1 and V2 — pin the ones your account's se
 | [Usage limit](../smart-sessions/policies/usage-limit) | `usageLimit` | `0x1F34eF8311345A3A4a4566aF321b313052F51493` | `0x00000000001d4479FA2A947026204d0283ceDe4B` |
 | Value limit | `valueLimit` | `0x730DA93267E7E513e932301B47F2ac7D062abC83` | `0x000000000021dC45451291BCDfc9f0B46d6f0278` |
 
-`argPolicy` is new in V2 and has no V1 equivalent — a session enabled under V1 never used it, so there's nothing to pin. New accounts need none of this; the V2 defaults are correct.
-
 ### Quote selection
 
 `prepareTransaction` now returns `quotes: { best, all }` instead of a single `quote`. Existing `prepare → sign → submit` code keeps working — `signTransaction` defaults to `quotes.best`:

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -145,15 +145,15 @@ const session = toSession({
 
 The singletons that changed between V1 and V2 — pin the ones your account's sessions were enabled against:
 
-| `policyAddresses` key | Policy | V1 address | V2 address (default) |
+| Policy | `policyAddresses` key | V1 address | V2 address (default) |
 | --- | --- | --- | --- |
-| `sudo` | [Sudo](../smart-sessions/policies/sudo) | `0x0000003111cD8e92337C100F22B7A9dbf8DEE301` | `0x0000000000FEEc8D74e3143fBaBbca515358d869` |
-| `universalAction` | [Call](../smart-sessions/policies/call) | `0x0000006DDA6c463511C4e9B05CFc34C1247fCF1F` | `0x0000000000714Cf48FcF88A0bFBa70d313415032` |
-| `argPolicy` | Arg policy | — (new in V2) | `0x0000000000167edE64D8751daACDdC0312565a73` |
-| `spendingLimits` | [Spending limit](../smart-sessions/policies/spending-limit) | `0x00000088D48cF102A8Cdb0137A9b173f957c6343` | `0x000000000033212E272655D8a22402Db819477A6` |
-| `timeFrame` | [Timeframe](../smart-sessions/policies/timeframe) | `0x8177451511dE0577b911C254E9551D981C26dc72` | `0x0000000000D30f611fA3bf652ac6879428586930` |
-| `usageLimit` | [Usage limit](../smart-sessions/policies/usage-limit) | `0x1F34eF8311345A3A4a4566aF321b313052F51493` | `0x00000000001d4479FA2A947026204d0283ceDe4B` |
-| `valueLimit` | Value limit | `0x730DA93267E7E513e932301B47F2ac7D062abC83` | `0x000000000021dC45451291BCDfc9f0B46d6f0278` |
+| [Sudo](../smart-sessions/policies/sudo) | `sudo` | `0x0000003111cD8e92337C100F22B7A9dbf8DEE301` | `0x0000000000FEEc8D74e3143fBaBbca515358d869` |
+| [Call](../smart-sessions/policies/call) | `universalAction` | `0x0000006DDA6c463511C4e9B05CFc34C1247fCF1F` | `0x0000000000714Cf48FcF88A0bFBa70d313415032` |
+| Arg policy | `argPolicy` | — (new in V2) | `0x0000000000167edE64D8751daACDdC0312565a73` |
+| [Spending limit](../smart-sessions/policies/spending-limit) | `spendingLimits` | `0x00000088D48cF102A8Cdb0137A9b173f957c6343` | `0x000000000033212E272655D8a22402Db819477A6` |
+| [Timeframe](../smart-sessions/policies/timeframe) | `timeFrame` | `0x8177451511dE0577b911C254E9551D981C26dc72` | `0x0000000000D30f611fA3bf652ac6879428586930` |
+| [Usage limit](../smart-sessions/policies/usage-limit) | `usageLimit` | `0x1F34eF8311345A3A4a4566aF321b313052F51493` | `0x00000000001d4479FA2A947026204d0283ceDe4B` |
+| Value limit | `valueLimit` | `0x730DA93267E7E513e932301B47F2ac7D062abC83` | `0x000000000021dC45451291BCDfc9f0B46d6f0278` |
 
 `argPolicy` is new in V2 and has no V1 equivalent — a session enabled under V1 never used it, so there's nothing to pin. New accounts need none of this; the V2 defaults are correct.
 

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -93,6 +93,58 @@ const session = toSession({
 
 The hand-written shape is now `SessionDefinition`; `Session` is the resolved output of `toSession`.
 
+### Session policies are declarative
+
+In 1.x, each `action` carried a raw `policies` array that you assembled by hand. Those arrays are gone — policies are now expressed through fields on the permission's function config, and `toSession` compiles them into the right on-chain policies:
+
+- `params: { x: { anyOf: [a, b] } }` — allowlist a parameter against several values (compiles to an arg-policy OR chain). A single `{ condition, value }` stays a cheaper universal-action.
+- `maxUses` — cap how many times the function may be called.
+- `validUntil` / `validAfter` — restrict the function to a time window (`Date` or ms-epoch).
+- `valueLimit` — cap cumulative ETH value (payable functions only; rejected at compile time otherwise).
+- `spendingLimit: { token, amount }` — cap cumulative ERC-20 spend (only on `transfer` / `transferFrom` / `approve` / `increaseAllowance`-shaped functions).
+
+```ts
+const session = toSession({
+  chain: base,
+  owners: { type: 'ecdsa', accounts: [sessionOwner] },
+  permissions: [
+    {
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: {
+        transfer: {
+          params: { recipient: { anyOf: [alice, bob] } },
+          spendingLimit: { token: usdcAddress, amount: 1_000_000n },
+          maxUses: 10n,
+        },
+      },
+    },
+  ],
+})
+```
+
+Passing a raw `policies` array on a permission now throws instead of being silently dropped. See [Policies](../smart-sessions/policies/sudo) for the full set.
+
+### Session policy addresses
+
+The SmartSession policy singletons were redeployed for V2, and `toSession` now bakes the new (V2) addresses into the session digest by default. If an account already enabled sessions against the **previous** deployments, re-encoding that session under the new SDK binds different policy addresses into the digest preimage — the recomputed digest diverges from the signature the user originally produced, and `_enableSession` reverts on-chain with `HashMismatch`.
+
+Pin the affected policies back to the addresses the account was enabled against via `SessionDefinition.policyAddresses`. It's a partial map — only override what you need; everything else falls back to the V2 default:
+
+```ts
+const session = toSession({
+  chain: base,
+  owners: { type: 'ecdsa', accounts: [sessionOwner] },
+  permissions: [/* … */],
+  policyAddresses: {
+    // legacy V1 sudo policy
+    sudo: '0x0000003111cD8e92337C100F22B7A9dbf8DEE301',
+  },
+})
+```
+
+The map accepts `sudo`, `universalAction`, `argPolicy`, `spendingLimits`, `timeFrame`, `usageLimit`, and `valueLimit`. New accounts need none of this — the V2 defaults are correct.
+
 ### Quote selection
 
 `prepareTransaction` now returns `quotes: { best, all }` instead of a single `quote`. Existing `prepare → sign → submit` code keeps working — `signTransaction` defaults to `quotes.best`:


### PR DESCRIPTION
Adds two subsections to the **Migrating from 1.x SDK** part of the migration guide, covering the SmartSession policy changes shipped in SDK [#542](https://github.com/rhinestonewtf/sdk/pull/542) and the legacy-pin fix in deposit-service-processor [#390](https://github.com/rhinestonewtf/deposit-service-processor/pull/390).

- **Session policies are declarative** — raw `policies` arrays are replaced by permission function fields (`anyOf`, `maxUses`, `validUntil`/`validAfter`, `valueLimit`, `spendingLimit`); a raw `policies` array now throws.
- **Session policy addresses** — `policyAddresses` pinning for accounts already enabled against the previous policy deployments, avoiding the on-chain `HashMismatch` when a session is re-encoded under the V2 defaults.

`bunx mintlify broken-links` passes.