### PR TITLE
Add multisig & MFA examples

### DIFF
--- a/smart-wallet/advanced/multi-factor-authentication.mdx
+++ b/smart-wallet/advanced/multi-factor-authentication.mdx
@@ -24,8 +24,9 @@ const rhinestone = new RhinestoneSDK()
 const rhinestoneAccount = await rhinestone.createAccount({
   owners: {
     type: 'multi-factor',
-    // List of subvalidators to use
-    // Multiple validators can have the same type
+    // Require a valid signature from both an EOA and a passkey signer
+    threshold: 2,
+    // List of subvalidators to use; multiple validators can have the same type
     validators: [
       {
         type: 'ecdsa',
@@ -35,8 +36,6 @@ const rhinestoneAccount = await rhinestone.createAccount({
         type: 'passkey',
         accounts: [passkeyAccount],
       },
-      // Setting this will require a valid signature from both an EOA and a passkey signer
-      threshold: 2,
     ],
   },
 })
@@ -135,4 +134,66 @@ const transaction = await rhinestoneAccount.prepareTransaction({
     }),
   ],
 })
+```
+
+## Example: EOA + passkey (2-of-2)
+
+End to end: create an account that requires both an EOA and a passkey, then approve a transaction with both factors.
+
+```ts
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { toWebAuthnAccount } from 'viem/account-abstraction'
+import { base, arbitrum } from 'viem/chains'
+import { encodeFunctionData, erc20Abi, parseUnits } from 'viem'
+
+const eoaAccount = privateKeyToAccount(generatePrivateKey())
+const passkeyAccount = toWebAuthnAccount({ credential })
+
+const rhinestone = new RhinestoneSDK({
+  apiKey: process.env.RHINESTONE_API_KEY as string,
+})
+
+// Require a signature from both the EOA and the passkey
+const rhinestoneAccount = await rhinestone.createAccount({
+  owners: {
+    type: 'multi-factor',
+    threshold: 2,
+    validators: [
+      { type: 'ecdsa', accounts: [eoaAccount] },
+      { type: 'passkey', accounts: [passkeyAccount] },
+    ],
+  },
+})
+
+const usdcAmount = parseUnits('0.1', 6)
+const prepared = await rhinestoneAccount.prepareTransaction({
+  sourceChains: [base],
+  targetChain: arbitrum,
+  calls: [
+    {
+      to: 'USDC',
+      value: 0n,
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: ['0xd8da6bf26964af9d7eed9e03e53415d37aa96045', usdcAmount],
+      }),
+    },
+  ],
+  tokenRequests: [{ address: 'USDC', amount: usdcAmount }],
+  // Provide both factors. `id` is each validator's index in the list above.
+  signers: {
+    type: 'owner',
+    kind: 'multi-factor',
+    validators: [
+      { type: 'ecdsa', id: 0, accounts: [eoaAccount] },
+      { type: 'passkey', id: 1, accounts: [passkeyAccount] },
+    ],
+  },
+})
+
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
+const result = await rhinestoneAccount.waitForExecution(transaction)
 ```

--- a/smart-wallet/core/multisig.mdx
+++ b/smart-wallet/core/multisig.mdx
@@ -217,3 +217,65 @@ To retrieve the current list of owners along with the signature threshold:
 const owners = await rhinestoneAccount.getOwners(chain)
 // → { "accounts": ["0xaaa…", "0xbbb…", "0xccc…"], "threshold": 2 }
 ```
