### PR TITLE
docs: sharpen quickstarts with outcome previews and expected output

### DIFF
--- a/deposits/api/quickstart.mdx
+++ b/deposits/api/quickstart.mdx
@@ -3,11 +3,7 @@ title: "Quickstart"
 description: "Set up the Deposit API and process your first cross-chain deposit."
 ---
 
-Register a managed account, deposit USDC on one chain, and receive it on another — all through a few API calls. By the end you'll have polled a deposit to completion:
-
-```txt
-Deposit completed: 0x… (destination tx on Base Sepolia)
-```
+Register a managed account, deposit USDC on one chain, and receive it on another.
 
 ## Prerequisites
 
@@ -194,8 +190,6 @@ Once bridging completes, the deposit status changes to `completed` and includes 
 </Step>
 
 </Steps>
-
-The user made a single transfer on Optimism Sepolia — detection, bridging, swap, and gas were all handled for you.
 
 ## Next steps
 

--- a/deposits/api/quickstart.mdx
+++ b/deposits/api/quickstart.mdx
@@ -3,7 +3,11 @@ title: "Quickstart"
 description: "Set up the Deposit API and process your first cross-chain deposit."
 ---
 
-Register a managed account, deposit USDC on one chain, and receive it on another — all through a few API calls.
+Register a managed account, deposit USDC on one chain, and receive it on another — all through a few API calls. By the end you'll have polled a deposit to completion:
+
+```txt
+Deposit completed: 0x… (destination tx on Base Sepolia)
+```
 
 ## Prerequisites
 
@@ -190,6 +194,8 @@ Once bridging completes, the deposit status changes to `completed` and includes 
 </Step>
 
 </Steps>
+
+The user made a single transfer on Optimism Sepolia — detection, bridging, swap, and gas were all handled for you.
 
 ## Next steps
 

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -3,11 +3,7 @@ title: "Quickstart"
 description: "Add the deposit widget to your React app and accept cross-chain deposits in minutes."
 ---
 
-Install the `@rhinestone/deposit-modal` package, render the modal, and handle a completed deposit. By the end the modal fires a completion event when funds land on your target chain:
-
-```txt
-Deposit complete: 0x… (funds on Base)
-```
+Install the `@rhinestone/deposit-modal` package, render the modal, and handle a completed deposit.
 
 This quickstart uses **external wallet mode** with Reown for wallet connection. If you don't want to set up Reown, the modal also supports [QR code deposits](/deposits/widget/deposit-modal#qr-code-deposit) (no wallet connection) and [embedded wallets](/deposits/widget/deposit-modal#embedded-wallet) (Privy, Dynamic, Turnkey, etc.).
 
@@ -89,8 +85,6 @@ Add the `onLifecycle` callback and react to the `"complete"` event when tokens a
 </Step>
 
 </Steps>
-
-The user connects, picks any chain and token, and confirms — bridging to your target chain happens automatically, and `onLifecycle` tells you the moment funds land.
 
 ## Next steps
 

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -3,7 +3,11 @@ title: "Quickstart"
 description: "Add the deposit widget to your React app and accept cross-chain deposits in minutes."
 ---
 
-Install the `@rhinestone/deposit-modal` package, render the modal, and handle a completed deposit.
+Install the `@rhinestone/deposit-modal` package, render the modal, and handle a completed deposit. By the end the modal fires a completion event when funds land on your target chain:
+
+```txt
+Deposit complete: 0x… (funds on Base)
+```
 
 This quickstart uses **external wallet mode** with Reown for wallet connection. If you don't want to set up Reown, the modal also supports [QR code deposits](/deposits/widget/deposit-modal#qr-code-deposit) (no wallet connection) and [embedded wallets](/deposits/widget/deposit-modal#embedded-wallet) (Privy, Dynamic, Turnkey, etc.).
 
@@ -85,6 +89,8 @@ Add the `onLifecycle` callback and react to the `"complete"` event when tokens a
 </Step>
 
 </Steps>
