### PR TITLE
Reconcile example links, remove stale swap stub

### DIFF
--- a/intents/use-cases/chain-abstracted-swaps.mdx
+++ b/intents/use-cases/chain-abstracted-swaps.mdx
@@ -1,8 +1,0 @@
----
-title: "Chain abstracted swaps"
-description: "Bridge and swap in a single transaction."
----
-
-<Card title="Swaps guide" icon="arrow-right-left" href="../../smart-wallet/chain-abstraction/swaps">
-  Full SDK and API documentation for solver-based and injected swaps.
-</Card>

--- a/smart-wallet/core/passkeys.mdx
+++ b/smart-wallet/core/passkeys.mdx
@@ -183,3 +183,5 @@ const result = await account.waitForExecution(transaction)
 ```
 
 When the user adds a new device, register a passkey for it and add it as an owner — see [Add a passkey (new device)](#add-a-passkey-new-device).
+
+**See it in action:** [passkey example](https://github.com/rhinestonewtf/e2e-examples/tree/main/passkey) — a passkey-only account with no third-party auth provider.

--- a/smart-wallet/core/signers/dynamic.mdx
+++ b/smart-wallet/core/signers/dynamic.mdx
@@ -376,8 +376,9 @@ Try the full integration in our example repository:
 
 ```bash
 git clone https://github.com/rhinestonewtf/e2e-examples.git
-cd e2e-examples/dynamic
-npm install && npm run dev
+cd e2e-examples
+pnpm install
+cd dynamic && pnpm dev
 ```
 
 The example demonstrates:

--- a/smart-wallet/core/signers/external-wallet-signer.mdx
+++ b/smart-wallet/core/signers/external-wallet-signer.mdx
@@ -187,13 +187,15 @@ Try the full integration in our example repository. We have lots of examples, ca
 
 ```bash
 git clone https://github.com/rhinestonewtf/e2e-examples.git
-cd e2e-examples/reown
-npm install && npm run dev
+cd e2e-examples
+pnpm install
+cd reown && pnpm dev
 ```
 
 ## Next Steps
 
 - **See it in action**: [External Wallet + Rhinestone Example](https://github.com/rhinestonewtf/e2e-examples/tree/main/reown)
+- **No auth provider**: pure [wagmi](https://github.com/rhinestonewtf/e2e-examples/tree/main/standalone-wagmi) (injected connector) and [viem](https://github.com/rhinestonewtf/e2e-examples/tree/main/standalone-viem) (Node script) examples
 - **Reown + Wagmi connectors**: Learn about [wagmi connectors](https://docs.reown.com/appkit/next/core/installation)
 - **Session keys**: Set up [session keys](../../smart-sessions/overview) for automated operations
 - **Cross-chain transactions**: Explore [chain abstraction](../create-first-transaction) for complex multi-chain operations

--- a/smart-wallet/core/signers/para.mdx
+++ b/smart-wallet/core/signers/para.mdx
@@ -204,7 +204,8 @@ const result = await rhinestoneAccount.waitForExecution(transaction)
 
 See the full working example with Para + Rhinestone:
 
-- [Para Example Repository](https://github.com/rhinestonewtf/e2e-examples/tree/main/para)
+- [Para (viem) example](https://github.com/rhinestonewtf/e2e-examples/tree/main/para-viem)
+- [Para (wagmi) example](https://github.com/rhinestonewtf/e2e-examples/tree/main/para-wagmi)
 
 ## Next Steps
 

--- a/smart-wallet/core/signers/privy.mdx
+++ b/smart-wallet/core/signers/privy.mdx
@@ -291,8 +291,9 @@ Try the full integration in our example repository:
 
 ```bash
 git clone https://github.com/rhinestonewtf/e2e-examples.git
-cd e2e-examples/privy
-npm install && npm run dev
+cd e2e-examples
+pnpm install
+cd privy && pnpm dev
 ```
 
 The example demonstrates:

--- a/smart-wallet/tutorials/session-keys.mdx
+++ b/smart-wallet/tutorials/session-keys.mdx
@@ -197,6 +197,8 @@ Before shipping session keys to production:
 - **Set a timeframe policy.** Add an expiry so sessions don't live forever.
 - **Set spending limits.** Cap ERC20 transfers to a sensible amount.
 
+**See it in action:** [session-keys example](https://github.com/rhinestonewtf/e2e-examples/tree/main/session-keys) — approve a scoped session once, then execute with the session key.
+
 ## Next steps
 
 <CardGroup cols={3}>


### PR DESCRIPTION
Docs cleanup after the e2e-examples v2 migration.

- **Remove stale stub** — `intents/use-cases/chain-abstracted-swaps.mdx` was an orphaned ~276B redirect to the swaps guide (no `docs.json` nav entry, no inbound links). Deleted.
- **Fix broken Para link** — `e2e-examples/tree/main/para` no longer exists (the repo has `para-viem` and `para-wagmi`). Now links to both.
- **Workspace-correct clone instructions** — the `dynamic`/`privy`/`external-wallet` pages told users to `cd e2e-examples/<app> && npm install`, which fails now that the repo is a pnpm workspace with `catalog:` deps. Updated to install once from the root, then run the app.
- **Link the new examples** — added "see it in action" links: passkey → passkeys page, session-keys → session-keys tutorial, and the standalone viem/wagmi examples → external-wallet page.

`bunx mintlify broken-links` clean for the changed files (one pre-existing unrelated hit in `deposits/overview.mdx`).

Closes [RHI-4636](https://linear.app/rhinestone/issue/RHI-4636)