### PR TITLE
docs: add generated SDK reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -188,6 +188,154 @@
               "smart-wallet/module-sdk",
               "smart-wallet/modulekit"
             ]
+          },
+          {
+            "group": "SDK Reference",
+            "pages": [
+              {
+                "group": "RhinestoneSDK",
+                "pages": [
+                  "sdk-reference/rhinestone-sdk/rhinestone-sdk",
+                  "sdk-reference/rhinestone-sdk/create-account",
+                  "sdk-reference/rhinestone-sdk/get-intent-status",
+                  "sdk-reference/rhinestone-sdk/split-intents"
+                ]
+              },
+              {
+                "group": "Account",
+                "pages": [
+                  {
+                    "group": "Deployment",
+                    "pages": [
+                      "sdk-reference/account/deployment/deploy",
+                      "sdk-reference/account/deployment/is-deployed",
+                      "sdk-reference/account/deployment/setup",
+                      "sdk-reference/account/deployment/get-init-data",
+                      "sdk-reference/account/deployment/sign-eip7702-init-data"
+                    ]
+                  },
+                  {
+                    "group": "Transactions",
+                    "pages": [
+                      "sdk-reference/account/transactions/prepare-transaction",
+                      "sdk-reference/account/transactions/get-transaction-messages",
+                      "sdk-reference/account/transactions/sign-transaction",
+                      "sdk-reference/account/transactions/sign-authorizations",
+                      "sdk-reference/account/transactions/sign-intent",
+                      "sdk-reference/account/transactions/submit-transaction"
+                    ]
+                  },
+                  {
+                    "group": "User operations",
+                    "pages": [
+                      "sdk-reference/account/user-operations/prepare-user-operation",
+                      "sdk-reference/account/user-operations/sign-user-operation",
+                      "sdk-reference/account/user-operations/submit-user-operation",
+                      "sdk-reference/account/user-operations/send-user-operation"
+                    ]
+                  },
+                  {
+                    "group": "Signing",
+                    "pages": [
+                      "sdk-reference/account/signing/sign-message",
+                      "sdk-reference/account/signing/sign-typed-data"
+                    ]
+                  },
+                  {
+                    "group": "Execution",
+                    "pages": [
+                      "sdk-reference/account/execution/wait-for-execution"
+                    ]
+                  },
+                  {
+                    "group": "Reads",
+                    "pages": [
+                      "sdk-reference/account/reads/get-address",
+                      "sdk-reference/account/reads/get-portfolio",
+                      "sdk-reference/account/reads/get-owners",
+                      "sdk-reference/account/reads/get-validators",
+                      "sdk-reference/account/reads/get-executors"
+                    ]
+                  },
+                  {
+                    "group": "Smart sessions",
+                    "pages": [
+                      "sdk-reference/account/smart-sessions/experimental-get-session-details",
+                      "sdk-reference/account/smart-sessions/experimental-is-session-enabled",
+                      "sdk-reference/account/smart-sessions/experimental-sign-enable-session"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Actions",
+                "pages": [
+                  {
+                    "group": "ECDSA",
+                    "pages": [
+                      "sdk-reference/actions/ecdsa/enable",
+                      "sdk-reference/actions/ecdsa/disable",
+                      "sdk-reference/actions/ecdsa/add-owner",
+                      "sdk-reference/actions/ecdsa/remove-owner",
+                      "sdk-reference/actions/ecdsa/change-threshold"
+                    ]
+                  },
+                  {
+                    "group": "Passkeys",
+                    "pages": [
+                      "sdk-reference/actions/passkeys/enable",
+                      "sdk-reference/actions/passkeys/disable",
+                      "sdk-reference/actions/passkeys/add-owner",
+                      "sdk-reference/actions/passkeys/remove-owner",
+                      "sdk-reference/actions/passkeys/change-threshold"
+                    ]
+                  },
+                  {
+                    "group": "MFA",
+                    "pages": [
+                      "sdk-reference/actions/mfa/enable",
+                      "sdk-reference/actions/mfa/disable",
+                      "sdk-reference/actions/mfa/change-threshold",
+                      "sdk-reference/actions/mfa/set-sub-validator",
+                      "sdk-reference/actions/mfa/remove-sub-validator"
+                    ]
+                  },
+                  {
+                    "group": "Recovery",
+                    "pages": [
+                      "sdk-reference/actions/recovery/enable",
+                      "sdk-reference/actions/recovery/recover-ecdsa-ownership",
+                      "sdk-reference/actions/recovery/recover-passkey-ownership"
+                    ]
+                  },
+                  {
+                    "group": "Modules",
+                    "pages": [
+                      "sdk-reference/actions/modules/install-module",
+                      "sdk-reference/actions/modules/uninstall-module",
+                      "sdk-reference/actions/modules/deploy"
+                    ]
+                  },
+                  {
+                    "group": "Smart sessions",
+                    "pages": [
+                      "sdk-reference/actions/smart-sessions/experimental-enable",
+                      "sdk-reference/actions/smart-sessions/experimental-disable",
+                      "sdk-reference/actions/smart-sessions/experimental-enable-session",
+                      "sdk-reference/actions/smart-sessions/create-cross-chain-permission"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Utils",
+                "pages": [
+                  "sdk-reference/utils/experimental-get-v0-init-data",
+                  "sdk-reference/utils/experimental-get-rhinestone-init-data",
+                  "sdk-reference/utils/to-view-only-account"
+                ]
+              }
+            ]
           }
         ]
       },
@@ -284,7 +432,9 @@
         "groups": [
           {
             "group": "Get started",
-            "pages": ["api-reference/introduction"]
+            "pages": [
+              "api-reference/introduction"
+            ]
           },
           {
             "group": "Intents",

--- a/sdk-reference/account/deployment/deploy.mdx
+++ b/sdk-reference/account/deployment/deploy.mdx
@@ -1,0 +1,28 @@
+---
+title: "deploy"
+description: "Deploy the account on a given chain."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const success = await account.deploy(chain)
+```
+
+## Parameters
+
+<ParamField path="chain" type="Chain" required>
+  Chain to deploy the account on
+</ParamField>
+
+<ParamField path="params" type="{ session: Session; sponsored: boolean }">
+  Optional deployment parameters (session, sponsorship)
+</ParamField>
+
+## Returns
+
+<ResponseField name="success" type="boolean">
+  `true` once the deployment is submitted
+</ResponseField>

--- a/sdk-reference/account/deployment/get-init-data.mdx
+++ b/sdk-reference/account/deployment/get-init-data.mdx
@@ -1,0 +1,22 @@
+---
+title: "getInitData"
+description: "Get the account initialization data, used to deploy the account onchain."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const initData = account.getInitData()
+```
+
+## Returns
+
+The factory address and factory data
+
+<ResponseField name="factory" type="`0x${string}`" required>
+</ResponseField>
+
+<ResponseField name="factoryData" type="`0x${string}`" required>
+</ResponseField>

--- a/sdk-reference/account/deployment/is-deployed.mdx
+++ b/sdk-reference/account/deployment/is-deployed.mdx
@@ -1,0 +1,24 @@
+---
+title: "isDeployed"
+description: "Check whether the account is deployed on a given chain."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const deployed = await account.isDeployed(chain)
+```
+
+## Parameters
+
+<ParamField path="chain" type="Chain" required>
+  Chain to check
+</ParamField>
+
+## Returns
+
+<ResponseField name="deployed" type="boolean">
+  `true` if the account is deployed, `false` otherwise
+</ResponseField>

--- a/sdk-reference/account/deployment/setup.mdx
+++ b/sdk-reference/account/deployment/setup.mdx
@@ -1,0 +1,24 @@
+---
+title: "setup"
+description: "Set up an existing account on a given chain by installing any missing modules."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const success = await account.setup(chain)
+```
+
+## Parameters
+
+<ParamField path="chain" type="Chain" required>
+  Chain to set the account up on
+</ParamField>
+
+## Returns
+
+<ResponseField name="success" type="boolean">
+  `true` once setup is submitted
+</ResponseField>

--- a/sdk-reference/account/deployment/sign-eip7702-init-data.mdx
+++ b/sdk-reference/account/deployment/sign-eip7702-init-data.mdx
@@ -1,0 +1,18 @@
+---
+title: "signEip7702InitData"
+description: "Prepare and sign the EIP-7702 account initialization data."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const signature = await account.signEip7702InitData()
+```
+
+## Returns
+
+<ResponseField name="signature" type="`0x${string}`">
+  The init data signature
+</ResponseField>

--- a/sdk-reference/account/execution/wait-for-execution.mdx
+++ b/sdk-reference/account/execution/wait-for-execution.mdx
@@ -8,7 +8,7 @@ Method on an account instance returned by [`createAccount`](/sdk-reference/rhine
 ## Usage
 
 ```ts
-const result = await account.waitForExecution(result)
+const output = await account.waitForExecution(result)
 ```
 
 ## Parameters

--- a/sdk-reference/account/execution/wait-for-execution.mdx
+++ b/sdk-reference/account/execution/wait-for-execution.mdx
@@ -1,0 +1,24 @@
+---
+title: "waitForExecution"
+description: "Wait for a submitted transaction or user operation to execute onchain. Polls the orchestrator until the intent reaches a terminal state; on failure an IntentFailedError is thrown."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const result = await account.waitForExecution(result)
+```
+
+## Parameters
+
+<ParamField path="result" type="TransactionResult" required>
+  The result returned by a submit/send call
+</ParamField>
+
+## Returns
+
+<ResponseField name="result" type="TransactionStatus">
+  The per-chain operation status (for intents) or a UserOp receipt
+</ResponseField>

--- a/sdk-reference/account/execution/wait-for-execution.mdx
+++ b/sdk-reference/account/execution/wait-for-execution.mdx
@@ -13,12 +13,12 @@ const result = await account.waitForExecution(result)
 
 ## Parameters
 
-<ParamField path="result" type="TransactionResult" required>
+<ParamField path="result" type="TransactionResult | UserOperationResult" required>
   The result returned by a submit/send call
 </ParamField>
 
 ## Returns
 
-<ResponseField name="result" type="TransactionStatus">
+<ResponseField name="result" type="TransactionStatus | UserOperationReceipt">
   The per-chain operation status (for intents) or a UserOp receipt
 </ResponseField>

--- a/sdk-reference/account/reads/get-address.mdx
+++ b/sdk-reference/account/reads/get-address.mdx
@@ -1,0 +1,18 @@
+---
+title: "getAddress"
+description: "Get the account address."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const address = account.getAddress()
+```
+
+## Returns
+
+<ResponseField name="address" type="`0x${string}`">
+  The smart account address
+</ResponseField>

--- a/sdk-reference/account/reads/get-executors.mdx
+++ b/sdk-reference/account/reads/get-executors.mdx
@@ -1,0 +1,24 @@
+---
+title: "getExecutors"
+description: "Get the account executor modules."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const executors = await account.getExecutors(chain)
+```
+
+## Parameters
+
+<ParamField path="chain" type="Chain" required>
+  Chain to read the executors from
+</ParamField>
+
+## Returns
+
+<ResponseField name="executors" type="`0x${string}`[]">
+  The executor module addresses
+</ResponseField>

--- a/sdk-reference/account/reads/get-owners.mdx
+++ b/sdk-reference/account/reads/get-owners.mdx
@@ -1,0 +1,26 @@
+---
+title: "getOwners"
+description: "Get the account owners."
+---
+
+<Note>Only returns ECDSA owners; owners managed by other validator types are not included.</Note>
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const owners = await account.getOwners(chain)
+```
+
+## Parameters
+
+<ParamField path="chain" type="Chain" required>
+  Chain to read the owners from
+</ParamField>
+
+## Returns
+
+<ResponseField name="owners" type="{ accounts: `0x${string}`[]; threshold: number } | null">
+  The owner addresses and threshold, or `null` if unavailable
+</ResponseField>

--- a/sdk-reference/account/reads/get-portfolio.mdx
+++ b/sdk-reference/account/reads/get-portfolio.mdx
@@ -1,0 +1,24 @@
+---
+title: "getPortfolio"
+description: "Get the account portfolio (token balances across chains)."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const portfolio = await account.getPortfolio()
+```
+
+## Parameters
+
+<ParamField path="onTestnets" type="boolean">
+  Whether to query testnet balances (default is `false`)
+</ParamField>
+
+## Returns
+
+<ResponseField name="portfolio" type="Portfolio">
+  The account balances
+</ResponseField>

--- a/sdk-reference/account/reads/get-validators.mdx
+++ b/sdk-reference/account/reads/get-validators.mdx
@@ -1,0 +1,24 @@
+---
+title: "getValidators"
+description: "Get the account validator modules."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const validators = await account.getValidators(chain)
+```
+
+## Parameters
+
+<ParamField path="chain" type="Chain" required>
+  Chain to read the validators from
+</ParamField>
+
+## Returns
+
+<ResponseField name="validators" type="`0x${string}`[]">
+  The validator module addresses
+</ResponseField>

--- a/sdk-reference/account/signing/sign-message.mdx
+++ b/sdk-reference/account/signing/sign-message.mdx
@@ -1,0 +1,36 @@
+---
+title: "signMessage"
+description: "Sign a message (EIP-191)."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const signature = await account.signMessage(message, chain, signers)
+```
+
+## Parameters
+
+<ParamField path="message" type="SignableMessage" required>
+  Message to sign
+</ParamField>
+
+<ParamField path="chain" type="Chain" required>
+  Chain to sign the message for
+</ParamField>
+
+<ParamField path="signers" type="SignerSet | undefined" required>
+  Signers to use, or `undefined` for the account default
+</ParamField>
+
+## Returns
+
+<ResponseField name="signature" type="`0x${string}`">
+  The signature
+</ResponseField>
+
+## See also
+
+- [signTypedData](/sdk-reference/account/signing/sign-typed-data) to sign EIP-712 typed data

--- a/sdk-reference/account/signing/sign-typed-data.mdx
+++ b/sdk-reference/account/signing/sign-typed-data.mdx
@@ -1,0 +1,36 @@
+---
+title: "signTypedData"
+description: "Sign typed data (EIP-712)."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const signature = await account.signTypedData(parameters, chain, signers)
+```
+
+## Parameters
+
+<ParamField path="parameters" type="HashTypedDataParameters<typedData, primaryType>" required>
+  Typed-data parameters
+</ParamField>
+
+<ParamField path="chain" type="Chain" required>
+  Chain to sign the typed data for
+</ParamField>
+
+<ParamField path="signers" type="SignerSet | undefined" required>
+  Signers to use, or `undefined` for the account default
+</ParamField>
+
+## Returns
+
+<ResponseField name="signature" type="`0x${string}`">
+  The signature
+</ResponseField>
+
+## See also
+
+- [signMessage](/sdk-reference/account/signing/sign-message) to sign an EIP-191 message

--- a/sdk-reference/account/smart-sessions/experimental-get-session-details.mdx
+++ b/sdk-reference/account/smart-sessions/experimental-get-session-details.mdx
@@ -1,0 +1,26 @@
+---
+title: "experimental_getSessionDetails"
+description: "Resolve the smart-session details for a set of sessions."
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const sessionDetails = await account.experimental_getSessionDetails(sessions)
+```
+
+## Parameters
+
+<ParamField path="sessions" type="Session[]" required>
+  Sessions to resolve
+</ParamField>
+
+## Returns
+
+<ResponseField name="sessionDetails" type="SessionDetails">
+  The resolved session details
+</ResponseField>

--- a/sdk-reference/account/smart-sessions/experimental-is-session-enabled.mdx
+++ b/sdk-reference/account/smart-sessions/experimental-is-session-enabled.mdx
@@ -1,0 +1,26 @@
+---
+title: "experimental_isSessionEnabled"
+description: "Check whether a smart session is enabled on the account."
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const sessionEnabled = await account.experimental_isSessionEnabled(session)
+```
+
+## Parameters
+
+<ParamField path="session" type="Session" required>
+  Session to check
+</ParamField>
+
+## Returns
+
+<ResponseField name="sessionEnabled" type="boolean">
+  `true` if the session is enabled
+</ResponseField>

--- a/sdk-reference/account/smart-sessions/experimental-sign-enable-session.mdx
+++ b/sdk-reference/account/smart-sessions/experimental-sign-enable-session.mdx
@@ -1,0 +1,26 @@
+---
+title: "experimental_signEnableSession"
+description: "Sign the data required to enable a smart session."
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const signature = await account.experimental_signEnableSession(details)
+```
+
+## Parameters
+
+<ParamField path="details" type="SessionDetails" required>
+  Session details to enable
+</ParamField>
+
+## Returns
+
+<ResponseField name="signature" type="`0x${string}`">
+  The enable-session signature
+</ResponseField>

--- a/sdk-reference/account/transactions/get-transaction-messages.mdx
+++ b/sdk-reference/account/transactions/get-transaction-messages.mdx
@@ -1,0 +1,39 @@
+---
+title: "getTransactionMessages"
+description: "Get the typed-data messages to sign for a prepared transaction."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const transactionMessages = account.getTransactionMessages(preparedTransaction)
+```
+
+## Parameters
+
+<ParamField path="preparedTransaction" type="PreparedTransactionData" required>
+  Prepared transaction data
+</ParamField>
+
+<ParamField path="options" type="QuoteSelection">
+  Optional override; pass `{ intentId }` to inspect a specific quote from `preparedTransaction.quotes.all`
+</ParamField>
+
+## Returns
+
+The origin, destination, and (when required) target-execution typed-data messages
+
+<ResponseField name="destination" type="MessageDefinition" required>
+</ResponseField>
+
+<ResponseField name="origin" type="MessageDefinition[]" required>
+</ResponseField>
+
+<ResponseField name="targetExecution" type="MessageDefinition">
+</ResponseField>
+
+## See also
+
+- [prepareTransaction](/sdk-reference/account/transactions/prepare-transaction) to prepare the transaction data for signing

--- a/sdk-reference/account/transactions/prepare-transaction.mdx
+++ b/sdk-reference/account/transactions/prepare-transaction.mdx
@@ -8,7 +8,7 @@ Method on an account instance returned by [`createAccount`](/sdk-reference/rhine
 ## Usage
 
 ```ts
-const transaction = await account.prepareTransaction(transaction)
+const result = await account.prepareTransaction(transaction)
 ```
 
 ## Parameters

--- a/sdk-reference/account/transactions/prepare-transaction.mdx
+++ b/sdk-reference/account/transactions/prepare-transaction.mdx
@@ -1,0 +1,29 @@
+---
+title: "prepareTransaction"
+description: "Prepare a transaction for signing."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction(transaction)
+```
+
+## Parameters
+
+<ParamField path="transaction" type="Transaction" required>
+  Transaction to prepare
+</ParamField>
+
+## Returns
+
+<ResponseField name="transaction" type="PreparedTransactionData">
+  The prepared transaction data
+</ResponseField>
+
+## See also
+
+- [signTransaction](/sdk-reference/account/transactions/sign-transaction) to sign the prepared transaction
+- [submitTransaction](/sdk-reference/account/transactions/submit-transaction) to submit the signed transaction

--- a/sdk-reference/account/transactions/sign-authorizations.mdx
+++ b/sdk-reference/account/transactions/sign-authorizations.mdx
@@ -1,0 +1,28 @@
+---
+title: "signAuthorizations"
+description: "Sign the EIP-7702 authorizations required for a transaction."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const authorizations = await account.signAuthorizations(preparedTransaction)
+```
+
+## Parameters
+
+<ParamField path="preparedTransaction" type="PreparedTransactionData" required>
+  Prepared transaction data
+</ParamField>
+
+## Returns
+
+<ResponseField name="authorizations" type="SignedAuthorizationList">
+  The signed authorization list
+</ResponseField>
+
+## See also
+
+- [prepareTransaction](/sdk-reference/account/transactions/prepare-transaction) to prepare the transaction data for signing

--- a/sdk-reference/account/transactions/sign-intent.mdx
+++ b/sdk-reference/account/transactions/sign-intent.mdx
@@ -1,0 +1,36 @@
+---
+title: "signIntent"
+description: "Sign an orchestrator intent operation. Used by headless flows that prepare the intent outside the SDK but still need the SDK-owned smart-session signature packing and target-execution signature routing."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const signatures = await account.signIntent(signData, targetChain)
+```
+
+## Parameters
+
+<ParamField path="signData" type="SignData" required>
+  Sign data returned by the orchestrator (origin/destination/targetExecution typed data)
+</ParamField>
+
+<ParamField path="targetChain" type="DestinationChain" required>
+  Chain where the destination execution runs
+</ParamField>
+
+<ParamField path="signers" type="SignerSet">
+  Signers to use, or `undefined` for the account default
+</ParamField>
+
+## Returns
+
+<ResponseField name="signatures" type="SignedIntentData">
+  The intent signatures, ready for submission
+</ResponseField>
+
+## See also
+
+- [signTransaction](/sdk-reference/account/transactions/sign-transaction) for the canonical signing path

--- a/sdk-reference/account/transactions/sign-transaction.mdx
+++ b/sdk-reference/account/transactions/sign-transaction.mdx
@@ -1,0 +1,33 @@
+---
+title: "signTransaction"
+description: "Sign a prepared transaction."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const transaction = await account.signTransaction(preparedTransaction)
+```
+
+## Parameters
+
+<ParamField path="preparedTransaction" type="PreparedTransactionData" required>
+  Prepared transaction data
+</ParamField>
+
+<ParamField path="options" type="QuoteSelection">
+  Optional override; pass `{ intentId }` to sign a specific quote from `preparedTransaction.quotes.all`
+</ParamField>
+
+## Returns
+
+<ResponseField name="transaction" type="SignedTransactionData">
+  The signed transaction data
+</ResponseField>
+
+## See also
+
+- [prepareTransaction](/sdk-reference/account/transactions/prepare-transaction) to prepare the transaction data for signing
+- [submitTransaction](/sdk-reference/account/transactions/submit-transaction) to submit the signed transaction

--- a/sdk-reference/account/transactions/submit-transaction.mdx
+++ b/sdk-reference/account/transactions/submit-transaction.mdx
@@ -1,0 +1,34 @@
+---
+title: "submitTransaction"
+description: "Submit a signed transaction."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const transaction = await account.submitTransaction(signedTransaction)
+```
+
+## Parameters
+
+<ParamField path="signedTransaction" type="SignedTransactionData" required>
+  Signed transaction data
+</ParamField>
+
+<ParamField path="options" type="SubmitTransactionOptions">
+  Optional submission options (e.g. EIP-7702 `authorizations`)
+</ParamField>
+
+## Returns
+
+<ResponseField name="transaction" type="TransactionResult">
+  The transaction result (an intent ID)
+</ResponseField>
+
+## See also
+
+- [signTransaction](/sdk-reference/account/transactions/sign-transaction) to sign the transaction data
+- [signAuthorizations](/sdk-reference/account/transactions/sign-authorizations) to sign the required EIP-7702 authorizations
+- [waitForExecution](/sdk-reference/account/execution/wait-for-execution) to wait for the transaction to execute onchain

--- a/sdk-reference/account/user-operations/prepare-user-operation.mdx
+++ b/sdk-reference/account/user-operations/prepare-user-operation.mdx
@@ -1,0 +1,30 @@
+---
+title: "prepareUserOperation"
+description: "Prepare a user operation for signing."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const userOperation = await account.prepareUserOperation(transaction)
+```
+
+## Parameters
+
+<ParamField path="transaction" type="UserOperationTransaction" required>
+  User operation to prepare
+</ParamField>
+
+## Returns
+
+<ResponseField name="userOperation" type="PreparedUserOperationData">
+  The prepared user operation data
+</ResponseField>
+
+## See also
+
+- [signUserOperation](/sdk-reference/account/user-operations/sign-user-operation) to sign the prepared user operation
+- [submitUserOperation](/sdk-reference/account/user-operations/submit-user-operation) to submit the signed user operation
+- [sendUserOperation](/sdk-reference/account/user-operations/send-user-operation) to prepare, sign, and submit in one call

--- a/sdk-reference/account/user-operations/send-user-operation.mdx
+++ b/sdk-reference/account/user-operations/send-user-operation.mdx
@@ -1,0 +1,28 @@
+---
+title: "sendUserOperation"
+description: "Prepare, sign, and submit a user operation in a single call."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const userOperation = await account.sendUserOperation(transaction)
+```
+
+## Parameters
+
+<ParamField path="transaction" type="UserOperationTransaction" required>
+  User operation to send
+</ParamField>
+
+## Returns
+
+<ResponseField name="userOperation" type="UserOperationResult">
+  The user operation result (a UserOp hash)
+</ResponseField>
+
+## See also
+
+- [waitForExecution](/sdk-reference/account/execution/wait-for-execution) to wait for the user operation to execute onchain

--- a/sdk-reference/account/user-operations/sign-user-operation.mdx
+++ b/sdk-reference/account/user-operations/sign-user-operation.mdx
@@ -1,0 +1,29 @@
+---
+title: "signUserOperation"
+description: "Sign a prepared user operation."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const userOperation = await account.signUserOperation(preparedUserOperation)
+```
+
+## Parameters
+
+<ParamField path="preparedUserOperation" type="PreparedUserOperationData" required>
+  Prepared user operation data
+</ParamField>
+
+## Returns
+
+<ResponseField name="userOperation" type="SignedUserOperationData">
+  The signed user operation data
+</ResponseField>
+
+## See also
+
+- [prepareUserOperation](/sdk-reference/account/user-operations/prepare-user-operation) to prepare the user operation data for signing
+- [submitUserOperation](/sdk-reference/account/user-operations/submit-user-operation) to submit the signed user operation

--- a/sdk-reference/account/user-operations/submit-user-operation.mdx
+++ b/sdk-reference/account/user-operations/submit-user-operation.mdx
@@ -1,0 +1,29 @@
+---
+title: "submitUserOperation"
+description: "Submit a signed user operation."
+---
+
+Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
+
+## Usage
+
+```ts
+const userOperation = await account.submitUserOperation(signedUserOperation)
+```
+
+## Parameters
+
+<ParamField path="signedUserOperation" type="SignedUserOperationData" required>
+  Signed user operation data
+</ParamField>
+
+## Returns
+
+<ResponseField name="userOperation" type="UserOperationResult">
+  The user operation result (a UserOp hash)
+</ResponseField>
+
+## See also
+
+- [signUserOperation](/sdk-reference/account/user-operations/sign-user-operation) to sign the user operation data
+- [waitForExecution](/sdk-reference/account/execution/wait-for-execution) to wait for the user operation to execute onchain

--- a/sdk-reference/actions/ecdsa/add-owner.mdx
+++ b/sdk-reference/actions/ecdsa/add-owner.mdx
@@ -1,0 +1,31 @@
+---
+title: "addOwner"
+description: "Add an ECDSA owner"
+---
+
+## Import
+
+```ts
+import { addOwner } from '@rhinestone/sdk/actions/ecdsa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [addOwner(owner)],
+})
+```
+
+## Parameters
+
+<ParamField path="owner" type="`0x${string}`" required>
+  Owner address
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to add the owner
+</ResponseField>

--- a/sdk-reference/actions/ecdsa/change-threshold.mdx
+++ b/sdk-reference/actions/ecdsa/change-threshold.mdx
@@ -1,0 +1,31 @@
+---
+title: "changeThreshold"
+description: "Change an account's signer threshold (ECDSA)"
+---
+
+## Import
+
+```ts
+import { changeThreshold } from '@rhinestone/sdk/actions/ecdsa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [changeThreshold(newThreshold)],
+})
+```
+
+## Parameters
+
+<ParamField path="newThreshold" type="number" required>
+  New threshold
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to change the threshold
+</ResponseField>

--- a/sdk-reference/actions/ecdsa/disable.mdx
+++ b/sdk-reference/actions/ecdsa/disable.mdx
@@ -1,0 +1,25 @@
+---
+title: "disable"
+description: "Disable ECDSA authentication"
+---
+
+## Import
+
+```ts
+import { disable } from '@rhinestone/sdk/actions/ecdsa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [disable()],
+})
+```
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to disable ECDSA authentication
+</ResponseField>

--- a/sdk-reference/actions/ecdsa/enable.mdx
+++ b/sdk-reference/actions/ecdsa/enable.mdx
@@ -1,0 +1,35 @@
+---
+title: "enable"
+description: "Enable ECDSA authentication"
+---
+
+## Import
+
+```ts
+import { enable } from '@rhinestone/sdk/actions/ecdsa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [enable(owners, threshold)],
+})
+```
+
+## Parameters
+
+<ParamField path="owners" type="`0x${string}`[]" required>
+  Owners to use for authentication
+</ParamField>
+
+<ParamField path="threshold" type="number" required>
+  Threshold for the owners
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to enable ECDSA authentication
+</ResponseField>

--- a/sdk-reference/actions/ecdsa/remove-owner.mdx
+++ b/sdk-reference/actions/ecdsa/remove-owner.mdx
@@ -1,0 +1,35 @@
+---
+title: "removeOwner"
+description: "Remove an ECDSA owner"
+---
+
+## Import
+
+```ts
+import { removeOwner } from '@rhinestone/sdk/actions/ecdsa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [removeOwner(prevOwner, ownerToRemove)],
+})
+```
+
+## Parameters
+
+<ParamField path="prevOwner" type="`0x${string}`" required>
+  Previous owner address
+</ParamField>
+
+<ParamField path="ownerToRemove" type="`0x${string}`" required>
+  Owner to remove
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to remove the owner
+</ResponseField>

--- a/sdk-reference/actions/mfa/change-threshold.mdx
+++ b/sdk-reference/actions/mfa/change-threshold.mdx
@@ -1,0 +1,31 @@
+---
+title: "changeThreshold"
+description: "Change the multi-factor threshold"
+---
+
+## Import
+
+```ts
+import { changeThreshold } from '@rhinestone/sdk/actions/mfa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [changeThreshold(newThreshold)],
+})
+```
+
+## Parameters
+
+<ParamField path="newThreshold" type="number" required>
+  New threshold
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to change the threshold
+</ResponseField>

--- a/sdk-reference/actions/mfa/disable.mdx
+++ b/sdk-reference/actions/mfa/disable.mdx
@@ -1,0 +1,25 @@
+---
+title: "disable"
+description: "Disable multi-factor authentication"
+---
+
+## Import
+
+```ts
+import { disable } from '@rhinestone/sdk/actions/mfa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [disable()],
+})
+```
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to disable multi-factor authentication
+</ResponseField>

--- a/sdk-reference/actions/mfa/enable.mdx
+++ b/sdk-reference/actions/mfa/enable.mdx
@@ -1,0 +1,35 @@
+---
+title: "enable"
+description: "Enable multi-factor authentication"
+---
+
+## Import
+
+```ts
+import { enable } from '@rhinestone/sdk/actions/mfa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [enable(validators, threshold)],
+})
+```
+
+## Parameters
+
+<ParamField path="validators" type="OwnableValidatorConfig | WebauthnValidatorConfig | null[]" required>
+  List of validators to use
+</ParamField>
+
+<ParamField path="threshold" type="number" required>
+  Threshold for the validators
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to enable multi-factor authentication
+</ResponseField>

--- a/sdk-reference/actions/mfa/remove-sub-validator.mdx
+++ b/sdk-reference/actions/mfa/remove-sub-validator.mdx
@@ -1,0 +1,35 @@
+---
+title: "removeSubValidator"
+description: "Remove a sub-validator (multi-factor)"
+---
+
+## Import
+
+```ts
+import { removeSubValidator } from '@rhinestone/sdk/actions/mfa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [removeSubValidator(id, validator)],
+})
+```
+
+## Parameters
+
+<ParamField path="id" type="number | `0x${string}`" required>
+  Validator ID
+</ParamField>
+
+<ParamField path="validator" type="OwnableValidatorConfig | WebauthnValidatorConfig" required>
+  Validator module
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to remove the sub-validator
+</ResponseField>

--- a/sdk-reference/actions/mfa/set-sub-validator.mdx
+++ b/sdk-reference/actions/mfa/set-sub-validator.mdx
@@ -1,0 +1,35 @@
+---
+title: "setSubValidator"
+description: "Set a sub-validator (multi-factor)"
+---
+
+## Import
+
+```ts
+import { setSubValidator } from '@rhinestone/sdk/actions/mfa'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [setSubValidator(id, validator)],
+})
+```
+
+## Parameters
+
+<ParamField path="id" type="number | `0x${string}`" required>
+  Validator ID
+</ParamField>
+
+<ParamField path="validator" type="OwnableValidatorConfig | WebauthnValidatorConfig" required>
+  Validator module
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to set the sub-validator
+</ResponseField>

--- a/sdk-reference/actions/modules/deploy.mdx
+++ b/sdk-reference/actions/modules/deploy.mdx
@@ -1,0 +1,28 @@
+---
+title: "deploy"
+---
+
+## Import
+
+```ts
+import { deploy } from '@rhinestone/sdk/actions'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [deploy(account)],
+})
+```
+
+## Parameters
+
+<ParamField path="account" type="RhinestoneAccount" required>
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+</ResponseField>

--- a/sdk-reference/actions/modules/install-module.mdx
+++ b/sdk-reference/actions/modules/install-module.mdx
@@ -1,0 +1,31 @@
+---
+title: "installModule"
+description: "Install a custom module"
+---
+
+## Import
+
+```ts
+import { installModule } from '@rhinestone/sdk/actions'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [installModule(module)],
+})
+```
+
+## Parameters
+
+<ParamField path="module" type="ModuleInput" required>
+  Module to install
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to install the module
+</ResponseField>

--- a/sdk-reference/actions/modules/uninstall-module.mdx
+++ b/sdk-reference/actions/modules/uninstall-module.mdx
@@ -1,0 +1,31 @@
+---
+title: "uninstallModule"
+description: "Uninstall a custom module"
+---
+
+## Import
+
+```ts
+import { uninstallModule } from '@rhinestone/sdk/actions'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [uninstallModule(module)],
+})
+```
+
+## Parameters
+
+<ParamField path="module" type="ModuleInput" required>
+  Module to uninstall
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to uninstall the module
+</ResponseField>

--- a/sdk-reference/actions/passkeys/add-owner.mdx
+++ b/sdk-reference/actions/passkeys/add-owner.mdx
@@ -1,0 +1,39 @@
+---
+title: "addOwner"
+description: "Add a passkey owner"
+---
+
+## Import
+
+```ts
+import { addOwner } from '@rhinestone/sdk/actions/passkeys'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [addOwner(pubKeyX, pubKeyY, requireUserVerification)],
+})
+```
+
+## Parameters
+
+<ParamField path="pubKeyX" type="bigint" required>
+  Public key X
+</ParamField>
+
+<ParamField path="pubKeyY" type="bigint" required>
+  Public key Y
+</ParamField>
+
+<ParamField path="requireUserVerification" type="boolean" required>
+  Whether to require user verification
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to add the passkey owner
+</ResponseField>

--- a/sdk-reference/actions/passkeys/change-threshold.mdx
+++ b/sdk-reference/actions/passkeys/change-threshold.mdx
@@ -1,0 +1,31 @@
+---
+title: "changeThreshold"
+description: "Change an account's signer threshold (passkey)"
+---
+
+## Import
+
+```ts
+import { changeThreshold } from '@rhinestone/sdk/actions/passkeys'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [changeThreshold(newThreshold)],
+})
+```
+
+## Parameters
+
+<ParamField path="newThreshold" type="number" required>
+  New threshold
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to change the threshold
+</ResponseField>

--- a/sdk-reference/actions/passkeys/disable.mdx
+++ b/sdk-reference/actions/passkeys/disable.mdx
@@ -1,0 +1,25 @@
+---
+title: "disable"
+description: "Disable passkeys (WebAuthn) authentication"
+---
+
+## Import
+
+```ts
+import { disable } from '@rhinestone/sdk/actions/passkeys'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [disable()],
+})
+```
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to disable passkeys authentication
+</ResponseField>

--- a/sdk-reference/actions/passkeys/enable.mdx
+++ b/sdk-reference/actions/passkeys/enable.mdx
@@ -1,0 +1,30 @@
+---
+title: "enable"
+description: "Enable passkeys authentication"
+---
+
+## Import
+
+```ts
+import { enable } from '@rhinestone/sdk/actions/passkeys'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [enable(credential)],
+})
+```
+
+## Parameters
+
+<ParamField path="credential" type="WebauthnCredential" required>
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to enable passkeys authentication
+</ResponseField>

--- a/sdk-reference/actions/passkeys/remove-owner.mdx
+++ b/sdk-reference/actions/passkeys/remove-owner.mdx
@@ -1,0 +1,35 @@
+---
+title: "removeOwner"
+description: "Remove a passkey owner"
+---
+
+## Import
+
+```ts
+import { removeOwner } from '@rhinestone/sdk/actions/passkeys'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [removeOwner(pubKeyX, pubKeyY)],
+})
+```
+
+## Parameters
+
+<ParamField path="pubKeyX" type="bigint" required>
+  Public key X
+</ParamField>
+
+<ParamField path="pubKeyY" type="bigint" required>
+  Public key Y
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput">
+  Call to remove the passkey owner
+</ResponseField>

--- a/sdk-reference/actions/recovery/enable.mdx
+++ b/sdk-reference/actions/recovery/enable.mdx
@@ -1,0 +1,35 @@
+---
+title: "enable"
+description: "Set up social recovery"
+---
+
+## Import
+
+```ts
+import { enable } from '@rhinestone/sdk/actions/recovery'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [enable(guardians, threshold)],
+})
+```
+
+## Parameters
+
+<ParamField path="guardians" type="Account[]" required>
+  Guardians to use for recovery
+</ParamField>
+
+<ParamField path="threshold" type="number" required>
+  Threshold for the guardians
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to set up social recovery
+</ResponseField>

--- a/sdk-reference/actions/recovery/recover-ecdsa-ownership.mdx
+++ b/sdk-reference/actions/recovery/recover-ecdsa-ownership.mdx
@@ -1,0 +1,42 @@
+---
+title: "recoverEcdsaOwnership"
+description: "Recover an account's ownership (ECDSA)"
+---
+
+## Import
+
+```ts
+import { recoverEcdsaOwnership } from '@rhinestone/sdk/actions/recovery'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [recoverEcdsaOwnership(address, newOwners, chain, config)],
+})
+```
+
+## Parameters
+
+<ParamField path="address" type="`0x${string}`" required>
+  Account address
+</ParamField>
+
+<ParamField path="newOwners" type="OwnableValidatorConfig" required>
+  New owners
+</ParamField>
+
+<ParamField path="chain" type="Chain" required>
+  Chain to recover ownership on
+</ParamField>
+
+<ParamField path="config" type="RhinestoneConfig" required>
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput[]">
+  Calls to recover ownership
+</ResponseField>

--- a/sdk-reference/actions/recovery/recover-ecdsa-ownership.mdx
+++ b/sdk-reference/actions/recovery/recover-ecdsa-ownership.mdx
@@ -14,7 +14,7 @@ import { recoverEcdsaOwnership } from '@rhinestone/sdk/actions/recovery'
 ```ts
 const transaction = await account.prepareTransaction({
   chain,
-  calls: [recoverEcdsaOwnership(address, newOwners, chain, config)],
+  calls: await recoverEcdsaOwnership(address, newOwners, chain, config),
 })
 ```
 

--- a/sdk-reference/actions/recovery/recover-passkey-ownership.mdx
+++ b/sdk-reference/actions/recovery/recover-passkey-ownership.mdx
@@ -1,0 +1,46 @@
+---
+title: "recoverPasskeyOwnership"
+description: "Recover an account's ownership (Passkey)"
+---
+
+## Import
+
+```ts
+import { recoverPasskeyOwnership } from '@rhinestone/sdk/actions/recovery'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [recoverPasskeyOwnership(address, oldCredentials, newOwners, chain, config)],
+})
+```
+
+## Parameters
+
+<ParamField path="address" type="`0x${string}`" required>
+  Account address
+</ParamField>
+
+<ParamField path="oldCredentials" type="{ pubKeyX: bigint; pubKeyY: bigint }[]" required>
+  Old credentials to be replaced (with pubKeyX, pubKeyY)
+</ParamField>
+
+<ParamField path="newOwners" type="WebauthnValidatorConfig" required>
+  New passkey owners
+</ParamField>
+
+<ParamField path="chain" type="Chain" required>
+  Chain to recover ownership on
+</ParamField>
+
+<ParamField path="config" type="RhinestoneConfig" required>
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CalldataInput[]">
+  Calls to recover ownership
+</ResponseField>

--- a/sdk-reference/actions/recovery/recover-passkey-ownership.mdx
+++ b/sdk-reference/actions/recovery/recover-passkey-ownership.mdx
@@ -14,7 +14,7 @@ import { recoverPasskeyOwnership } from '@rhinestone/sdk/actions/recovery'
 ```ts
 const transaction = await account.prepareTransaction({
   chain,
-  calls: [recoverPasskeyOwnership(address, oldCredentials, newOwners, chain, config)],
+  calls: await recoverPasskeyOwnership(address, oldCredentials, newOwners, chain, config),
 })
 ```
 

--- a/sdk-reference/actions/smart-sessions/create-cross-chain-permission.mdx
+++ b/sdk-reference/actions/smart-sessions/create-cross-chain-permission.mdx
@@ -45,5 +45,5 @@ const session = toSession({
 
 ## Returns
 
-<ResponseField name="call" type="CrossChainPermit">
+<ResponseField name="crossChainPermission" type="CrossChainPermit">
 </ResponseField>

--- a/sdk-reference/actions/smart-sessions/create-cross-chain-permission.mdx
+++ b/sdk-reference/actions/smart-sessions/create-cross-chain-permission.mdx
@@ -1,0 +1,49 @@
+---
+title: "createCrossChainPermission"
+description: "Build a CrossChainPermit from an ergonomic input shape."
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+Accepts:
+  - a single `from`/`to` leg or arrays of legs
+  - `TokenSymbol` ("USDC", "USDT", ...) which is resolved to the
+    per-chain ERC-20 address via the shared token registry
+  - `Date` or unix-seconds `bigint` for `validUntil`/`validAfter`
+
+Plug the returned object into `SessionDefinition.crossChainPermits`
+to permission a session key for Permit2-backed cross-chain transfers.
+
+## Import
+
+```ts
+import { createCrossChainPermission } from '@rhinestone/sdk/actions/smart-sessions'
+```
+
+## Usage
+
+```ts
+import { arbitrum, mainnet } from 'viem/chains'
+
+const permit = createCrossChainPermission({
+  from: { chain: mainnet, token: 'USDC', maxAmount: 1_000_000_000n },
+  to:   { chain: arbitrum, token: 'USDC' },
+  validUntil: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+})
+
+const session = toSession({
+  chain: mainnet,
+  owners: { type: 'ecdsa', accounts: [sessionKey] },
+  crossChainPermits: [permit],
+})
+```
+
+## Parameters
+
+<ParamField path="input" type="CreateCrossChainPermissionInput" required>
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="CrossChainPermit">
+</ResponseField>

--- a/sdk-reference/actions/smart-sessions/experimental-disable.mdx
+++ b/sdk-reference/actions/smart-sessions/experimental-disable.mdx
@@ -1,0 +1,27 @@
+---
+title: "experimental_disable"
+description: "Disable smart sessions"
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+## Import
+
+```ts
+import { experimental_disable } from '@rhinestone/sdk/actions/smart-sessions'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [experimental_disable()],
+})
+```
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to disable smart sessions
+</ResponseField>

--- a/sdk-reference/actions/smart-sessions/experimental-enable-session.mdx
+++ b/sdk-reference/actions/smart-sessions/experimental-enable-session.mdx
@@ -1,0 +1,49 @@
+---
+title: "experimental_enableSession"
+description: "Enable a smart session"
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+The `session` must be a resolved `Session` (the return value of
+`toSession(...)`). Re-resolving it here would drop the explicit
+`permissions` — a `Session` only carries the derived `actions`, not the
+original `SessionDefinition.permissions` — which makes the on-chain digest
+computed by `SmartSessionLens.getAndVerifyDigest` diverge from the one
+signed in `getSessionDetails`, causing the emissary to reject the enable.
+
+## Import
+
+```ts
+import { experimental_enableSession } from '@rhinestone/sdk/actions/smart-sessions'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [experimental_enableSession(session, enableSessionSignature, hashesAndChainIds, sessionToEnableIndex)],
+})
+```
+
+## Parameters
+
+<ParamField path="session" type="Session" required>
+  resolved session to enable
+</ParamField>
+
+<ParamField path="enableSessionSignature" type="`0x${string}`" required>
+</ParamField>
+
+<ParamField path="hashesAndChainIds" type="{ chainId: bigint; sessionDigest: `0x${string}` }[]" required>
+</ParamField>
+
+<ParamField path="sessionToEnableIndex" type="number" required>
+</ParamField>
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to enable the smart session
+</ResponseField>

--- a/sdk-reference/actions/smart-sessions/experimental-enable.mdx
+++ b/sdk-reference/actions/smart-sessions/experimental-enable.mdx
@@ -1,0 +1,27 @@
+---
+title: "experimental_enable"
+description: "Enable smart sessions"
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+## Import
+
+```ts
+import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
+```
+
+## Usage
+
+```ts
+const transaction = await account.prepareTransaction({
+  chain,
+  calls: [experimental_enable()],
+})
+```
+
+## Returns
+
+<ResponseField name="call" type="LazyCallInput">
+  Calls to enable smart sessions
+</ResponseField>

--- a/sdk-reference/rhinestone-sdk/create-account.mdx
+++ b/sdk-reference/rhinestone-sdk/create-account.mdx
@@ -1,0 +1,35 @@
+---
+title: "createAccount"
+description: "Create an account using this instance's shared configuration."
+---
+
+Method on a [`RhinestoneSDK`](/sdk-reference/rhinestone-sdk/rhinestone-sdk) instance.
+
+## Usage
+
+```ts
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const owner = privateKeyToAccount('0x...')
+
+const sdk = new RhinestoneSDK({
+  auth: { mode: 'apiKey', apiKey: process.env.RHINESTONE_API_KEY! },
+})
+
+const account = await sdk.createAccount({
+  owners: { type: 'ecdsa', accounts: [owner] },
+})
+```
+
+## Parameters
+
+<ParamField path="config" type="RhinestoneAccountConfig" required>
+  Per-account configuration (owners, account type, modules, sessions)
+</ParamField>
+
+## Returns
+
+<ResponseField name="account" type="RhinestoneAccount">
+  The account instance
+</ResponseField>

--- a/sdk-reference/rhinestone-sdk/get-intent-status.mdx
+++ b/sdk-reference/rhinestone-sdk/get-intent-status.mdx
@@ -1,0 +1,24 @@
+---
+title: "getIntentStatus"
+description: "Get the current status of a submitted intent."
+---
+
+Method on a [`RhinestoneSDK`](/sdk-reference/rhinestone-sdk/rhinestone-sdk) instance.
+
+## Usage
+
+```ts
+const intentStatus = await sdk.getIntentStatus(intentId)
+```
+
+## Parameters
+
+<ParamField path="intentId" type="string" required>
+  The intent ID returned when the transaction was submitted
+</ParamField>
+
+## Returns
+
+<ResponseField name="intentStatus" type="TransactionStatus">
+  The intent status
+</ResponseField>

--- a/sdk-reference/rhinestone-sdk/rhinestone-sdk.mdx
+++ b/sdk-reference/rhinestone-sdk/rhinestone-sdk.mdx
@@ -1,0 +1,24 @@
+---
+title: "RhinestoneSDK"
+description: "Stateful entry point that holds shared configuration (auth, provider, bundler, paymaster) and creates accounts from it."
+---
+
+## Import
+
+```ts
+import { RhinestoneSDK } from '@rhinestone/sdk'
+```
+
+## Usage
+
+```ts
+const sdk = new RhinestoneSDK({
+  // ...config
+})
+```
+
+## Parameters
+
+<ParamField path="options" type="RhinestoneSDKConfig" required>
+  Shared configuration applied to every account created by this instance
+</ParamField>

--- a/sdk-reference/rhinestone-sdk/split-intents.mdx
+++ b/sdk-reference/rhinestone-sdk/split-intents.mdx
@@ -1,0 +1,24 @@
+---
+title: "splitIntents"
+description: "Split a transaction into multiple intents across chains."
+---
+
+Method on a [`RhinestoneSDK`](/sdk-reference/rhinestone-sdk/rhinestone-sdk) instance.
+
+## Usage
+
+```ts
+const intents = await sdk.splitIntents(input)
+```
+
+## Parameters
+
+<ParamField path="input" type="SplitIntentsInput" required>
+  The intents to split
+</ParamField>
+
+## Returns
+
+<ResponseField name="intents" type="SplitIntentsResult">
+  The split-intents result
+</ResponseField>

--- a/sdk-reference/utils/experimental-get-rhinestone-init-data.mdx
+++ b/sdk-reference/utils/experimental-get-rhinestone-init-data.mdx
@@ -1,0 +1,43 @@
+---
+title: "experimental_getRhinestoneInitData"
+description: "Compute the Rhinestone initialization data for an account configuration."
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+Use this to reconstruct the `initData` for an account originally created with
+the Rhinestone SDK, then pass it back into `createAccount` instead of
+providing the factory and factory data manually.
+
+## Import
+
+```ts
+import { experimental_getRhinestoneInitData } from '@rhinestone/sdk/utils'
+```
+
+## Usage
+
+```ts
+import { experimental_getRhinestoneInitData } from '@rhinestone/sdk/utils'
+
+const initData = experimental_getRhinestoneInitData({
+  owners: { type: 'ecdsa', accounts: [owner] },
+})
+
+const account = await sdk.createAccount({
+  owners: { type: 'ecdsa', accounts: [owner] },
+  initData,
+})
+```
+
+## Parameters
+
+<ParamField path="config" type="RhinestoneAccountConfig" required>
+  Account configuration
+</ParamField>
+
+## Returns
+
+<ResponseField name="rhinestoneInitData" type="object | { address: `0x${string}` }">
+  The account address, plus factory data when the account is not yet deployed
+</ResponseField>

--- a/sdk-reference/utils/experimental-get-v0-init-data.mdx
+++ b/sdk-reference/utils/experimental-get-v0-init-data.mdx
@@ -1,0 +1,52 @@
+---
+title: "experimental_getV0InitData"
+description: "Compute the v0 (legacy) initialization data for an account configuration."
+---
+
+<Warning>This API is experimental and may change in a future release.</Warning>
+
+Use this to reconstruct the `initData` for an account originally created with
+the Rhinestone SDK v0, then pass it back into `createAccount`.
+
+## Import
+
+```ts
+import { experimental_getV0InitData } from '@rhinestone/sdk/utils'
+```
+
+## Usage
+
+```ts
+import { experimental_getV0InitData } from '@rhinestone/sdk/utils'
+
+const initData = experimental_getV0InitData({
+  owners: { type: 'ecdsa', accounts: [owner] },
+})
+
+const account = await sdk.createAccount({
+  owners: { type: 'ecdsa', accounts: [owner] },
+  initData,
+})
+```
+
+## Parameters
+
+<ParamField path="config" type="RhinestoneAccountConfig" required>
+  Account configuration
+</ParamField>
+
+## Returns
+
+The account address, factory, factory data, and whether the intent executor is installed
+
+<ResponseField name="address" type="`0x${string}`" required>
+</ResponseField>
+
+<ResponseField name="factory" type="`0x${string}`" required>
+</ResponseField>
+
+<ResponseField name="factoryData" type="`0x${string}`" required>
+</ResponseField>
+
+<ResponseField name="intentExecutorInstalled" type="boolean" required>
+</ResponseField>

--- a/sdk-reference/utils/to-view-only-account.mdx
+++ b/sdk-reference/utils/to-view-only-account.mdx
@@ -1,0 +1,35 @@
+---
+title: "toViewOnlyAccount"
+description: "Create a view-only viem Account for an address. Any signing operation throws."
+---
+
+Useful as an account owner when signing happens elsewhere (e.g. a server-held
+session signer), so the SDK can read from the account without holding a key.
+
+## Import
+
+```ts
+import { toViewOnlyAccount } from '@rhinestone/sdk/utils'
+```
+
+## Usage
+
+```ts
+import { toViewOnlyAccount } from '@rhinestone/sdk/utils'
+
+const account = await sdk.createAccount({
+  owners: { type: 'ecdsa', accounts: [toViewOnlyAccount(userAddress)] },
+})
+```
+
+## Parameters
+
+<ParamField path="address" type="`0x${string}`" required>
+  Address to wrap
+</ParamField>
+
+## Returns
+
+<ResponseField name="account" type="Account">
+  A viem account that can be read from but not signed with
+</ResponseField>


### PR DESCRIPTION
Adds an "SDK Reference" section at the bottom of the **Wallet** tab — one page per public symbol (entry point, account methods, actions, utils), in a viem-style template (Import / Usage / Parameters / Returns / See also).

The MDX is generated from the SDK's JSDoc by the reference generator in the `sdk` repo (`bun run reference`), and committed here since Mintlify builds from repo content. Companion SDK PR: rhinestonewtf/sdk#589.

Closes [RHI-3672](https://linear.app/rhinestone/issue/RHI-3672/reference-for-sdk).