### PR TITLE
docs: new /check response format with CAIP-2 sources

### DIFF
--- a/deposits/api/account-registration.mdx
+++ b/deposits/api/account-registration.mdx
@@ -96,9 +96,18 @@ const data = await check.json();
   "isRegistered": true,
   "targetChain": "eip155:42161",
   "targetToken": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-  "sourceChains": ["eip155:8453", "eip155:10", "eip155:42161"]
+  "sources": [
+    { "chain": "eip155:8453", "depositAddress": "<evmDepositAddress>" },
+    { "chain": "eip155:42161", "depositAddress": "<evmDepositAddress>" },
+    {
+      "chain": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "depositAddress": "<solanaDepositAddress>"
+    }
+  ]
 }
 ```
+
+`sources` lists every chain the account can receive deposits from, each with its deposit address — EVM chains share the `evmDepositAddress`, Solana carries the `solanaDepositAddress`.
 
 </Step>
 </Steps>
@@ -202,7 +211,7 @@ The JSON replacer `(_, v) => typeof v === "bigint" ? v.toString() : v` is needed
 ```ts
 const check = await fetch(`${DEPOSIT_SERVICE_URL}/check/${address}`);
 const data = await check.json();
-// { isRegistered: true, targetChain: "eip155:42161", ... }
+// { isRegistered: true, targetChain: "eip155:42161", sources: [...] }
 ```
 
 </Step>

--- a/deposits/api/quickstart.mdx
+++ b/deposits/api/quickstart.mdx
@@ -104,7 +104,11 @@ You should see:
   "isRegistered": true,
   "targetChain": "eip155:84532",
   "targetToken": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-  "sourceChains": ["eip155:84532", "eip155:11155420", "eip155:421614"]
+  "sources": [
+    { "chain": "eip155:84532", "depositAddress": "<evmDepositAddress>" },
+    { "chain": "eip155:11155420", "depositAddress": "<evmDepositAddress>" },
+    { "chain": "eip155:421614", "depositAddress": "<evmDepositAddress>" }
+  ]
 }
 ```
 


### PR DESCRIPTION
Updates the Deposits API docs to the new `/check/{address}` response format: a unified, CAIP-2-keyed `sources` array (chain + deposit address) that covers EVM, Solana, and Tron identically. Drops the legacy `sourceChains` field from the examples.

- `account-registration.mdx` (managed) — `sources` with EVM + Solana entries
- `account-registration.mdx` (user-owned) — inline comment updated
- `quickstart.mdx` — EVM-only `sources` (testnet)

Documents the response shape introduced in deposit-service-processor#397.