+
+## Example: 2-of-3 approval
+
+End to end: create a 2-of-3 ECDSA account, then approve a transaction with two of the three owners.
+
+```ts
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { base, arbitrum } from 'viem/chains'
+import { encodeFunctionData, erc20Abi, parseUnits } from 'viem'
+
+const accountA = privateKeyToAccount(generatePrivateKey())
+const accountB = privateKeyToAccount(generatePrivateKey())
+const accountC = privateKeyToAccount(generatePrivateKey())
+
+const rhinestone = new RhinestoneSDK({
+  apiKey: process.env.RHINESTONE_API_KEY as string,
+})
+
+// Any two of the three owners can approve
+const rhinestoneAccount = await rhinestone.createAccount({
+  owners: {
+    type: 'ecdsa',
+    accounts: [accountA, accountB, accountC],
+    threshold: 2,
+  },
+})
+
+const usdcAmount = parseUnits('0.1', 6)
+const prepared = await rhinestoneAccount.prepareTransaction({
+  sourceChains: [base],
+  targetChain: arbitrum,
+  calls: [
+    {
+      to: 'USDC',
+      value: 0n,
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: ['0xd8da6bf26964af9d7eed9e03e53415d37aa96045', usdcAmount],
+      }),
+    },
+  ],
+  tokenRequests: [{ address: 'USDC', amount: usdcAmount }],
+  // Sign with two owners to meet the threshold
+  signers: {
+    type: 'owner',
+    kind: 'ecdsa',
+    accounts: [accountA, accountB],
+  },
+})
+
+const signed = await rhinestoneAccount.signTransaction(prepared)
+const transaction = await rhinestoneAccount.submitTransaction(signed)
+const result = await rhinestoneAccount.waitForExecution(transaction)
+```
+
+Signing with only one owner would fail validation, since the account requires two.
+
+<Note>
+For clarity this signs with both owners in a single call. In practice the owners are usually separate parties who each sign the same transaction independently, and their signatures are merged into the account's multisig signature. A dedicated helper for independent signing and merging is coming.
+</Note>

--- a/smart-wallet/core/passkeys.mdx
+++ b/smart-wallet/core/passkeys.mdx
@@ -125,3 +125,61 @@ const transaction = await account.prepareTransaction({
   tokenRequests: [],
 })
 ```
+
+## Example: multi-device 1-of-n
+
+Register a passkey per device and use a 1-of-n threshold, so the user can sign from any of their devices.
+
+```ts
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { toWebAuthnAccount } from 'viem/account-abstraction'
+import { base, arbitrum } from 'viem/chains'
+import { encodeFunctionData, erc20Abi, parseUnits } from 'viem'
+
+// One passkey per device, each registered via WebAuthn on that device
+const passkeyAccountA = toWebAuthnAccount({ credential: credentialFromDeviceA })
+const passkeyAccountB = toWebAuthnAccount({ credential: credentialFromDeviceB })
+
+const rhinestone = new RhinestoneSDK({
+  apiKey: process.env.RHINESTONE_API_KEY as string,
+})
+
+// Any single registered device can sign
+const account = await rhinestone.createAccount({
+  owners: {
+    type: 'passkey',
+    accounts: [passkeyAccountA, passkeyAccountB],
+    threshold: 1,
+  },
+})
+
+const usdcAmount = parseUnits('0.1', 6)
+const prepared = await account.prepareTransaction({
+  sourceChains: [base],
+  targetChain: arbitrum,
+  calls: [
+    {
+      to: 'USDC',
+      value: 0n,
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: ['0xd8da6bf26964af9d7eed9e03e53415d37aa96045', usdcAmount],
+      }),
+    },
+  ],
+  tokenRequests: [{ address: 'USDC', amount: usdcAmount }],
+  // Sign from a single device
+  signers: {
+    type: 'owner',
+    kind: 'passkey',
+    accounts: [passkeyAccountA],
+  },
+})
+
+const signed = await account.signTransaction(prepared)
+const transaction = await account.submitTransaction(signed)
+const result = await account.waitForExecution(transaction)
+```
+
+When the user adds a new device, register a passkey for it and add it as an owner — see [Add a passkey (new device)](#add-a-passkey-new-device).


### PR DESCRIPTION
Adds an end-to-end **Example** section to each signer-type page, showing the full approval flow (create → prepare → sign with the threshold-meeting signer set → submit → wait) instead of scattered config fragments. No new pages.

- **`core/multisig.mdx`** — 2-of-3 ECDSA. Signs with two of three owners via the `signers` subset. Includes a note that production owners are usually separate parties who sign independently, with their signatures merged into the multisig signature (a dedicated helper is pending — see below).
- **`core/passkeys.mdx`** — multi-device 1-of-n (a passkey per device, any one can sign).
- **`advanced/multi-factor-authentication.mdx`** — EOA + passkey 2-of-2.

Also fixes the MFA **Initialization** snippet on that page, which placed `threshold` *inside* the `validators` array (a syntax error — it's a sibling of `validators`).

All signer-set shapes verified against the published types. `bunx mintlify broken-links` is clean for the changed files.

Closes [RHI-4635](https://linear.app/rhinestone/issue/RHI-4635)
Follow-up: [RHI-4647](https://linear.app/rhinestone/issue/RHI-4647/sdk-util-to-merge-independent-multisig-signatures) — SDK helper to merge independent multisig signatures; update the multisig example once it ships.