### PR TITLE
chore: add update-screenshots skill

### DIFF
--- a/.claude/skills/update-screenshots/SKILL.md
+++ b/.claude/skills/update-screenshots/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: update-screenshots
+description: Capture or refresh the Rhinestone dashboard screenshots used by the docs guides, using mock/stubbed data and no backend stack. Use when screenshots under images/dashboard/ are stale (dashboard redesign, new guide, changed labels) and need re-shooting.
+---
+
+# Update dashboard screenshots
+
+Re-captures the dashboard screenshots that the docs guides embed (everything under `images/dashboard/<guide>/`). It runs the **real dashboard** dev server against a **mock user-service** that returns stubbed JSON, then drives a headless browser to screenshot each screen and modal. No postgres/redis/KMS/orchestrator needed.
+
+Why this works: dashboard auth is entirely client-side — `pages/Main.vue` only checks `authClient.useSession()` (better-auth `GET /users/auth/get-session`); every other call is a `credentials:'include'` fetch. Return a non-null session + stubbed data and the app renders fully populated.
+
+## Prerequisites
+
+- A local checkout of the `dashboard` repo (sibling to this `docs` repo by default; override with `DASHBOARD_DIR`).
+- `bun` (runs the mock + the dashboard dev server).
+- A Playwright install + a chromium browser. The capture script auto-discovers both (npx cache + `~/.cache/ms-playwright`), or set `PLAYWRIGHT_PATH` / `CHROME_BIN`.
+
+## Steps
+
+1. **Check what the guides reference.** Grep the guides for image paths so the shot list matches reality:
+   ```bash
+   grep -rho '/images/dashboard/[^"]*' --include=*.mdx . | sort -u
+   ```
+   If a guide added/renamed a shot, add a matching capture in `scripts/shoot.mjs` (see "Adding a shot").
+
+2. **Disable the Vue devtools plugin** in the dashboard's `vite.config.ts` (comment out `VueDevTools()`). Otherwise its floating "V" pill appears in every full-page shot. **Remember to restore it after.** (CSS-hiding the host element does not work — it renders in a shadow root.)
+
+3. **Point the dashboard at the mock.** In the dashboard `.env`:
+   ```
+   VITE_USER_SERVICE_BASE_URL=http://localhost:3000
+   VITE_APP_BASE_URL=http://localhost:5173
+   ```
+   Set the mock org's `ORG_ID` (in `scripts/mock-user-service.ts`) equal to `VITE_RHINESTONE_ORG_ID` to show the brand mark.
+
+4. **Boot both servers.** Background them with `setsid` (see Gotchas):
+   ```bash
+   setsid bash -c 'bun run <skill>/scripts/mock-user-service.ts >/tmp/mock.log 2>&1' </dev/null >/dev/null 2>&1 &
+   cd "$DASHBOARD_DIR" && setsid bash -c 'bun run dev >/tmp/dash.log 2>&1' </dev/null >/dev/null 2>&1 &
+   sleep 4
+   curl -s -o /dev/null -w 'mock:%{http_code} ' http://localhost:3000/users/me
+   curl -s -o /dev/null -w 'dash:%{http_code}\n' http://localhost:5173/
+   ```
+   Both should report `200`.
+
+5. **Capture.** `node <skill>/scripts/shoot.mjs` — writes PNGs into `images/dashboard/<guide>/` (auto-resolved relative to the skill; override with `SCREENSHOT_OUT`). It prints `OK`/`FAIL` per shot.
+
+6. **Review every shot** by reading the PNGs. Check: auth passed (not stuck on `/login`), data populated, correct dialog, no stray toasts, dark theme. Re-run after fixing the mock data or the script.
+
+7. **Validate links** and **clean up**: `bunx mintlify broken-links` (no new broken image refs); remove orphaned old screenshots; **restore `vite.config.ts`**; stop the servers (kill by PID — never `pkill -f vite`, see Gotchas).
+
+## Adding a shot
+
+In `scripts/shoot.mjs`, navigate to the route and call `shoot(page, '<guide>/<name>.png')`. For a modal, open it then `shoot(page, '<guide>/<name>.png', { dialog: true })` (crops to `[role="dialog"]`). For an unauthenticated screen, stub the session to null first: `page.route('**/users/auth/get-session*', r => r.fulfill({ body: 'null' }))`.
+
+Role-gated controls (Create key, scopes editor, Refund) only render when the mock session `user.email` matches an org member with role OWNER/ADMIN — keep them aligned in `mock-user-service.ts`.
+
+## Gotchas
+
+- **Backgrounding:** use `setsid bash -c '…' </dev/null &`. A plain `&` (or a harness "run in background") gets the server killed by a signal (exit 144) when the launching turn ends.
+- **Killing servers:** never `pkill -f "vite"` / `pgrep -f "vite"` — the pattern matches the shell running your own command and kills it (also exit 144). Find the PID (`pgrep -af vite`) and `kill <pid>`.
+- **Playwright MCP** leaves a stale chrome `SingletonLock` ("Browser is already in use"). This skill drives Playwright via a script instead — don't mix the two.
+- **CORS:** the mock must reflect the dashboard origin and `Access-Control-Allow-Credentials: true`, and answer `OPTIONS` (the service sets `Content-Type` on GETs, triggering preflight). Already handled in `scripts/mock-user-service.ts`.
+
+## Files
+
+- `scripts/mock-user-service.ts` — stub user-service (edit the data constants to change what renders).
+- `scripts/shoot.mjs` — the capture script (edit the shot list / viewport).

