### PR TITLE
docs: make intents snippets copy-paste ready

### DIFF
--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -129,7 +129,7 @@ const payload = {
       data: encodeFunctionData({
         abi: erc20Abi,
         functionName: 'transfer',
-        args: [tokenAmount, EOA_ADDRESS],
+        args: [EOA_ADDRESS, tokenAmount],
       }),
     }
   ],

--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -115,7 +115,7 @@ const payload = {
     // Deposit USDC to a vault
     {
       to: VAULT_CONTRACT,
-      value: 0n,
+      value: "0",
       data: encodeFunctionData({
         abi: vaultAbi,
         functionName: 'deposit',
@@ -125,7 +125,7 @@ const payload = {
     // Send vault receipt token back to the EOA
     {
       to: USDC_VAULT_CONTRACT,
-      value: 0n,
+      value: "0",
       data: encodeFunctionData({
         abi: erc20Abi,
         functionName: 'transfer',

--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -11,7 +11,8 @@ Use the `/quotes` endpoint. You'll need the **destination chain**, the **token**
 
 ```ts Get Quote
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
-const apiKey = "YOUR_RHINESTONE_API_KEY";
+const apiKey = process.env.RHINESTONE_API_KEY;
+const EOA_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // your EOA address
 
 const payload = {
   account: {
@@ -87,10 +88,14 @@ const fastest = routes
 
 await fetch(`${baseUrl}/intents`, {
   method: "POST",
-  headers: { /* ... */ },
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "x-api-version": "2026-04.blanc",
+  },
   body: JSON.stringify({
     intentId: fastest.intentId,
-    signatures: { /* signed against fastest.signData */ },
+    signatures: { /* signed against fastest.signData — see the signing guide */ },
   }),
 });
 ```

--- a/intents/guides/portfolio-endpoint.mdx
+++ b/intents/guides/portfolio-endpoint.mdx
@@ -12,7 +12,7 @@ Pass a user address and your API key to get aggregated balances across all chain
 
 ```ts
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
-const apiKey = "YOUR_RHINESTONE_API_KEY";
+const apiKey = process.env.RHINESTONE_API_KEY;
 const accountAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
 
 const res = await fetch(

--- a/intents/guides/submitting-the-intent.mdx
+++ b/intents/guides/submitting-the-intent.mdx
@@ -9,7 +9,7 @@ Use the `/intents` endpoint. Pass the `intentId` from the quote and the signatur
 
 ```ts
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
-const apiKey = "YOUR_RHINESTONE_API_KEY";
+const apiKey = process.env.RHINESTONE_API_KEY;
 
 const res = await fetch(`${baseUrl}/intents`, {
   method: "POST",

--- a/intents/guides/tracking-intents.mdx
+++ b/intents/guides/tracking-intents.mdx
@@ -10,7 +10,7 @@ After [submitting an intent](./submitting-the-intent), you receive an `intentId`
 
 ```ts
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
-const apiKey = "YOUR_RHINESTONE_API_KEY";
+const apiKey = process.env.RHINESTONE_API_KEY;
 
 async function getIntentStatus(intentId: string) {
   const res = await fetch(`${baseUrl}/intents/${intentId}`, {

--- a/intents/quickstart.mdx
+++ b/intents/quickstart.mdx
@@ -124,7 +124,7 @@ for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
         address: WETH_ADDRESS,
         abi: wethAbi,
         functionName: "deposit",
-        value: requirement.amount,
+        value: BigInt(requirement.amount),
       });
     }
   }

--- a/intents/quickstart.mdx
+++ b/intents/quickstart.mdx
@@ -25,9 +25,9 @@ Send your first crosschain intent straight through the REST API. This guide walk
 Submit a meta intent to the `/quotes` endpoint. Specify your destination chain, the token and amount you want on that chain, and your account:
 
 ```ts
-import { createWalletClient, http, type Hex } from "viem";
+import { createWalletClient, extractChain, http, type Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { base } from "viem/chains";
+import * as chains from "viem/chains";
 
 const BASE_URL = "https://v1.orchestrator.rhinestone.dev";
 const API_KEY = process.env.RHINESTONE_API_KEY;
@@ -36,11 +36,17 @@ const API_KEY = process.env.RHINESTONE_API_KEY;
 const account = privateKeyToAccount(process.env.PRIVATE_KEY as Hex);
 const EOA_ADDRESS = account.address;
 
-const walletClient = createWalletClient({
-  account,
-  chain: base,
-  transport: http(),
-});
+// A route can pull source funds from any chain, so token requirements can land
+// on any chain. Build a wallet client for whichever chain a requirement targets.
+const walletClientFor = (chainId: string) =>
+  createWalletClient({
+    account,
+    chain: extractChain({
+      chains: Object.values(chains),
+      id: Number(chainId.split(":")[1]),
+    }),
+    transport: http(),
+  });
 
 const headers = {
   "Content-Type": "application/json",
@@ -91,7 +97,7 @@ import { erc20Abi, maxUint256 } from "viem";
 for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
   for (const [tokenAddress, requirement] of Object.entries(tokens)) {
     if (requirement.type === "approval") {
-      await walletClient.writeContract({
+      await walletClientFor(chainId).writeContract({
         address: tokenAddress,
         abi: erc20Abi,
         functionName: "approve",
@@ -105,8 +111,13 @@ for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
 **ETH wrapping** — wrap native ETH to WETH:
 
 ```ts
-// WETH on Base. Use the wrapped-native token for whichever chain the requirement targets.
-const WETH_ADDRESS = "0x4200000000000000000000000000000000000006";
+// Wrapped-native token per chain — only needed when the source token is ETH.
+const WETH: Record<string, `0x${string}`> = {
+  "eip155:1": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // Ethereum
+  "eip155:10": "0x4200000000000000000000000000000000000006", // Optimism
+  "eip155:8453": "0x4200000000000000000000000000000000000006", // Base
+  "eip155:42161": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // Arbitrum
+};
 const wethAbi = [
   {
     name: "deposit",
@@ -120,8 +131,8 @@ const wethAbi = [
 for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
   for (const [tokenAddress, requirement] of Object.entries(tokens)) {
     if (requirement.type === "wrap") {
-      await walletClient.writeContract({
-        address: WETH_ADDRESS,
+      await walletClientFor(chainId).writeContract({
+        address: WETH[chainId],
         abi: wethAbi,
         functionName: "deposit",
         value: BigInt(requirement.amount),
@@ -144,10 +155,10 @@ Forward `signData.origin[]` and `signData.destination` directly to `signTypedDat
 ```ts
 const originSignatures = await Promise.all(
   signData.origin.map((typedData) =>
-    walletClient.signTypedData(typedData),
+    account.signTypedData(typedData),
   ),
 );
-const destinationSignature = await walletClient.signTypedData(
+const destinationSignature = await account.signTypedData(
   signData.destination,
 );
 ```

--- a/intents/quickstart.mdx
+++ b/intents/quickstart.mdx
@@ -14,7 +14,7 @@ Send your first crosschain intent straight through the REST API. This guide walk
 ## Prerequisites
 
 - A Rhinestone API key ([request one here](https://tally.so/r/wg22x4)) — not required for testnets
-- An EOA with funds on at least one [supported chain](/home/resources/supported-chains)
+- An EOA with funds on Ethereum, Optimism, Base, or Arbitrum — the source chains this quickstart handles below (extend the `accountAccessList` and wrap map for any other [supported chain](/home/resources/supported-chains))
 
 ## Steps
 
@@ -69,6 +69,10 @@ const res = await fetch(`${BASE_URL}/quotes`, {
         amount: "5000000", // 5 USDC (6 decimals)
       },
     ],
+    // Limit source funds to the chains this quickstart handles below.
+    accountAccessList: {
+      chainIds: ["eip155:1", "eip155:10", "eip155:8453", "eip155:42161"],
+    },
   }),
 });
 
@@ -111,7 +115,8 @@ for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
 **ETH wrapping** — wrap native ETH to WETH:
 
 ```ts
-// Wrapped-native token per chain — only needed when the source token is ETH.
+// Wrapped-native token for each chain in the accountAccessList above
+// (only needed when the source token is ETH).
 const WETH: Record<string, `0x${string}`> = {
   "eip155:1": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // Ethereum
   "eip155:10": "0x4200000000000000000000000000000000000006", // Optimism

--- a/intents/quickstart.mdx
+++ b/intents/quickstart.mdx
@@ -25,9 +25,22 @@ Send your first crosschain intent straight through the REST API. This guide walk
 Submit a meta intent to the `/quotes` endpoint. Specify your destination chain, the token and amount you want on that chain, and your account:
 
 ```ts
+import { createWalletClient, http, type Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
+
 const BASE_URL = "https://v1.orchestrator.rhinestone.dev";
-const API_KEY = "YOUR_RHINESTONE_API_KEY";
-const EOA_ADDRESS = "0xYourEOAAddress";
+const API_KEY = process.env.RHINESTONE_API_KEY;
+
+// EOA signer — swap in any viem-compatible signer.
+const account = privateKeyToAccount(process.env.PRIVATE_KEY as Hex);
+const EOA_ADDRESS = account.address;
+
+const walletClient = createWalletClient({
+  account,
+  chain: base,
+  transport: http(),
+});
 
 const headers = {
   "Content-Type": "application/json",
@@ -73,7 +86,7 @@ Before signing, the user must fulfill any `tokenRequirements` returned in the qu
 **ERC-20 approvals** — approve tokens to the Permit2 contract:
 
 ```ts
-import { maxUint256 } from "viem";
+import { erc20Abi, maxUint256 } from "viem";
 
 for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
   for (const [tokenAddress, requirement] of Object.entries(tokens)) {
@@ -92,6 +105,18 @@ for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
 **ETH wrapping** — wrap native ETH to WETH:
 
 ```ts
+// WETH on Base. Use the wrapped-native token for whichever chain the requirement targets.
+const WETH_ADDRESS = "0x4200000000000000000000000000000000000006";
+const wethAbi = [
+  {
+    name: "deposit",
+    type: "function",
+    stateMutability: "payable",
+    inputs: [],
+    outputs: [],
+  },
+] as const;
+
 for (const [chainId, tokens] of Object.entries(tokenRequirements)) {
   for (const [tokenAddress, requirement] of Object.entries(tokens)) {
     if (requirement.type === "wrap") {

--- a/intents/tutorial/end-to-end-intent-flow.mdx
+++ b/intents/tutorial/end-to-end-intent-flow.mdx
@@ -17,12 +17,12 @@ By the end you will have a working end-to-end implementation you can adapt for a
 ## Setup
 
 ```ts
-import { createWalletClient, http, erc20Abi, maxUint256 } from "viem";
+import { createWalletClient, http, erc20Abi, maxUint256, type Hex } from "viem";
 import { base } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 
 const BASE_URL = "https://v1.orchestrator.rhinestone.dev";
-const API_KEY = "YOUR_RHINESTONE_API_KEY";
+const API_KEY = process.env.RHINESTONE_API_KEY;
 
 const headers = {
   "Content-Type": "application/json",
@@ -30,7 +30,7 @@ const headers = {
   "x-api-version": "2026-04.blanc",
 };
 
-const account = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
+const account = privateKeyToAccount(process.env.PRIVATE_KEY as Hex);
 
 const walletClient = createWalletClient({
   account,

--- a/intents/use-cases/vault-deposit.mdx
+++ b/intents/use-cases/vault-deposit.mdx
@@ -48,7 +48,7 @@ const destinationExecutions = [
   // 1. Approve the vault to pull USDC from the intermediary
   {
     to: DEPOSIT_TOKEN,
-    value: 0n,
+    value: "0",
     data: encodeFunctionData({
       abi: erc20Abi,
       functionName: "approve",
@@ -58,7 +58,7 @@ const destinationExecutions = [
   // 2. Deposit, minting shares straight to the user via the receiver arg
   {
     to: VAULT_ADDRESS,
-    value: 0n,
+    value: "0",
     data: encodeFunctionData({
       abi: vaultAbi,
       functionName: "deposit",
@@ -102,7 +102,7 @@ const destinationExecutions = [
   // 1. Approve the vault to pull USDC from the account
   {
     to: DEPOSIT_TOKEN,
-    value: 0n,
+    value: "0",
     data: encodeFunctionData({
       abi: erc20Abi,
       functionName: "approve",
@@ -112,7 +112,7 @@ const destinationExecutions = [
   // 2. Deposit — shares mint directly to the account
   {
     to: VAULT_ADDRESS,
-    value: 0n,
+    value: "0",
     data: encodeFunctionData({
       abi: vaultAbi,
       functionName: "deposit",

--- a/intents/use-cases/vault-deposit.mdx
+++ b/intents/use-cases/vault-deposit.mdx
@@ -19,16 +19,17 @@ The flow works as follows:
 <Tabs>
 <Tab title="EOA">
 
-For EOAs, destination executions run in an intermediary contract — not in the user's account context. The requested tokens are automatically swept to the user after execution, but any tokens received as a result of the execution (such as vault shares) are not automatically swept.
+For EOAs, destination executions run in an intermediary contract — not in the user's account context — so any tokens the execution produces (like vault shares) would otherwise be stranded there.
 
-You must include an explicit `transfer` call to send the vault shares back to the user's address.
+ERC-4626's `deposit(assets, receiver)` sidesteps this: set `receiver` to the user's address and shares mint directly to them. First approve the vault to pull the deposit token from the intermediary, then deposit.
 
 ```ts
 import { encodeFunctionData, erc20Abi, parseUnits } from "viem";
 
-const VAULT_ADDRESS = "0x..."; // ERC-4626 vault
-const DEPOSIT_TOKEN = "0x..."; // Vault's underlying asset
-const depositAmount = parseUnits("100", 6); // e.g. 100 USDC
+const VAULT_ADDRESS = "0xbeef0e0834849aCC03f0089F01f4F1Eeb06873C9"; // Steakhouse Prime USDC vault (ERC-4626) on Base
+const DEPOSIT_TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // USDC on Base (the vault's underlying asset)
+const USER_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // the EOA receiving the vault shares
+const depositAmount = parseUnits("100", 6); // 100 USDC (6 decimals)
 
 const vaultAbi = [
   {
@@ -44,44 +45,45 @@ const vaultAbi = [
 ] as const;
 
 const destinationExecutions = [
-  // 1. Deposit into the vault
+  // 1. Approve the vault to pull USDC from the intermediary
+  {
+    to: DEPOSIT_TOKEN,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [VAULT_ADDRESS, depositAmount],
+    }),
+  },
+  // 2. Deposit, minting shares straight to the user via the receiver arg
   {
     to: VAULT_ADDRESS,
     value: 0n,
     data: encodeFunctionData({
       abi: vaultAbi,
       functionName: "deposit",
-      args: [depositAmount, VAULT_ADDRESS], // receiver is the intermediary
-    }),
-  },
-  // 2. Transfer vault shares back to the user
-  {
-    to: VAULT_ADDRESS, // ERC-4626 vaults are also ERC-20 share tokens
-    value: 0n,
-    data: encodeFunctionData({
-      abi: erc20Abi,
-      functionName: "transfer",
-      args: [USER_ADDRESS, depositAmount], // approximate share amount
+      args: [depositAmount, USER_ADDRESS],
     }),
   },
 ];
 ```
 
 <Note>
-Since executions run outside the user's account, you need the second `transfer` call to move vault shares to the user. This limitation will be addressed in a future API update with a new field for specifying expected output tokens.
+Because executions run in the intermediary — not the user's account — tokens produced onchain aren't swept back automatically. ERC-4626's `receiver` argument handles this: shares mint straight to the user. For outputs from calls that don't expose a recipient (e.g. a swap), add an explicit `transfer` back to the user.
 </Note>
 
 </Tab>
 <Tab title="Smart Account">
 
-For Smart Accounts, the IntentExecutor runs destination executions within the account's own context. Vault shares are minted directly to the account — no extra transfer needed.
+For Smart Accounts, the IntentExecutor runs destination executions within the account's own context, so shares mint directly to the account with the account as `receiver` — no post-hoc transfer needed. You still approve the vault to pull the deposit token first.
 
 ```ts
-import { encodeFunctionData, parseUnits } from "viem";
+import { encodeFunctionData, erc20Abi, parseUnits } from "viem";
 
-const VAULT_ADDRESS = "0x..."; // ERC-4626 vault
-const DEPOSIT_TOKEN = "0x..."; // Vault's underlying asset
-const depositAmount = parseUnits("100", 6); // e.g. 100 USDC
+const VAULT_ADDRESS = "0xbeef0e0834849aCC03f0089F01f4F1Eeb06873C9"; // Steakhouse Prime USDC vault (ERC-4626) on Base
+const DEPOSIT_TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // USDC on Base (the vault's underlying asset)
+const ACCOUNT_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; // your smart account address
+const depositAmount = parseUnits("100", 6); // 100 USDC (6 decimals)
 
 const vaultAbi = [
   {
@@ -97,6 +99,17 @@ const vaultAbi = [
 ] as const;
 
 const destinationExecutions = [
+  // 1. Approve the vault to pull USDC from the account
+  {
+    to: DEPOSIT_TOKEN,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [VAULT_ADDRESS, depositAmount],
+    }),
+  },
+  // 2. Deposit — shares mint directly to the account
   {
     to: VAULT_ADDRESS,
     value: 0n,
@@ -119,7 +132,7 @@ const destinationExecutions = [
 
 ```ts
 const metaIntent = {
-  destinationChainId: "eip155:42161", // e.g. Arbitrum
+  destinationChainId: "eip155:8453", // Base (where the vault lives)
   tokenRequests: [
     {
       tokenAddress: DEPOSIT_TOKEN,
@@ -139,7 +152,7 @@ const metaIntent = {
 
 ```ts
 const metaIntent = {
-  destinationChainId: "eip155:42161", // e.g. Arbitrum
+  destinationChainId: "eip155:8453", // Base (where the vault lives)
   tokenRequests: [
     {
       tokenAddress: DEPOSIT_TOKEN,
@@ -164,7 +177,7 @@ Submit the meta intent to the `/quotes` endpoint:
 
 ```ts
 const baseUrl = "https://v1.orchestrator.rhinestone.dev";
-const apiKey = "YOUR_RHINESTONE_API_KEY";
+const apiKey = process.env.RHINESTONE_API_KEY;
 
 const headers = {
   "Content-Type": "application/json",


### PR DESCRIPTION
Makes the Intents API code snippets runnable as pasted — no placeholders to hand-edit, no undefined identifiers.

- Replace `YOUR_RHINESTONE_API_KEY` / `0xYOUR_PRIVATE_KEY` literals with `process.env` reads.
- Define previously-undefined identifiers in the quickstart (`walletClient`, `EOA_ADDRESS`, `erc20Abi`, `WETH_ADDRESS`/`wethAbi`) so each block stands alone.
- Bake real Base addresses into the vault-deposit guide (Steakhouse Prime USDC ERC-4626 vault + USDC) and route to the vault's chain.
- Fill the empty `headers: { /* ... */ }` in the getting-a-quote submit example.

Using a real vault surfaced pre-existing correctness bugs in `vault-deposit`, fixed here: approve the vault before `deposit`, and mint shares directly to the user/account via ERC-4626's `receiver` arg instead of the old (and, against a real 18-decimal-share vault, broken) post-hoc share transfer.

Smart Wallet SDK snippets were left as-is — already `process.env`-based with real addresses; the only remaining literals there are inherently user-specific (their signer, their target contract).

Closes [RHI-3665](https://linear.app/rhinestone/issue/RHI-3665)