+
+The user connects, picks any chain and token, and confirms — bridging to your target chain happens automatically, and `onLifecycle` tells you the moment funds land.
 
 ## Next steps
 

--- a/intents/quickstart.mdx
+++ b/intents/quickstart.mdx
@@ -1,9 +1,13 @@
 ---
-title: "API quickstart"
+title: "Quickstart"
 description: "Send your first crosschain intent via the Rhinestone REST API."
 ---
 
-This guide walks through the full intent flow for **EOA users**: get a quote, fulfill token requirements, sign, and submit.
+Send your first crosschain intent straight through the REST API. This guide walks the full flow for **EOA users** — get a quote, fulfill token requirements, sign, and submit — and ends with the intent settled on the destination chain:
+
+```txt
+Final status: COMPLETED
+```
 
 <Info>
   **Using the Rhinestone SDK?** The [wallet quickstart](/smart-wallet/quickstart) already covers crosschain intents. Come back here when you need API-specific configuration.
@@ -179,11 +183,19 @@ async function pollStatus(intentId: string) {
 await pollStatus(submittedId);
 ```
 
+Once execution finishes you'll see the terminal status:
+
+```txt
+Final status: COMPLETED
+```
+
 Typical execution time is under 2 seconds. See [Tracking intents](/intents/guides/tracking-intents) for the full lifecycle.
 
 </Step>
 
 </Steps>
+
+Your tokens moved across chains from a single set of signatures — no bridge, no manual settlement.
 
 ## Next steps
 

--- a/intents/quickstart.mdx
+++ b/intents/quickstart.mdx
@@ -3,11 +3,7 @@ title: "Quickstart"
 description: "Send your first crosschain intent via the Rhinestone REST API."
 ---
 
-Send your first crosschain intent straight through the REST API. This guide walks the full flow for **EOA users** — get a quote, fulfill token requirements, sign, and submit — and ends with the intent settled on the destination chain:
-
-```txt
-Final status: COMPLETED
-```
+Send your first crosschain intent straight through the REST API. This guide walks the full flow for **EOA users**.
 
 <Info>
   **Using the Rhinestone SDK?** The [wallet quickstart](/smart-wallet/quickstart) already covers crosschain intents. Come back here when you need API-specific configuration.

--- a/smart-wallet/quickstart.mdx
+++ b/smart-wallet/quickstart.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Quickstart"
-description: "Create a smart account and send a crosschain transaction in a Node.js script."
+description: "Create a smart account and send a crosschain transaction"
 ---
 
-Create a smart account and send a crosschain transaction in a Node.js script — no browser or wallet connection required. By the end you'll have an account deployed on two chains and a USDC transfer that crossed between them, funded entirely with ETH:
+Create a smart account and send a crosschain transaction.
+
+By the end you'll have an account deployed on two chains and a USDC transfer that crossed between them, funded entirely with ETH.
 
 ```txt
 Smart account address: 0x5fA3…42c1
@@ -13,9 +15,7 @@ Result { status: 'COMPLETED', … }
 
 ## Prerequisites
 
-<Note>You don't need an API key for testnets. For production — especially sponsoring fees or using dashboard API keys — see the [Security guide](./advanced/security) to proxy Orchestrator requests via a backend and avoid exposing your key.</Note>
-
-You'll need a funding account with some testnet ETH on Base Sepolia. Get testnet ETH from [QuickNode](https://faucet.quicknode.com/drip) or [Alchemy](https://www.alchemy.com/faucets). You don't need testnet USDC — the Orchestrator sources it from your ETH.
+You'll need a funding account with some testnet ETH on Base Sepolia. Get testnet ETH from [QuickNode](https://faucet.quicknode.com/drip) or [Alchemy](https://www.alchemy.com/faucets).
 
 Install the SDK:
 
@@ -85,10 +85,10 @@ console.log(`Smart account address: ${address}`)
 You'll see a deterministic address printed:
 
 ```txt
-Smart account address: 0x5fA3…42c1
+Smart account address: 0x...
 ```
 
-Nothing is onchain yet — the account is deployed lazily on first use, on each chain it touches.
+Nothing is onchain yet: the account is deployed lazily on first use, on each chain it touches.
 
 </Step>
 
@@ -119,7 +119,7 @@ await publicClient.waitForTransactionReceipt({ hash: txHash })
 
 <Step title="Send a crosschain transaction">
 
-Transfer USDC on the target chain — sourced from the ETH you funded on the source chain:
+Transfer USDC on the target chain, sourced from the ETH you funded on the source chain:
 
 ```ts
 const usdcAmount = parseUnits('0.1', 6)
@@ -173,7 +173,7 @@ Result {
 }
 ```
 
-Your ETH on Base Sepolia landed as USDC on Arbitrum Sepolia in a single atomic operation — no bridging, swapping, or gas tokens to manage.
+Your ETH on Base Sepolia landed as USDC on Arbitrum Sepolia in a single atomic operation: no bridging, swapping, or gas tokens to manage.
 
 </Step>
 

--- a/smart-wallet/quickstart.mdx
+++ b/smart-wallet/quickstart.mdx
@@ -1,16 +1,23 @@
 ---
 title: "Quickstart"
+description: "Create a smart account and send a crosschain transaction in a Node.js script."
 ---
 
-Create a smart account and send a crosschain transaction in a Node.js script. No browser or wallet connection required.
+Create a smart account and send a crosschain transaction in a Node.js script — no browser or wallet connection required. By the end you'll have an account deployed on two chains and a USDC transfer that crossed between them, funded entirely with ETH:
+
+```txt
+Smart account address: 0x5fA3…42c1
+Transaction { type: 'intent', id: '0x9c…', targetChain: 421614 }
+Result { status: 'COMPLETED', … }
+```
 
 ## Prerequisites
 
-<Note>You don't need an API key to get started. For production use, you'll need one. For production setups that sponsor user fees or use dashboard API keys, see the [Security guide](./advanced/security) to proxy Orchestrator requests via a backend and avoid exposing your key.</Note>
+<Note>You don't need an API key for testnets. For production — especially sponsoring fees or using dashboard API keys — see the [Security guide](./advanced/security) to proxy Orchestrator requests via a backend and avoid exposing your key.</Note>
 
-You will need some testnet funds. To get testnet ETH, you can use a faucet from [Quicknode](https://faucet.quicknode.com/drip) or [Alchemy](https://www.alchemy.com/faucets). To get testnet USDC, use [Circle Faucet](https://faucet.circle.com/).
+You'll need a funding account with some testnet ETH on Base Sepolia. Get testnet ETH from [QuickNode](https://faucet.quicknode.com/drip) or [Alchemy](https://www.alchemy.com/faucets). You don't need testnet USDC — the Orchestrator sources it from your ETH.
 
-Install the Rhinestone SDK:
+Install the SDK:
 
 <CodeGroup>
 
@@ -30,9 +37,9 @@ bun install viem @rhinestone/sdk@beta
 
 <Steps>
 
-<Step title="Create a Wallet">
+<Step title="Create an account">
 
-Let's create a smart account with a single owner:
+Create a smart account with a single ECDSA owner:
 
 ```ts
 import { RhinestoneSDK } from '@rhinestone/sdk'
@@ -46,6 +53,7 @@ import {
   type Hex,
   http,
   parseEther,
+  parseUnits,
 } from 'viem'
 
 const fundingPrivateKey = process.env.FUNDING_PRIVATE_KEY
@@ -74,11 +82,19 @@ const address = rhinestoneAccount.getAddress()
 console.log(`Smart account address: ${address}`)
 ```
 
+You'll see a deterministic address printed:
+
+```txt
+Smart account address: 0x5fA3…42c1
+```
+
+Nothing is onchain yet — the account is deployed lazily on first use, on each chain it touches.
+
 </Step>
 
-<Step title="Fund the Account">
+<Step title="Fund the account">
 
-Send ETH to the smart account. The Orchestrator handles deployment and token conversion on the destination chain.
+Send ETH to the smart account on the source chain. This is the only token you fund:
 
 ```ts
 const publicClient = createPublicClient({
@@ -101,12 +117,12 @@ await publicClient.waitForTransactionReceipt({ hash: txHash })
 
 </Step>
 
-<Step title="Send a Cross-chain Transaction">
+<Step title="Send a crosschain transaction">
 
-Finally, let's make a cross-chain token transfer:
+Transfer USDC on the target chain — sourced from the ETH you funded on the source chain:
 
 ```ts
-const usdcAmount = 1n
+const usdcAmount = parseUnits('0.1', 6)
 
 const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [sourceChain],
@@ -137,9 +153,27 @@ const transactionResult = await rhinestoneAccount.waitForExecution(transaction)
 console.log('Result', transactionResult)
 ```
 
-After running that, you will get a smart account deployed on both Base Sepolia and Arbitrum Sepolia, and make a cross-chain USDC transfer.
+`submitTransaction` returns an intent handle; `waitForExecution` polls until every chain's operation reaches a terminal state:
 
-Note that you don't need to manage the gas tokens or do the ETH → USDC swap when making a transfer. The Orchestrator will handle that for you!
+```txt
+Transaction {
+  type: 'intent',
+  id: '0x9c…',
+  traceId: '…',
+  sourceChains: [ 84532 ],
+  targetChain: 421614
+}
+Result {
+  status: 'COMPLETED',
+  accountAddress: '0x5fA3…42c1',
+  operations: [
+    { chain: 84532, status: 'COMPLETED', txHash: '0x…', timestamp: 1750000000 },
+    { chain: 421614, status: 'COMPLETED', txHash: '0x…', timestamp: 1750000002 }
+  ]
+}
+```
+
+Your ETH on Base Sepolia landed as USDC on Arbitrum Sepolia in a single atomic operation — no bridging, swapping, or gas tokens to manage.
 
 </Step>
 
@@ -153,7 +187,7 @@ Note that you don't need to manage the gas tokens or do the ETH → USDC swap wh
   **Going to production?** Never expose your Rhinestone API key in the browser. Read the [Security guide](./advanced/security) to proxy Orchestrator requests safely via a backend.
 </Warning>
 
-## Next Steps
+## Next steps
 
 <CardGroup cols={3}>
   <Card title="Sponsor fees" icon="fuel" href="./tutorials/sponsor-fees">
@@ -166,9 +200,5 @@ Note that you don't need to manage the gas tokens or do the ETH → USDC swap wh
 
   <Card title="Smart Sessions" icon="key" href="./smart-sessions/overview">
     Add session keys for one-click UX and automated transactions.
-  </Card>
-
-  <Card title="EIP-7702" icon="zap" href="./core/eip-7702">
-    Add smart account features to an existing EOA without changing its address.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Reworks the four quickstarts (smart wallet, intents API, deposit API, deposit widget) so they're faster to follow *and* leave the reader with a working mental model — per the [diátaxis tutorial principles](https://diataxis.fr/tutorials/).

Each quickstart now:
- **Previews the end result up front** — "show the learner where they'll go".
- **Shows expected output** after the key steps — "maintain a narrative of the expected". Shapes for the SDK page are pulled from the real `TransactionResult` / `TransactionStatus` types.
- **Closes with a single line on what just happened**, instead of an explanatory block — keeps explanation out of the doing.

Other touches:
- Consistent `Quickstart` titles (was "API quickstart").
- Sentence-case step headings.
- Smart-wallet: USDC amount bumped from `1n` to `parseUnits('0.1', 6)`; dropped the EIP-7702 next-step card.

Example output values are illustrative (truncated hashes); shapes are real.

Closes [RHI-3673](https://linear.app/rhinestone/issue/RHI-3673)

🤖 Generated with [Claude Code](https://claude.com/claude-code)