### PR TITLE
chore: add context7 library claim file

### DIFF
--- a/public/context7.json
+++ b/public/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/rhinestone_dev",
+  "public_key": "pk_3YNHBdkQM5LaJvYHAeSyL"
+}


### PR DESCRIPTION
Adds the Context7 ownership verification file so we can claim the `rhinestone_dev` library on Context7.

Once deployed, it's reachable at `https://docs.rhinestone.dev/public/context7.json`, which is the URL used to verify ownership.