### PR TITLE
docs: correct remaining smart-session snippet highlights

### DIFF
--- a/smart-wallet/smart-sessions/overview.mdx
+++ b/smart-wallet/smart-sessions/overview.mdx
@@ -169,7 +169,7 @@ const session = toSession({
 
 Use `crossChainPermits` to scope which routes, tokens, amounts, and recipients it may bridge:
 
-```ts {8-13}
+```ts {7-12}
 const session = toSession({
   chain: base,
   owners: {

--- a/smart-wallet/smart-sessions/policies/call.mdx
+++ b/smart-wallet/smart-sessions/policies/call.mdx
@@ -21,7 +21,7 @@ Available conditions:
 
 To restrict an ERC20 transfer to a single recipient:
 
-```ts {14-17}
+```ts {15-17}
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
 const session = toSession({

--- a/smart-wallet/smart-sessions/policies/cross-chain.mdx
+++ b/smart-wallet/smart-sessions/policies/cross-chain.mdx
@@ -11,7 +11,7 @@ You set them at the session level via `crossChainPermits`, not per function. Eac
 
 Restrict a session to only bridge USDC from Base to Arbitrum:
 
-```ts {6-11}
+```ts {7-12}
 const session = toSession({
   chain: base,
   owners: {
@@ -38,7 +38,7 @@ A token can be a symbol (resolved to the per-chain address) or an explicit addre
 
 Tighten a permit with optional bounds:
 
-```ts {9-13}
+```ts {8-14}
 const session = toSession({
   chain: base,
   owners: {
@@ -65,26 +65,40 @@ const session = toSession({
 
 By default a cross-chain permit enforces **bridge-to-self** on-chain: the destination recipient must be the smart account itself. This stops a leaked session key from routing funds to an attacker-controlled address. Opt out explicitly only when you need to bridge to a different recipient:
 
-```ts {4-5}
-crossChainPermits: [
-  {
-    from: [{ chain: base, token: 'USDC' }],
-    to: [{ chain: arbitrum, token: 'USDC', recipient: payoutAddress }],
-    allowRecipientNotAccount: true,
+```ts {10-11}
+const session = toSession({
+  chain: base,
+  owners: {
+    type: 'ecdsa',
+    accounts: [sessionOwnerAccount],
   },
-]
+  crossChainPermits: [
+    {
+      from: [{ chain: base, token: 'USDC' }],
+      to: [{ chain: arbitrum, token: 'USDC', recipient: payoutAddress }],
+      allowRecipientNotAccount: true,
+    },
+  ],
+})
 ```
 
 ## Settlement layers
 
 A permit allows any supported settlement layer by default. Pass `settlementLayers` to narrow it to a subset:
 
-```ts {4}
-crossChainPermits: [
-  {
-    from: [{ chain: base, token: 'USDC' }],
-    to: [{ chain: arbitrum, token: 'USDC' }],
-    settlementLayers: ['ECO'],
+```ts {11}
+const session = toSession({
+  chain: base,
+  owners: {
+    type: 'ecdsa',
+    accounts: [sessionOwnerAccount],
   },
-]
+  crossChainPermits: [
+    {
+      from: [{ chain: base, token: 'USDC' }],
+      to: [{ chain: arbitrum, token: 'USDC' }],
+      settlementLayers: ['ECO'],
+    },
+  ],
+})
 ```


### PR DESCRIPTION
Follow-up to #154 — fixes the remaining off-by-a-line highlights and wraps the last two bare `crossChainPermits` snippets in `toSession`.

- Smart sessions overview: basic cross-chain permit block `{8-13}` → `{7-12}`
- Call policy: recipient param `{14-17}` → `{15-17}`
- Cross-chain basic usage `{6-11}` → `{7-12}`, guardrails `{9-13}` → `{8-14}`
- Cross-chain recipient-safety + settlement-layer snippets wrapped in `toSession`; settlement-layer highlight moved onto the `settlementLayers` line (was on `to`)

Closes [RHI-4652](https://linear.app/rhinestone/issue/RHI-4652/fix-docs-code-snippet-highlight-ranges-and-small-copy-fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)