### PR TITLE
docs: complete legacy policy addresses in address book

### DIFF
--- a/home/resources/address-book.mdx
+++ b/home/resources/address-book.mdx
@@ -87,7 +87,10 @@ Additional variables:
 | :-------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
 | ERC20 Spending Limit Policy | [0x00000088D48cF102A8Cdb0137A9b173f957c6343](https://contractscan.xyz/contract/0x00000088D48cF102A8Cdb0137A9b173f957c6343) |
 | Universal Action Policy     | [0x0000006DDA6c463511C4e9B05CFc34C1247fCF1F](https://contractscan.xyz/contract/0x0000006DDA6c463511C4e9B05CFc34C1247fCF1F) |
+| Usage Limit Policy          | [0x1F34eF8311345A3A4a4566aF321b313052F51493](https://contractscan.xyz/contract/0x1F34eF8311345A3A4a4566aF321b313052F51493) |
 | Sudo Policy                 | [0x0000003111cD8e92337C100F22B7A9dbf8DEE301](https://contractscan.xyz/contract/0x0000003111cD8e92337C100F22B7A9dbf8DEE301) |
+| Time-Frame Policy           | [0x8177451511dE0577b911C254E9551D981C26dc72](https://contractscan.xyz/contract/0x8177451511dE0577b911C254E9551D981C26dc72) |
+| Value Limit Policy          | [0x730DA93267E7E513e932301B47F2ac7D062abC83](https://contractscan.xyz/contract/0x730DA93267E7E513e932301B47F2ac7D062abC83) |
 
 ### Mocks
 


### PR DESCRIPTION
The current policy singletons under **V1 → Policies** already list the latest deployments. The **Legacy → Policies** block only had Sudo, Universal Action, and ERC20 Spending Limit — this adds the three other superseded singletons (Time-Frame, Usage Limit, Value Limit) so the legacy set is complete.

Reference for the V1↔V2 mapping: the [migration guide](https://docs.rhinestone.dev/smart-wallet/advanced/migration-guide#session-policy-addresses).