### PR TITLE
docs: fix snippet highlight ranges and small copy fixes

### DIFF
--- a/intents/features/execute-crosschain-calls.mdx
+++ b/intents/features/execute-crosschain-calls.mdx
@@ -141,7 +141,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
 
 If the source call hands over tokens (an unwrap, an unstake, withdrawing from a vault), declare them via `provides`. Routing then treats those tokens as available, the same way `auxiliaryFunds` does:
 
-```ts {7-9}
+```ts {6-8}
 sourceCalls: {
   [base.id]: [
     {

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -253,7 +253,7 @@ const transactions = await Promise.all(splits.map(sendIntent))
 
 You can optionally filter which settlement layers to use:
 
-```ts {5}
+```ts {6}
 const splits = await rhinestone.splitIntents({
   chain: base,
   tokens: {

--- a/smart-wallet/chain-abstraction/source-token-amount.mdx
+++ b/smart-wallet/chain-abstraction/source-token-amount.mdx
@@ -34,7 +34,7 @@ This will bridge 10 USDC from Optimism to Base.
 
 To bridge the entire balance of a token:
 
-```ts {8-13,22}
+```ts {9-14,23}
 const sourceChain = optimism
 const targetChain = base
 const usdcOnOptimism = '0x0b2c639c533813F4AA9D7837CAF62653d097Ff85'

--- a/smart-wallet/chain-abstraction/swaps.mdx
+++ b/smart-wallet/chain-abstraction/swaps.mdx
@@ -1,20 +1,15 @@
 ---
 title: "Swaps"
-description: "Bridge and swap in a single transaction. Use Warp's built-in swaps or supply your own swap calldata."
+description: "Bridge and swap in a single transaction using Warp's built-in solver liquidity."
 ---
 
-Rhinestone supports two swap modes:
-
-- **Swaps**: Warp handles the swap using solver liquidity. Simpler to integrate, best for common tokens.
-- **Injected swaps**: you supply the calldata for a swap from an external API (1inch, 0x, etc.). More setup, but full token coverage and best-price routing.
+Warp can bridge and swap in a single transaction. Specify the token you want on the destination chain, and if it differs from what the user holds, Warp routes through solver liquidity to swap and bridge automatically.
 
 <Tabs>
 
 <Tab title="SDK">
 
-## Swaps
-
-Specify the token you want on the destination chain. If it differs from what the user holds, Warp handles the bridge and swap automatically.
+Request ETH on the target chain via `tokenRequests`. If the user only holds another token there (or on the source chain), Warp swaps and bridges to cover it:
 
 ```ts
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
@@ -46,78 +41,9 @@ If the user has USDC on Base Sepolia, Warp will swap it to ETH, bridge to Arbitr
 
 <Note>The token address in `calls` and `tokenRequests` must correspond to the _target_ chain.</Note>
 
-## Injected swaps
-
-For full token coverage or best-price routing, supply swap calldata from a DEX aggregator and include it as destination chain calls.
-
-The example below makes a WETH to cbBTC swap on Base using funds from Arbitrum, via 1inch.
-
-**1. Initialize the 1inch client:**
-
-```ts
-const walletAddress = rhinestoneAccount.getAddress()
-const wethBase = '0x4200000000000000000000000000000000000006'
-const wethAmount = parseEther('0.1')
-const cbbtcBase = '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf'
-const oneInchApiKey = 'YOUR_1INCH_API_KEY'
-const baseUrl = 'https://api.1inch.dev/swap/v6.0/8453'
-
-async function call1inchAPI<T>(
-  endpointPath: string,
-  queryParams: Record<string, string>
-): Promise<T> {
-  const url = new URL(baseUrl + endpointPath)
-  url.search = new URLSearchParams(queryParams).toString()
-  const response = await fetch(url.toString(), {
-    headers: { Accept: 'application/json', Authorization: `Bearer ${oneInchApiKey}` },
-  })
-  if (!response.ok) throw new Error(`1inch API error ${response.status}`)
-  return response.json() as Promise<T>
-}
-```
-
-**2. Fetch approval and swap data:**
-
-```ts
-const approveTx = await call1inchAPI<ApproveTransactionResponse>('/approve/transaction', {
-  tokenAddress: wethBase,
-  amount: wethAmount.toString(),
-})
-
-const swapTx = await call1inchAPI<TxResponse>('/swap', {
-  src: wethBase,
-  dst: cbbtcBase,
-  amount: wethAmount.toString(),
-  from: walletAddress,
-  slippage: '1',
-  disableEstimate: 'false',
-  allowPartialFill: 'false',
-})
-```
-
-**3. Submit as a crosschain transaction:**
-
-```ts
-const transaction = await rhinestoneAccount.prepareTransaction({
-  sourceChains: [arbitrum],
-  targetChain: base,
-  calls: [
-    { to: approveTx.to, data: approveTx.data, value: approveTx.value },
-    { to: swapTx.tx.to, data: swapTx.tx.data, value: swapTx.tx.value },
-  ],
-  tokenRequests: [
-    { address: wethBase, amount: wethAmount },
-  ],
-})
-```
-
-This bridges from Arbitrum to get 0.1 WETH on Base, then executes the 1inch swap to cbBTC.
-
 </Tab>
 
 <Tab title="API">
-
-## Swaps
 
 When you request a token on the destination chain that differs from the user's source token, Warp routes through the solver market to bridge and swap in a single operation. No additional parameters are required — the quote response tells you what will be spent and what will be received.
 

--- a/smart-wallet/customize/bring-your-own-account.mdx
+++ b/smart-wallet/customize/bring-your-own-account.mdx
@@ -50,7 +50,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
 
 If the account was originally created with the Rhinestone SDK, you can use `experimental_getRhinestoneInitData` to compute the `initData` automatically instead of providing the factory and factory data manually.
 
-```ts {1,3-5,10}
+```ts
 import { experimental_getRhinestoneInitData } from '@rhinestone/sdk'
 
 const initData = await experimental_getRhinestoneInitData({
@@ -72,7 +72,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
 
 For accounts created with the Rhinestone SDK V0, use `experimental_getV0InitData`:
 
-```ts {1,3-5,10}
+```ts
 import { experimental_getV0InitData } from '@rhinestone/sdk'
 
 const initData = await experimental_getV0InitData({

--- a/smart-wallet/customize/json-rpc-providers.mdx
+++ b/smart-wallet/customize/json-rpc-providers.mdx
@@ -55,4 +55,6 @@ const rhinestoneAccount = await rhinestone.createAccount({
 </Tab>
 </Tabs>
 
-[Reach out](https://github.com/rhinestonewtf/sdk/issues) if you need support for other JSON-RPC providers!
+<Note>
+  Need support for a different RPC provider? [Open an issue](https://github.com/rhinestonewtf/sdk/issues) and we'll take a look.
+</Note>

--- a/smart-wallet/customize/smart-account-providers.mdx
+++ b/smart-wallet/customize/smart-account-providers.mdx
@@ -7,6 +7,18 @@ By default, the Rhinestone SDK uses a Safe smart account. You can override this 
 
 <CodeGroup>
 
+```ts Nexus
+const rhinestoneAccount = await rhinestone.createAccount({
+  account: {
+    type: 'nexus',
+  },
+  owners: {
+    type: 'ecdsa',
+    accounts: [account],
+  },
+})
+```
+
 ```ts Safe
 const rhinestoneAccount = await rhinestone.createAccount({
   account: {
@@ -23,14 +35,15 @@ const rhinestoneAccount = await rhinestone.createAccount({
 })
 ```
 
-```ts Nexus
+```ts Startale
 const rhinestoneAccount = await rhinestone.createAccount({
   account: {
-    type: 'nexus',
+    type: 'startale',
   },
   owners: {
     type: 'ecdsa',
     accounts: [account],
+    module: '0x00000072f286204bb934ed49d8969e86f7dec7b1',
   },
 })
 ```
@@ -43,19 +56,6 @@ const rhinestoneAccount = await rhinestone.createAccount({
   owners: {
     type: 'ecdsa',
     accounts: [account],
-  },
-})
-```
-
-```ts Startale
-const rhinestoneAccount = await rhinestone.createAccount({
-  account: {
-    type: 'startale',
-  },
-  owners: {
-    type: 'ecdsa',
-    accounts: [account],
-    module: '0x00000072f286204bb934ed49d8969e86f7dec7b1',
   },
 })
 ```

--- a/smart-wallet/quickstart.mdx
+++ b/smart-wallet/quickstart.mdx
@@ -177,10 +177,6 @@ Your ETH on Base Sepolia landed as USDC on Arbitrum Sepolia in a single atomic o
   **Building a browser app?** Use the [Reown + Rhinestone example](https://github.com/rhinestonewtf/e2e-examples/tree/main/reown) to get wallet connection working with MetaMask or any WalletConnect-compatible wallet.
 </Info>
 
-<Warning>
-  **Going to production?** Never expose your Rhinestone API key in the browser. Read the [Security guide](./advanced/security) to proxy Orchestrator requests safely via a backend.
-</Warning>
-
 ## Next steps
 
 <CardGroup cols={3}>

--- a/smart-wallet/smart-sessions/overview.mdx
+++ b/smart-wallet/smart-sessions/overview.mdx
@@ -139,7 +139,7 @@ const session = toSession({
 
 Finally, you can constrain function parameters. The SDK derives the selector and parameter offsets from the ABI, so you reference parameters by name:
 
-```ts {12-16}
+```ts {11-20}
 const session = toSession({
   chain: base,
   owners: {
@@ -169,7 +169,7 @@ const session = toSession({
 
 Use `crossChainPermits` to scope which routes, tokens, amounts, and recipients it may bridge:
 
-```ts {7-12}
+```ts {8-13}
 const session = toSession({
   chain: base,
   owners: {

--- a/smart-wallet/smart-sessions/policies/call.mdx
+++ b/smart-wallet/smart-sessions/policies/call.mdx
@@ -21,7 +21,7 @@ Available conditions:
 
 To restrict an ERC20 transfer to a single recipient:
 
-```ts {15}
+```ts {14-17}
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
 const session = toSession({
@@ -52,24 +52,31 @@ Reference parameters by name — the SDK looks them up in the ABI. Only static t
 
 Cap the total accumulated value of a param across all session uses with `usageLimit`. Useful for capping cumulative spend across calls.
 
-```ts {8-12}
-permissions: [
-  {
-    abi: erc20Abi,
-    address: usdcAddress,
-    functions: {
-      transfer: {
-        params: {
-          amount: {
-            condition: 'lessThan',
-            value: parseUnits('10', 6),
-            usageLimit: parseUnits('50', 6),
+```ts {13-19}
+const session = toSession({
+  chain: base,
+  owners: {
+    type: 'ecdsa',
+    accounts: [sessionOwnerAccount],
+  },
+  permissions: [
+    {
+      abi: erc20Abi,
+      address: usdcAddress,
+      functions: {
+        transfer: {
+          params: {
+            amount: {
+              condition: 'lessThan',
+              value: parseUnits('10', 6),
+              usageLimit: parseUnits('50', 6),
+            },
           },
         },
       },
     },
-  },
-],
+  ],
+})
 ```
 
 This caps each transfer at 10 USDC and the total across the session lifetime at 50 USDC.
@@ -78,18 +85,25 @@ This caps each transfer at 10 USDC and the total across the session lifetime at 
 
 To cap the ETH value sent on a single call, use `valueLimitPerUse` at the function level:
 
-```ts {7}
-permissions: [
-  {
-    abi: vaultAbi,
-    address: vaultAddress,
-    functions: {
-      depositEth: {
-        valueLimitPerUse: parseUnits('0.1', 18),
+```ts {13}
+const session = toSession({
+  chain: base,
+  owners: {
+    type: 'ecdsa',
+    accounts: [sessionOwnerAccount],
+  },
+  permissions: [
+    {
+      abi: vaultAbi,
+      address: vaultAddress,
+      functions: {
+        depositEth: {
+          valueLimitPerUse: parseUnits('0.1', 18),
+        },
       },
     },
-  },
-],
+  ],
+})
 ```
 
 This limits the value per call to 0.1 ETH.

--- a/smart-wallet/smart-sessions/policies/cross-chain.mdx
+++ b/smart-wallet/smart-sessions/policies/cross-chain.mdx
@@ -38,16 +38,23 @@ A token can be a symbol (resolved to the per-chain address) or an explicit addre
 
 Tighten a permit with optional bounds:
 
-```ts {3-7}
-crossChainPermits: [
-  {
-    from: [{ chain: base, token: 'USDC', maxAmount: parseUnits('100', 6) }],
-    to: [{ chain: arbitrum, token: 'USDC' }],
-    validAfter: new Date('2026-01-01'),
-    validUntil: new Date('2027-01-01'),
-    fillDeadline: [{ chain: arbitrum, max: new Date('2027-01-01') }],
+```ts {9-13}
+const session = toSession({
+  chain: base,
+  owners: {
+    type: 'ecdsa',
+    accounts: [sessionOwnerAccount],
   },
-]
+  crossChainPermits: [
+    {
+      from: [{ chain: base, token: 'USDC', maxAmount: parseUnits('100', 6) }],
+      to: [{ chain: arbitrum, token: 'USDC' }],
+      validAfter: new Date('2026-01-01'),
+      validUntil: new Date('2027-01-01'),
+      fillDeadline: [{ chain: arbitrum, max: new Date('2027-01-01') }],
+    },
+  ],
+})
 ```
 
 - `maxAmount` on a source leg caps how much of that token the session can pull (a spending limit).


### PR DESCRIPTION
Fixes a batch of code-snippet highlight ranges that were off by a line or two, plus a few small copy/structure fixes.

**Highlight fixes**
- Smart sessions overview: recipient param + basic cross-chain permit blocks
- Call policy: recipient, param accumulator, value-limit blocks (accumulator + value-limit also wrapped in `toSession` for completeness)
- Cross-chain permits: guardrails block wrapped in `toSession`
- Spend max tokens: "entire balance" block, both highlight ranges
- Multi-chain intent: `splitIntents` settlement-layer block
- Execute crosschain calls: `provides` block
- Bring your own account: drop the noisy highlights on the two `initData` examples

**Copy / structure**
- Smart account providers: reorder to Nexus, Safe, Startale, Kernel
- JSON-RPC providers: reword the "reach out" line as a `<Note>` callout
- Quickstart: remove the "Going to production?" warning
- Swaps: drop the "Injected swaps" mode, simplify the page to built-in swaps only

Closes [RHI-4652](https://linear.app/rhinestone/issue/RHI-4652/fix-docs-code-snippet-highlight-ranges-and-small-copy-fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)