### PR TITLE
docs: document v2 cleanup breaking changes in the migration guide

### DIFF
--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -99,7 +99,7 @@ In 1.x, each `action` carried a raw `policies` array that you assembled by hand.
 
 - `params: { x: { anyOf: [a, b] } }` — allowlist a parameter against several values (compiles to an arg-policy OR chain). A single `{ condition, value }` stays a cheaper universal-action.
 - `maxUses` — cap how many times the function may be called.
-- `validUntil` / `validAfter` — restrict the function to a time window (`Date` or ms-epoch).
+- `validUntil` / `validAfter` — restrict the function to a time window (`Date`).
 - `valueLimit` — cap cumulative ETH value (payable functions only; rejected at compile time otherwise).
 - `spendingLimit: { token, amount }` — cap cumulative ERC-20 spend (only on `transfer` / `transferFrom` / `approve` / `increaseAllowance`-shaped functions).
 
@@ -345,8 +345,75 @@ const allowance = await publicClient.readContract({
 })
 ```
 
+### Cross-chain permits fold into `toSession`
+
+`createCrossChainPermission` is removed. Pass the same input directly on `SessionDefinition.crossChainPermits` — `toSession` resolves token symbols, deadlines, and leg normalization internally:
+
+```ts
+// Before
+import { createCrossChainPermission } from '@rhinestone/sdk/actions/smart-sessions'
+
+const permit = createCrossChainPermission({
+  from: { chain: base, token: 'USDC' },
+  to: { chain: arbitrum, token: 'USDC' },
+})
+const session = toSession({ chain: base, owners, crossChainPermits: [permit] })
+
+// After
+const session = toSession({
+  chain: base,
+  owners,
+  crossChainPermits: [
+    {
+      from: { chain: base, token: 'USDC' },
+      to: { chain: arbitrum, token: 'USDC' },
+    },
+  ],
+})
+```
+
+The input type is now `CrossChainPermissionInput` (was `CreateCrossChainPermissionInput`).
+
+### Datetime inputs accept `Date`
+
+Public datetime inputs accept a `Date` only — raw epoch `number` / `bigint` are no longer accepted. This affects permission `validUntil` / `validAfter`, the cross-chain permit `validUntil` / `validAfter` / `fillDeadline` bounds, and `experimental_disableSession`'s `expires`. Convert at the boundary:
+
+```ts
+// Before
+functions: { transfer: { validUntil: 1893456000000 } }
+
+// After
+functions: { transfer: { validUntil: new Date('2030-01-01') } }
+```
+
+### ENS validator owner set
+
+`ENSValidatorConfig` couples each owner with its expiry instead of using parallel arrays. Omit `expiration` for an owner that never expires:
+
+```ts
+// Before — parallel arrays, expirations in unix seconds
+const validator = {
+  type: 'ens',
+  accounts: [alice, bob],
+  ownerExpirations: [1893456000, 1893456000],
+}
+
+// After — each owner carries its own expiry (omit `expiration` to never expire)
+const validator = {
+  type: 'ens',
+  owners: [
+    { account: alice, expiration: new Date('2030-01-01') },
+    { account: bob, expiration: new Date('2030-01-01') },
+  ],
+}
+```
+
 ### Removed and relocated helpers
 
+- **`createRhinestoneAccount`** is removed. Use `new RhinestoneSDK({ apiKey }).createAccount(config)`.
+- **Account recovery.** The `@rhinestone/sdk/actions/recovery` subpackage (`enable`, `recoverEcdsaOwnership`, `recoverPasskeyOwnership`), the `recovery` field on the account config, and the guardian signer set are removed.
+- **`account.deploy()` session param.** The unused `session` option on `account.deploy()` is removed (it was a no-op).
+- **`@rhinestone/sdk/smart-sessions`** now exports only the curated public surface — `toSession`, the policy address constants, and the `SessionDetails` / `ChainDigest` types. The internal helpers it previously re-exported are no longer public.
 - **Compact-bound surface.** The `@rhinestone/sdk/actions/compact` subpackage, the `lockFunds` transaction option, and `Account.emissaryConfig` are removed alongside the orchestrator's compact-based deposit/withdrawal flow.
 - **Permit2 signing helpers.** `signPermit2Batch`, `signPermit2Sequential`, and the related `MultiChainPermit2Config` / `MultiChainPermit2Result` / `BatchPermit2Result` types are removed. Signing now uses orchestrator-provided EIP-712 typed data internally.
 - **`getPermit2Address`** is removed. Permit2 lives at `0x000000000022D473030F116dDEE9F6B43aC78BA3` on every supported chain — hardcode the constant.
@@ -401,7 +468,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
 
 ### Transaction utilities (actions)
 
-Action utilities related to using modules and resource locking (e.g., `installModule`, `addOwner`, `recoverEcdsaOwnership`) were moved to separate subpackages:
+Action utilities related to using modules and account management (e.g., `installModule`, `addOwner`) were moved to separate subpackages:
 
 ```ts
 // Before
@@ -466,10 +533,6 @@ await rhinestoneAccount.sendTransaction({
     * `addOwner` to add an owner
     * `removeOwner` to remove an owner
     * `changeThreshold` to change the signature threshold
-  * `/actions/recovery` (social recovery):
-    * `enable` to enable the validator
-    * `recoverEcdsaOwnership` to recover ownership to a new ECDSA owner
-    * `recoverPasskeyOwnership` to recover ownership to a new passkey owner
 </Accordion>
 
 ### Errors
@@ -487,7 +550,7 @@ import { isAccountError, AccountError, SigningNotSupportedForAccountError } from
 
 All transactions executed with `sendTransaction` and `prepareTransaction` now use Rhinestone intents.
 
-Using the ERC-4337 user operations (for example, when using a social recovery) now requires a separate flow.
+Using the ERC-4337 user operations now requires a separate flow.
 
 This change lets us improve type-safety and DX around using intents.
 


### PR DESCRIPTION
Adds the SDK v2 cleanup breaking changes to the v1→v2 migration section.

- `createCrossChainPermission` folded into `toSession` (`crossChainPermits`)
- Datetime inputs are `Date`-only (no epoch number/bigint)
- `ENSValidatorConfig` owner-set reshape (`owners: { account, expiration? }[]`)
- Removed: `createRhinestoneAccount`, the recovery subpackage + guardian signer, the `deploy()` `session` param; trimmed `./smart-sessions` surface
- Drops the removed recovery action from the alpha-section "All actions" accordion

Closes [RHI-4593](https://linear.app/rhinestone/issue/RHI-4593)