--- a/.claude/skills/update-screenshots/scripts/mock-user-service.ts
+++ b/.claude/skills/update-screenshots/scripts/mock-user-service.ts
@@ -111,16 +111,17 @@ const createdApiKey = {
   plaintext: 'rh_sk_live_9Hb3kQ7tWmZ2pX4vN8sLcRf6yJ0aD1gUe2c8',
 }
 
+const CORS = {
+  'Access-Control-Allow-Origin': ORIGIN,
+  'Access-Control-Allow-Credentials': 'true',
+  'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+}
+
 function json(body: unknown, status = 200): Response {
-  return new Response(body === null ? 'null' : JSON.stringify(body), {
+  return new Response(JSON.stringify(body), {
     status,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': ORIGIN,
-      'Access-Control-Allow-Credentials': 'true',
-      'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type,Authorization',
-    },
+    headers: { 'Content-Type': 'application/json', ...CORS },
   })
 }
 
@@ -129,7 +130,9 @@ Bun.serve({
   fetch(req) {
     const p = new URL(req.url).pathname
     const m = req.method
-    if (m === 'OPTIONS') return json(null, 204)
+    // 204 is a null-body status — return an empty body so the preflight is
+    // spec-compliant on strict Fetch runtimes (Bun tolerates a body; others reject).
+    if (m === 'OPTIONS') return new Response(null, { status: 204, headers: CORS })
     if (p === '/users/auth/get-session') return json(SESSION)
     if (p === '/users/me' && m === 'GET') return json({ org: { orgId: ORG_ID, org: { name: 'Rhinestone' } } })
     if (p === '/users/me/projects' && m === 'GET') return json([PROJECT])

--- a/.claude/skills/update-screenshots/scripts/mock-user-service.ts
+++ b/.claude/skills/update-screenshots/scripts/mock-user-service.ts
@@ -1,0 +1,151 @@
+// Mock user-service for dashboard screenshots. Pure Bun.serve, no deps.
+// Returns stubbed JSON for every endpoint the dashboard hits, with CORS that
+// satisfies credentials:'include' from the Vite dev origin.
+//
+// Run: bun run mock-user-service.ts   (listens on :3000)
+// Edit the data constants below to change what renders in the screenshots.
+
+const ORIGIN = process.env.DASHBOARD_ORIGIN || 'http://localhost:5173'
+const ORG_ID = 'cmpv8v6wa0000ht5ilfoh2tp4' // set equal to VITE_RHINESTONE_ORG_ID for the brand mark
+const PROJECT_ID = 'proj_rhinestone_prod'
+
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString()
+const MIN = 60_000
+const HOUR = 60 * MIN
+const DAY = 24 * HOUR
+
+// The signed-in user. Their email MUST match an ACTIVE OWNER/ADMIN member in
+// ORG below, or role-gated controls (Create key, scopes, Refund) won't render.
+const USER = {
+  id: 'user_kurt',
+  name: 'Kurt Larsen',
+  email: 'kurt@rhinestone.dev',
+  emailVerified: true,
+  image: null,
+  createdAt: ago(120 * DAY),
+  updatedAt: ago(1 * DAY),
+}
+
+const SESSION = {
+  session: {
+    id: 'sess_1',
+    token: 'mock-session-token',
+    userId: USER.id,
+    expiresAt: new Date(Date.now() + 7 * DAY).toISOString(),
+    createdAt: ago(1 * HOUR),
+    updatedAt: ago(1 * HOUR),
+    ipAddress: '127.0.0.1',
+    userAgent: 'mock',
+  },
+  user: USER,
+}
+
+const SCOPES_FULL = { allowMainnet: true, intents: 'write', deposits: 'write' }
+const SCOPES_LIMITED = { allowMainnet: false, intents: 'read', deposits: 'none' }
+
+const API_KEYS = [
+  { id: 'key_prod', name: 'prod', lastChars: 'a4f9', createdAt: ago(12 * DAY), lastUsedAt: ago(2 * HOUR), revokedAt: null, scopes: SCOPES_FULL },
+  { id: 'key_ci', name: 'ci-staging', lastChars: '7b2e', createdAt: ago(5 * DAY), lastUsedAt: ago(3 * DAY), revokedAt: null, scopes: SCOPES_LIMITED },
+]
+
+const PROJECT = { id: PROJECT_ID, name: 'Production', org: { name: 'Rhinestone' }, apiKeys: API_KEYS }
+
+const ORG = {
+  name: 'Rhinestone',
+  members: [
+    { id: 'm_kurt', role: 'OWNER', status: 'ACTIVE', email: 'kurt@rhinestone.dev', user: { name: 'Kurt Larsen', image: '', email: 'kurt@rhinestone.dev' } },
+    { id: 'm_konrad', role: 'ADMIN', status: 'ACTIVE', email: 'konrad@rhinestone.dev', user: { name: 'Konrad Kopp', image: '', email: 'konrad@rhinestone.dev' } },
+    { id: 'm_alex', role: 'MEMBER', status: 'PENDING', email: 'alex@rhinestone.dev', user: null },
+  ],
+}
+
+const JWT_KEYS = [
+  { id: 'jwt_prod', kid: 'prod-2026-06', integratorId: 'rhinestone', algorithm: 'ES256', enabled: true, createdAt: ago(5 * DAY) },
+]
+
+const SPONSORSHIPS = [
+  { projectId: PROJECT_ID, address: '0x8a911a7e3a0bff0f9f0e9b2d3b9f1c2d4e5f6a7b', pendingDisbursements: 0, credits: '0' },
+]
+
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const USDC_ARB = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+
+const deposit = (o: Record<string, unknown>) => ({
+  chain: 'eip155:42161', txHash: '0x' + '00'.repeat(32), token: USDC_ARB, amount: '100000000',
+  sender: '0x1111111111111111111111111111111111111111', account: '0x2222222222222222222222222222222222222222',
+  targetChain: 'eip155:8453', targetToken: USDC_BASE, status: 'completed', errorCode: null, retryable: false,
+  sourceTxHash: '0x' + '11'.repeat(32), destinationTxHash: '0x' + '22'.repeat(32),
+  sourceAmount: '100000000', destinationAmount: '99800000', createdAt: ago(2 * HOUR), completedAt: ago(2 * HOUR + 30_000), ...o,
+})
+
+const DEPOSITS = [
+  deposit({ txHash: '0xa1' + '00'.repeat(31), amount: '250000000', sourceAmount: '250000000', destinationAmount: '249500000', createdAt: ago(35 * MIN), completedAt: ago(34 * MIN), account: '0x3333333333333333333333333333333333333333' }),
+  deposit({ txHash: '0xb2' + '00'.repeat(31), chain: 'eip155:8453', token: USDC_BASE, status: 'processing', amount: '50000000', sourceAmount: '50000000', destinationAmount: null, destinationTxHash: null, completedAt: null, createdAt: ago(6 * MIN), account: '0x4444444444444444444444444444444444444444' }),
+  // failed + retryable on an EVM chain -> shows both Retry and Refund (OWNER/ADMIN)
+  deposit({ txHash: '0xc3' + '00'.repeat(31), chain: 'eip155:56', token: '0x55d398326f99059fF775485246999027B3197955', status: 'failed', retryable: true, errorCode: 'BRIDGE-1', amount: '120000000000000000000', sourceAmount: '120000000000000000000', destinationAmount: null, sourceTxHash: '0x' + '33'.repeat(32), destinationTxHash: null, completedAt: null, createdAt: ago(50 * MIN), account: '0x5555555555555555555555555555555555555555' }),
+  deposit({ txHash: '0xd4' + '00'.repeat(31), createdAt: ago(3 * HOUR), completedAt: ago(3 * HOUR - 40_000), account: '0x6666666666666666666666666666666666666666' }),
+]
+
+const DEPOSIT_STATS = { totalDeposits: 1284, uniqueUsers: 342, volumeUsd: '48213.55' }
+
+let intentSeq = 0
+const intent = (o: Record<string, unknown>) => ({
+  id: 'int_' + (intentSeq++).toString(36).padStart(6, '0'),
+  status: 'COMPLETED', fromChains: [42161], toChain: 8453, token: USDC_BASE, amount: '100000000',
+  account: '0x2222222222222222222222222222222222222222', createdAt: Math.floor((Date.now() - 2 * HOUR) / 1000), ...o,
+})
+
+const INTENTS = {
+  data: [
+    intent({ createdAt: Math.floor((Date.now() - 12 * MIN) / 1000), amount: '250000000' }),
+    intent({ status: 'PENDING', token: USDC_ARB, toChain: 42161, fromChains: [8453], amount: '100000000', createdAt: Math.floor((Date.now() - 40 * MIN) / 1000) }),
+    intent({ amount: '75000000', createdAt: Math.floor((Date.now() - 3 * HOUR) / 1000) }),
+    intent({ status: 'FAILED', amount: '500000000', createdAt: Math.floor((Date.now() - 8 * HOUR) / 1000) }),
+  ],
+  pagination: { nextCursor: null, hasNextPage: false },
+}
+
+const createdApiKey = {
+  id: 'key_new', name: 'mobile-app', lastChars: 'e2c8', createdAt: new Date().toISOString(),
+  lastUsedAt: null, revokedAt: null, scopes: SCOPES_FULL,
+  plaintext: 'rh_sk_live_9Hb3kQ7tWmZ2pX4vN8sLcRf6yJ0aD1gUe2c8',
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(body === null ? 'null' : JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': ORIGIN,
+      'Access-Control-Allow-Credentials': 'true',
+      'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+    },
+  })
+}
+
+Bun.serve({
+  port: 3000,
+  fetch(req) {
+    const p = new URL(req.url).pathname
+    const m = req.method
+    if (m === 'OPTIONS') return json(null, 204)
+    if (p === '/users/auth/get-session') return json(SESSION)
+    if (p === '/users/me' && m === 'GET') return json({ org: { orgId: ORG_ID, org: { name: 'Rhinestone' } } })
+    if (p === '/users/me/projects' && m === 'GET') return json([PROJECT])
+    if (p === '/users/me/org' && m === 'GET') return json(ORG)
+    if (p === '/users/me/invite') return json({ message: 'no invite' }, 404)
+    if (p === '/users/me/sponsorships') return json(SPONSORSHIPS)
+    if (p === '/users/me/deposits' && m === 'GET') return json({ deposits: DEPOSITS, nextCursor: null })
+    if (p === '/users/me/deposits/stats') return json(DEPOSIT_STATS)
+    if (p.endsWith('/integrator-keys') && m === 'GET') return json(JWT_KEYS)
+    if (p === '/users/me/intents' && m === 'GET') return json(INTENTS)
+    if (p.endsWith('/api-keys') && m === 'POST') return json(createdApiKey)
+    if (p.endsWith('/integrator-keys') && m === 'POST') return json({ ...JWT_KEYS[0], id: 'jwt_new', kid: 'mobile-2026-06' })
+    if (p.includes('/api-keys/') && m === 'PATCH') return json({ ...API_KEYS[0] })
+    if (p.includes('/revoke')) return json({ ...API_KEYS[0], revokedAt: new Date().toISOString() })
+    return json({ ok: true })
+  },
+})
+
+console.log('mock user-service on http://localhost:3000')

--- a/.claude/skills/update-screenshots/scripts/shoot.mjs
+++ b/.claude/skills/update-screenshots/scripts/shoot.mjs
@@ -1,0 +1,190 @@
+// Capture dashboard screenshots into images/dashboard/<guide>/.
+// Run: node shoot.mjs   (after the mock + dashboard dev servers are up)
+//
+// Resolves Playwright + chromium automatically; override with PLAYWRIGHT_PATH /
+// CHROME_BIN. Output dir defaults to the docs images dir (resolved relative to
+// this script); override with SCREENSHOT_OUT. Dashboard URL: DASHBOARD_URL.
+
+import { createRequire } from 'node:module'
+import { readdirSync, existsSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function findPlaywright() {
+  if (process.env.PLAYWRIGHT_PATH) return process.env.PLAYWRIGHT_PATH
+  try {
+    return require.resolve('playwright')
+  } catch {}
+  const npx = join(homedir(), '.npm/_npx')
+  if (existsSync(npx))
+    for (const d of readdirSync(npx)) {
+      const p = join(npx, d, 'node_modules/playwright/index.js')
+      if (existsSync(p)) return p
+    }
+  throw new Error('playwright not found — set PLAYWRIGHT_PATH')
+}
+
+function findChrome() {
+  if (process.env.CHROME_BIN) return process.env.CHROME_BIN
+  const base = join(homedir(), '.cache/ms-playwright')
+  if (!existsSync(base)) return undefined
+  const subs = ['chrome-linux64/chrome', 'chrome-linux/chrome', 'chrome-mac/Chromium.app/Contents/MacOS/Chromium']
+  for (const d of readdirSync(base).filter((x) => x.startsWith('chromium-')).sort().reverse())
+    for (const s of subs) {
+      const p = join(base, d, s)
+      if (existsSync(p)) return p
+    }
+  return undefined // fall back to Playwright's own download
+}
+
+const { chromium } = require(findPlaywright())
+const EXEC = findChrome()
+const BASE = process.env.DASHBOARD_URL || 'http://localhost:5173'
+const OUT = process.env.SCREENSHOT_OUT || join(__dirname, '../../../../images/dashboard')
+for (const d of ['access', 'api-keys', 'team', 'jwt-keys', 'deposits', 'sponsorship'])
+  mkdirSync(`${OUT}/${d}`, { recursive: true })
+
+const results = []
+async function shoot(page, file, { dialog = false } = {}) {
+  try {
+    await page.waitForTimeout(450)
+    if (dialog) {
+      const d = page.locator('[role="dialog"]').first()
+      await d.waitFor({ timeout: 4000 })
+      await d.screenshot({ path: `${OUT}/${file}` })
+    } else {
+      await page.screenshot({ path: `${OUT}/${file}` })
+    }
+    results.push(`OK   ${file}`)
+  } catch (e) {
+    results.push(`FAIL ${file} — ${e.message.split('\n')[0]}`)
+  }
+}
+
+async function appReady(page) {
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await page.getByText('API keys').first().waitFor({ timeout: 8000 })
+  await page.waitForTimeout(400)
+}
+
+const browser = await chromium.launch({ executablePath: EXEC, headless: true })
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2, colorScheme: 'dark' })
+const page = await ctx.newPage()
+page.setDefaultTimeout(8000)
+// Belt-and-suspenders: also disable the Vue devtools plugin in vite.config.ts.
+await page.addInitScript(() => {
+  const s = document.createElement('style')
+  s.textContent = '#vue-devtools-anchor,vue-devtools-anchor,#vue-inspector-container{display:none!important}'
+  ;(document.head || document.documentElement).appendChild(s)
+})
+
+// ---------- LOGIN (unauthenticated) ----------
+try {
+  await page.route('**/users/auth/get-session*', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: 'null' }))
+  await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' })
+  await shoot(page, 'access/invite-code.png')
+  await page.getByPlaceholder('Invite code').fill('RHINESTONE-2026')
+  await page.getByRole('button', { name: /continue/i }).click()
+  await page.waitForTimeout(700)
+  await shoot(page, 'access/sso.png')
+  await page.unroute('**/users/auth/get-session*')
+} catch (e) { results.push(`FAIL login flow — ${e.message.split('\n')[0]}`) }
+
+// ---------- NAV / app shell ----------
+await appReady(page)
+await shoot(page, 'access/nav.png')
+
+// ---------- API KEYS ----------
+await page.goto(`${BASE}/keys`, { waitUntil: 'networkidle' })
+await page.waitForTimeout(500)
+await shoot(page, 'api-keys/list.png')
+try {
+  await page.getByText('prod', { exact: true }).first().click()
+  await page.waitForTimeout(400)
+  await shoot(page, 'api-keys/scopes.png')
+  await page.getByRole('button', { name: /^revoke$/i }).first().click()
+  await shoot(page, 'api-keys/revoke.png', { dialog: true })
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(250)
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(250)
+} catch (e) { results.push(`FAIL api-keys scopes/revoke — ${e.message.split('\n')[0]}`) }
+try {
+  await page.goto(`${BASE}/keys`, { waitUntil: 'networkidle' })
+  await page.waitForTimeout(500)
+  await page.getByRole('button', { name: /create key/i }).first().click()
+  await shoot(page, 'api-keys/create.png', { dialog: true })
+  await page.getByPlaceholder(/prod/i).fill('mobile-app')
+  await page.getByRole('button', { name: /^create$/i }).click()
+  await shoot(page, 'api-keys/reveal.png', { dialog: true })
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(300)
+} catch (e) { results.push(`FAIL api-keys create — ${e.message.split('\n')[0]}`) }
+
+// ---------- TEAM ----------
+await page.goto(`${BASE}/settings/team`, { waitUntil: 'networkidle' })
+await page.waitForTimeout(500)
+await shoot(page, 'team/list.png')
+try {
+  await page.getByRole('button', { name: /invite member/i }).click()
+  await shoot(page, 'team/invite.png', { dialog: true })
+  await page.keyboard.press('Escape')
+} catch (e) { results.push(`FAIL team invite — ${e.message.split('\n')[0]}`) }
+
+// ---------- JWT KEYS ----------
+await page.goto(`${BASE}/keys/jwt`, { waitUntil: 'networkidle' })
+await page.waitForTimeout(500)
+try {
+  await page.getByRole('button', { name: /register key/i }).click()
+  await page.waitForTimeout(300)
+  await shoot(page, 'jwt-keys/generate.png', { dialog: true })
+  await page.getByPlaceholder(/application identifier/i).fill('rhinestone')
+  await page.getByPlaceholder(/unique name for this key/i).fill('mobile-2026-06')
+  await page.getByRole('button', { name: /create key/i }).click()
+  await page.waitForTimeout(800)
+  await shoot(page, 'jwt-keys/download.png', { dialog: true })
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(300)
+  await page.getByRole('button', { name: /register key/i }).click()
+  await page.waitForTimeout(300)
+  await page.getByText(/upload public key/i).click()
+  await page.waitForTimeout(300)
+  await shoot(page, 'jwt-keys/upload.png', { dialog: true })
+  await page.keyboard.press('Escape')
+} catch (e) { results.push(`FAIL jwt add — ${e.message.split('\n')[0]}`) }
+try {
+  await page.getByRole('button', { name: /^disable$/i }).first().click()
+  await shoot(page, 'jwt-keys/disable.png', { dialog: true })
+  await page.keyboard.press('Escape')
+} catch (e) { results.push(`FAIL jwt disable — ${e.message.split('\n')[0]}`) }
+
+// ---------- DEPOSITS ----------
+await page.goto(`${BASE}/deposits`, { waitUntil: 'networkidle' })
+await page.waitForTimeout(700)
+await shoot(page, 'deposits/list.png')
+try {
+  await page.getByRole('button', { name: /^retry$/i }).first().click()
+  await shoot(page, 'deposits/retry.png', { dialog: true })
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(300)
+  await page.getByRole('button', { name: /^refund$/i }).first().click()
+  await shoot(page, 'deposits/refund.png', { dialog: true })
+  await page.keyboard.press('Escape')
+} catch (e) { results.push(`FAIL deposits retry/refund — ${e.message.split('\n')[0]}`) }
+
+// ---------- SPONSORSHIP ----------
+await page.goto(`${BASE}/settings`, { waitUntil: 'networkidle' })
+await page.waitForTimeout(700)
+await shoot(page, 'sponsorship/balance.png')
+try {
+  await page.getByRole('button', { name: /^deposit$/i }).first().click()
+  await shoot(page, 'sponsorship/deposit-amount.png', { dialog: true })
+  await page.keyboard.press('Escape')
+} catch (e) { results.push(`FAIL sponsorship deposit — ${e.message.split('\n')[0]}`) }
+
+await browser.close()
+console.log(results.join('\n'))

--- a/.claude/skills/update-screenshots/scripts/shoot.mjs
+++ b/.claude/skills/update-screenshots/scripts/shoot.mjs
@@ -188,3 +188,11 @@ try {
 
 await browser.close()
 console.log(results.join('\n'))
+
+// Exit non-zero if any shot failed, so a caller (or CI) doesn't treat a
+// partial/failed refresh as success.
+const failed = results.filter((r) => r.startsWith('FAIL'))
+if (failed.length) {
+  console.error(`\n${failed.length} capture(s) failed`)
+  process.exitCode = 1
+}


### PR DESCRIPTION
Adds a `/update-screenshots` skill (`.claude/skills/update-screenshots/`) for refreshing the dashboard screenshots under `images/dashboard/`.

It boots the real dashboard dev server against a **mock user-service** (stubbed JSON, no backend stack — dashboard auth is fully client-side) and drives a headless browser to capture each screen and modal. `SKILL.md` documents the workflow and the gotchas (setsid backgrounding, never `pkill -f vite`, disable the Vue devtools plugin, CORS).

This is the same harness that produced the screenshots in #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)