### PR TITLE
fix: scope active-item background to sidebar

### DIFF
--- a/style.css
+++ b/style.css
@@ -175,9 +175,7 @@ table th:last-child {
 }
 
 /* Sidebar active/selected item */
-.dark [data-active="true"],
-.dark [aria-current="page"],
-.dark [aria-selected="true"] {
+.dark #sidebar [data-active="true"] {
   background-color: #141414 !important;
   border-radius: 6px;
 }


### PR DESCRIPTION
- `style.css` had a global rule painting a `#141414` background on every `[data-active="true"]` / `[aria-current="page"]` / `[aria-selected="true"]` element; it was only meant for the sidebar's active item
- This hit the top nav tabs, in-page `<Tabs>` buttons, and the page ToC — all underline-style components with no horizontal padding, so the background rendered as an unpadded block (plus a stray rounded border on tab buttons)
- Scoped the rule to `#sidebar [data-active="true"]`; verified against the live ERC-4337 page that the sidebar is unchanged and the other components return to underline-only styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)