### PR TITLE
Use declarative fields for session policies

### DIFF
--- a/smart-wallet/smart-sessions/policies/spending-limit.mdx
+++ b/smart-wallet/smart-sessions/policies/spending-limit.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Spending limit"
 
 You can limit the amount of ERC20 tokens transferable through a session function. Attach the policy at the function level — it caps the cumulative amount across all uses of that function.
 
-```ts {15-23}
+```ts {13-16}
 const session = toSession({
   chain: base,
   owners: {
@@ -18,21 +18,10 @@ const session = toSession({
       address: usdcAddress,
       functions: {
         transfer: {
-          policies: [
-            {
-              type: 'spending-limits',
-              limits: [
-                {
-                  token: usdcAddress,
-                  amount: parseUnits('10', 6),
-                },
-                {
-                  token: wethAddress,
-                  amount: parseUnits('0.1', 18),
-                },
-              ],
-            },
-          ],
+          spendingLimit: {
+            token: usdcAddress,
+            amount: parseUnits('10', 6),
+          },
         },
       },
     },
@@ -40,4 +29,4 @@ const session = toSession({
 })
 ```
 
-This caps total transfers within the session to 10 USDC and 0.1 WETH combined.
+This caps total USDC transfers within the session to 10 USDC.

--- a/smart-wallet/smart-sessions/policies/timeframe.mdx
+++ b/smart-wallet/smart-sessions/policies/timeframe.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Timeframe"
 
 Restrict when a session function can be called. Attach the policy at the function level.
 
-```ts {14-18}
+```ts {13-14}
 const session = toSession({
   chain: base,
   owners: {
@@ -18,13 +18,8 @@ const session = toSession({
       address: usdcAddress,
       functions: {
         transfer: {
-          policies: [
-            {
-              type: 'time-frame',
-              validAfter: Date.now(),
-              validUntil: Date.now() + 1000 * 60 * 60 * 24,
-            },
-          ],
+          validAfter: new Date(),
+          validUntil: new Date(Date.now() + 1000 * 60 * 60 * 24),
         },
       },
     },

--- a/smart-wallet/smart-sessions/policies/usage-limit.mdx
+++ b/smart-wallet/smart-sessions/policies/usage-limit.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Usage limit"
 
 Limit how many times a session function can be called.
 
-```ts {14-17}
+```ts {13}
 const session = toSession({
   chain: base,
   owners: {
@@ -18,12 +18,7 @@ const session = toSession({
       address: usdcAddress,
       functions: {
         transfer: {
-          policies: [
-            {
-              type: 'usage-limit',
-              limit: 10n,
-            },
-          ],
+          maxUses: 10n,
         },
       },
     },

--- a/smart-wallet/tutorials/session-keys.mdx
+++ b/smart-wallet/tutorials/session-keys.mdx
@@ -94,14 +94,10 @@ const session = toSession({
       address: usdcAddress,
       functions: {
         transfer: {
-          policies: [
-            {
-              type: 'spending-limits',
-              limits: [
-                { token: usdcAddress, amount: parseUnits('100', 6) }, // 100 USDC
-              ],
-            },
-          ],
+          spendingLimit: {
+            token: usdcAddress,
+            amount: parseUnits('100', 6), // 100 USDC
+          },
         },
       },
     },


### PR DESCRIPTION
The raw `functions: { fn: { policies: [{ type: … }] } }` permission shape was removed in SDK v2 and now throws at runtime. These docs still showed it, so the examples don't work against the current SDK (caught while building the new `session-keys` e2e example).

Updated to the shipped declarative fields, verified against the published types:

| Page | Before | After |
|------|--------|-------|
| `tutorials/session-keys.mdx` | `policies:[{type:'spending-limits',…}]` | `spendingLimit: { token, amount }` |
| `smart-sessions/policies/spending-limit.mdx` | same | `spendingLimit: { token, amount }` |
| `smart-sessions/policies/usage-limit.mdx` | `policies:[{type:'usage-limit',limit}]` | `maxUses: 10n` |
| `smart-sessions/policies/timeframe.mdx` | `policies:[{type:'time-frame',…}]` | `validAfter` / `validUntil` as `Date` |

`spending-limit.mdx` previously capped two tokens via the `limits` array; the declarative `spendingLimit` is single-token, so that example is now a single USDC limit.

Swept the rest of the docs — no other occurrences of the removed `policies`/`actions` shape (the `migration-guide.mdx` usage is the intentional v1 "before" snippet).