### PR TITLE
docs: note Safe placeholder owner for passkey/multi-factor accounts

### DIFF
--- a/smart-wallet/customize/smart-account-providers.mdx
+++ b/smart-wallet/customize/smart-account-providers.mdx
@@ -13,6 +13,10 @@ const rhinestoneAccount = await rhinestone.createAccount({
     type: 'safe',
   },
   owners: {
+    // ECDSA/ENS owners become the Safe's native owner. Passkey/multi-factor
+    // owners have no EOA, so the native owner is set to the NoSafeOwner
+    // contract (0xbabe99…5e72), which rejects every signature — the native
+    // owner path is dead and auth runs solely through the 7579 validators.
     type: 'ecdsa',
     accounts: [account],
   },


### PR DESCRIPTION
Inline comment in the Safe code block explaining the `NoSafeOwner` placeholder the SDK sets when a Safe is created with a `passkey` or `multi-factor` owner set.

Passkey/multi-factor owners have no EOA to register as the Safe's native owner, so the SDK sets the deployed `NoSafeOwner` contract (`0xbabe99…5e72`) as the native owner. Its `isValidSignature` always returns the failure value, so the native `execTransaction` path can never validate (`GS024`) — authorization runs solely through the ERC-7579 validator modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)