### PR TITLE
docs(deposits): add the fiat and CEX on-ramp guide

### DIFF
--- a/deposits/api/onramp.mdx
+++ b/deposits/api/onramp.mdx
@@ -1,0 +1,147 @@
+---
+title: "Fiat and CEX on-ramp"
+description: "Let users fund their account with a card, Apple Pay, a bank transfer, or a centralized exchange balance — powered by Swapped."
+---
+
+Users without crypto can fund their account directly inside your app. The deposit service mints a signed Swapped checkout URL for a registered account; the user pays in Swapped's hosted widget; the purchased crypto lands on the account and is processed like any other deposit — bridged to the account's target and reported through the same [status tracking](/deposits/api/status-tracking).
+
+## How it works
+
+1. Your backend requests a signed checkout URL for the user's account.
+2. You show the URL in an iframe or in-app browser.
+3. The user completes payment (and KYC, when required) with Swapped.
+4. You receive [`onramp-order`](/deposits/api/status-tracking#onramp-order) webhooks as the order progresses.
+5. Swapped sends the purchased crypto — currently USDC on Base — to the account. From here the standard pipeline takes over: the deposit is detected, bridged to the account's target, and reported via the regular [deposit webhooks](/deposits/api/status-tracking#webhooks).
+
+## Prerequisites
+
+- The account is [registered](/deposits/api/account-registration) — minting a checkout URL for an unregistered account returns `403`.
+- A [webhook URL](/deposits/api/initial-setup#configure-a-webhook) is configured if you want order updates pushed rather than polled.
+- Calls are made from your backend. The endpoints require your API key, which never ships in client-side code.
+
+## Mint a checkout URL
+
+```ts
+const DEPOSIT_SERVICE_URL =
+    "https://v1.orchestrator.rhinestone.dev/deposit-processor";
+const API_KEY = "YOUR_RHINESTONE_API_KEY";
+
+const response = await fetch(`${DEPOSIT_SERVICE_URL}/onramp/swapped/widget-url`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": API_KEY },
+    body: JSON.stringify({
+        smartAccount: "0xUSER_ACCOUNT_ADDRESS",
+        baseCurrencyCode: "EUR",
+        baseCurrencyAmount: 100,
+        method: "apple-pay",
+    }),
+});
+
+const { url, externalCustomerId, expiresAt } = await response.json();
+```
+
+Only `smartAccount` is required. The optional fields prefill the widget:
+
+| Field                | Type     | Description                                                        |
+| -------------------- | -------- | ------------------------------------------------------------------ |
+| `smartAccount`       | `string` | The registered account that receives the crypto                    |
+| `email`              | `string` | Prefills the user's email                                          |
+| `baseCountry`        | `string` | User's country (ISO 3166-1 alpha-2, e.g. `"DE"`)                   |
+| `baseCurrencyCode`   | `string` | Fiat currency to charge in (e.g. `"EUR"`)                          |
+| `baseCurrencyAmount` | `number` | Prefilled purchase amount in the fiat currency                     |
+| `locale`             | `string` | Widget language                                                    |
+| `method`             | `string` | Preselected payment method: `"creditcard"`, `"apple-pay"`, or `"bank-transfer"` |
+
+The response carries the signed URL:
+
+| Field                | Type      | Description                                                                 |
+| -------------------- | --------- | ---------------------------------------------------------------------------- |
+| `url`                | `string`  | The checkout URL to embed                                                    |
+| `currencyCode`       | `string`  | Asset the purchase settles in, as `ASSET_NETWORK` (currently `"USDC_BASE"`)  |
+| `sandbox`            | `boolean` | `true` when the service runs against Swapped's sandbox                      |
+| `externalCustomerId` | `string`  | `<account>:<orderUuid>` — correlates the checkout with its webhooks          |
+| `expiresAt`          | `string`  | End of the order-tracking window (ISO 8601)                                  |
+
+The URL is signed by the service, so its parameters — destination wallet and asset — can't be modified client-side. Mint a fresh URL for each checkout session. The purchase always settles in the asset reported by `currencyCode`; when the account's target differs, the bridge hop happens automatically.
+
+Full request and response schemas: [`POST /onramp/swapped/widget-url`](/api-reference/deposit-service/onramp/mint-a-signed-swapped-widget-url-fiat-on-ramp).
+
+### Fund from an exchange
+
+To let users transfer from a centralized exchange balance (Binance, Coinbase, and others) instead of paying with fiat, mint a Connect URL — same request shape plus an optional `connection` preselecting the exchange, same response shape:
+
+```ts
+const response = await fetch(`${DEPOSIT_SERVICE_URL}/onramp/swapped/connect-url`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": API_KEY },
+    body: JSON.stringify({
+        smartAccount: "0xUSER_ACCOUNT_ADDRESS",
+        connection: "binance",
+    }),
+});
+```
+
+List the supported exchanges with [`GET /onramp/swapped/connect-exchanges`](/api-reference/deposit-service/onramp/list-centralized-exchanges-for-the-connect-picker); full schema at [`POST /onramp/swapped/connect-url`](/api-reference/deposit-service/onramp/mint-a-signed-swapped-connect-url-cex-funding).
+
+## Show the widget
+
+Embed the URL in an iframe with payment and camera permissions — Apple Pay and camera-based KYC need them:
+
+```html
+<iframe src={url} allow="payment; camera; microphone; clipboard-write" />
+```
+
+In a mobile app, open the URL in an in-app browser (`SFSafariViewController` on iOS, Chrome Custom Tabs on Android) rather than a plain WebView — Apple Pay and camera access are restricted in bare WebViews.
+
+The URL carries no redirect or callback parameter. Detect completion through the [`onramp-order`](/deposits/api/status-tracking#onramp-order) webhook or by [polling order status](#track-the-order), then dismiss the widget from your own UI.
+
+<Warning>
+    A user who abandons checkout produces no terminal event — the order simply
+    never progresses. Apply your own timeout when waiting on an order.
+</Warning>
+
+## Track the order
+
+Orders move through a normalized lifecycle:
+
+| Status       | Meaning                                    | Terminal |
+| ------------ | ------------------------------------------ | -------- |
+| `pending`    | Order created; awaiting payment or KYC     | no       |
+| `processing` | Payment captured; crypto not yet sent      | no       |
+| `completed`  | Crypto sent on-chain                       | yes      |
+| `failed`     | Order cancelled or declined                | yes      |
+
+Each transition fires an [`onramp-order`](/deposits/api/status-tracking#onramp-order) webhook carrying the normalized `status`, Swapped's `rawStatus`, the fiat receipt, and — once completed — the on-chain `transactionId`.
+
+You can also poll the account's latest order:
+
+```ts
+const response = await fetch(
+    `${DEPOSIT_SERVICE_URL}/onramp/swapped/status/0xUSER_ACCOUNT_ADDRESS`,
+    { headers: { "x-api-key": API_KEY } },
+);
+const order = await response.json();
+// {
+//     ok: true,
+//     orderId: "…",
+//     status: "order_broadcasted",
+//     orderCrypto: "USDC",
+//     orderCryptoAmount: "98.61",
+//     transactionId: "0xdef456…",
+//     paidAmountUsd: 101.75,
+//     onrampFeeUsd: 1.75,
+//     paymentMethod: "creditcard",
+//     receivedAt: "2025-01-15T12:03:00.000Z"
+// }
+```
+
+Polling reflects the account's most recent order and returns `{ ok: false, reason: "no_order" }` before the first order update arrives. Full schema: [`GET /onramp/swapped/status/{smartAccount}`](/api-reference/deposit-service/onramp/poll-the-latest-swapped-order-status-for-a-smart-account).
+
+Once the order completes, the on-ramp hands off to the regular pipeline: `transactionId` reappears as the `transactionHash` on the [`deposit-received`](/deposits/api/status-tracking#deposit-received) event, followed by the usual bridge events. Card and Apple Pay orders typically complete within minutes; bank transfers can take days. Orders stay trackable for 7 days.
+
+## Good to know
+
+- **Session coverage** — on-ramp purchases land on Base, so the account's session set must include Base. The default [registration flow](/deposits/api/account-registration) covers every supported chain; if you restrict `sessionChainIds`, include Base or landed funds can't be bridged.
+- **Deposit whitelist** — if you [restrict accepted deposits](/deposits/api/initial-setup#restrict-accepted-deposits), allow USDC on Base above your minimum. Otherwise every on-ramp purchase is rejected with [`deposit-rejected`](/deposits/api/status-tracking#deposit-rejected).
+- **Same-chain target** — when the account's target is USDC on Base paid to the account itself, the purchase is already at its destination: no bridge events fire, and `onramp-order` with `status: "completed"` is your terminal signal.
+- **KYC and limits** — identity verification and purchase limits are handled by Swapped inside the widget.

--- a/deposits/api/onramp.mdx
+++ b/deposits/api/onramp.mdx
@@ -15,7 +15,7 @@ Users without crypto can fund their account directly inside your app. The deposi
 
 ## Prerequisites
 
-- The account is [registered](/deposits/api/account-registration) — minting a checkout URL for an unregistered account returns `403`.
+- The account is [registered](/deposits/api/account-registration) — minting a checkout URL for an account that isn't registered to your project returns `403 Unauthorized`.
 - A [webhook URL](/deposits/api/initial-setup#configure-a-webhook) is configured if you want order updates pushed rather than polled.
 - Calls are made from your backend. The endpoints require your API key, which never ships in client-side code.
 
@@ -68,7 +68,7 @@ Full request and response schemas: [`POST /onramp/swapped/widget-url`](/api-refe
 
 ### Fund from an exchange
 
-To let users transfer from a centralized exchange balance (Binance, Coinbase, and others) instead of paying with fiat, mint a Connect URL — same request shape plus an optional `connection` preselecting the exchange, same response shape:
+To let users transfer from a centralized exchange balance (Binance, Coinbase, and others) instead of paying with fiat, mint a Connect URL. The request takes a subset of the widget fields — `smartAccount` plus optional `baseCountry`, `baseCurrencyCode`, `locale`, and a `connection` preselecting the exchange. There's no amount or payment-method prefill; the user chooses those inside the exchange flow. The response shape is identical:
 
 ```ts
 const response = await fetch(`${DEPOSIT_SERVICE_URL}/onramp/swapped/connect-url`, {

--- a/deposits/api/status-tracking.mdx
+++ b/deposits/api/status-tracking.mdx
@@ -136,6 +136,7 @@ Every webhook request body follows the same envelope structure:
 | [`bridge-delayed`](#bridge-delayed)                       | Bridge provider did not fill within the expected window; a refund is expected |
 | [`bridge-failed`](#bridge-failed)                         | Bridging failed                                                               |
 | [`deposit-refunded`](#deposit-refunded)                   | Deposit funds returned to a recipient on the source chain                     |
+| [`onramp-order`](#onramp-order)                           | A [fiat or CEX on-ramp](/deposits/api/onramp) order changed status            |
 | [`error`](#error)                                         | Unexpected error while processing a deposit (the settlement catch-all)        |
 
 #### `deposit-received`
@@ -336,6 +337,61 @@ Sent when funds from a deposit are returned to a recipient on the source chain. 
 | `refund.amount`           | `string` | Refund amount                     |
 | `refund.recipient`        | `string` | Address that received the refund  |
 
+#### `onramp-order`
+
+Sent when a [fiat or CEX on-ramp](/deposits/api/onramp) order moves through its lifecycle. Unlike the other events, it is tied to a Swapped order rather than a deposit — once the purchased crypto lands on-chain, the regular deposit events take over. Correlate `transactionId` here with `transactionHash` on the subsequent [`deposit-received`](#deposit-received).
+
+| Field                 | Type                  | Description                                                                                       |
+| --------------------- | --------------------- | -------------------------------------------------------------------------------------------------- |
+| `orderId`             | `string`              | Swapped order identifier                                                                            |
+| `orderUuid`           | `string`              | UUID minted with the checkout URL — the suffix of `externalCustomerId`                              |
+| `account`             | `string`              | Account address                                                                                     |
+| `source`              | `string`              | `"onramp"` (fiat widget) or `"exchange"` (CEX transfer)                                             |
+| `status`              | `string`              | Normalized [order status](/deposits/api/onramp#track-the-order): `"pending"`, `"processing"`, `"completed"`, or `"failed"` |
+| `rawStatus`           | `string`              | Swapped's raw order status                                                                          |
+| `terminal`            | `boolean`             | `true` once `status` is `"completed"` or `"failed"`                                                 |
+| `token`               | `string \| null`      | Purchased token symbol (e.g. `"USDC"`)                                                              |
+| `cryptoAmount`        | `string \| null`      | Purchased amount as a decimal string — **not** raw token units                                      |
+| `fiat`                | `object \| null`      | Fiat receipt; `null` until Swapped reports amounts                                                  |
+| `fiat.currency`       | `string`              | Fiat currency of the payment (`"USD"` or `"EUR"`)                                                   |
+| `fiat.amount`         | `string`              | Fiat amount before Swapped's fee (decimal string)                                                   |
+| `fiat.amountPlusFees` | `string \| null`      | Fiat amount including Swapped's fee                                                                 |
+| `fiat.feeUsd`         | `string \| null`      | Swapped's fee in USD, when derivable                                                                |
+| `transactionId`       | `string \| null`      | On-chain transaction hash of the crypto transfer, present once completed                            |
+| `method`              | `string \| null`      | Payment method when `source` is `"onramp"` (e.g. `"creditcard"`)                                    |
+| `exchange`            | `string \| null`      | Exchange slug when `source` is `"exchange"` (e.g. `"binance"`)                                      |
+
+```json
+{
+    "version": "1.0",
+    "type": "onramp-order",
+    "eventId": "12350",
+    "time": "2025-01-15T12:03:00.000Z",
+    "data": {
+        "orderId": "8f14e45f-ceea-4672-a1d5-6f3b2a7c9e01",
+        "orderUuid": "0b0e8f9c-2d4a-4e6b-9c1f-3a5d7e9b0c2d",
+        "account": "0x1234567890abcdef1234567890abcdef12345678",
+        "source": "onramp",
+        "status": "completed",
+        "rawStatus": "order_broadcasted",
+        "terminal": true,
+        "token": "USDC",
+        "cryptoAmount": "98.61",
+        "fiat": {
+            "currency": "USD",
+            "amount": "100.00",
+            "amountPlusFees": "101.75",
+            "feeUsd": "1.75"
+        },
+        "transactionId": "0xdef456...",
+        "method": "creditcard",
+        "exchange": null
+    }
+}
+```
+
+`onramp-order` is delivered at-least-once and only ever moves forward through the order lifecycle — you may receive a duplicate for the same stage, never an earlier one. Dedupe on `eventId`.
+
 #### `error`
 
 Sent when an unexpected, unhandled error occurs while processing a deposit — the catch-all in the settlement pipeline. It is not part of the normal lifecycle ordering and may arrive at any point. It carries whatever deposit / account / intent context was available at the point of failure; the optional fields are present only when that context was known.
@@ -398,7 +454,7 @@ function verifyWebhookSignature(
 ### Delivery behavior
 
 - **Retries** — failed deliveries are retried multiple times before the event is marked `failed`. Events that exhaust their retries can still be replayed on demand via [`POST /webhooks/events/{id}/resend`](/api-reference/deposit-service/webhooks/re-attempt-delivery-of-a-stored-webhook-event), which reuses the original `eventId`.
-- **Ordering** — events for a single deposit are sent in lifecycle order: `deposit-received` → `bridge-started` → `bridge-complete` when it proceeds, or `deposit-received` → `deposit-rejected` when it won't be bridged. There is no global ordering guarantee across deposits.
+- **Ordering** — events for a single deposit are sent in lifecycle order: `deposit-received` → `bridge-started` → `bridge-complete` when it proceeds, or `deposit-received` → `deposit-rejected` when it won't be bridged. `onramp-order` events are likewise ordered per order and only move forward. There is no global ordering guarantee across deposits or orders.
 - **URL validation** — the webhook URL must use HTTPS and must not target internal or private network addresses.
 - **Idempotency** — use `eventId` from the envelope as the canonical dedupe key.
 
@@ -430,5 +486,5 @@ For more details, see the API reference for [`GET /webhooks/events`](/api-refere
 ## Conventions
 
 - EVM addresses and token addresses are **lowercase**. Non-EVM addresses (Solana, Tron) preserve their original case.
-- All amounts are **strings** (raw token units, not human-readable).
+- All amounts are **strings** (raw token units, not human-readable). Exception: `onramp-order` amounts are decimal strings as reported by Swapped.
 - Chains use [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) identifiers (e.g. `"eip155:8453"` for Base).

--- a/deposits/api/status-tracking.mdx
+++ b/deposits/api/status-tracking.mdx
@@ -486,5 +486,5 @@ For more details, see the API reference for [`GET /webhooks/events`](/api-refere
 ## Conventions
 
 - EVM addresses and token addresses are **lowercase**. Non-EVM addresses (Solana, Tron) preserve their original case.
-- All amounts are **strings** (raw token units, not human-readable). Exception: `onramp-order` amounts are decimal strings as reported by Swapped.
+- Token amounts are **strings in raw token units** (not human-readable). Fiat amounts are **decimal strings** (e.g. `"101.75"`). The one crossover: `onramp-order.cryptoAmount` is reported by Swapped as a decimal string, not raw units.
 - Chains use [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) identifiers (e.g. `"eip155:8453"` for Base).

--- a/deposits/overview.mdx
+++ b/deposits/overview.mdx
@@ -130,7 +130,7 @@ Rhinestone Deposits supports a wide range of EVM chains plus Solana. Each chain 
 
 <Info>
   This data is also available programmatically via the [List supported chains
-  and tokens](/api-reference/deposit-service/info/list-supported-chains-and-tokens) endpoint.
+  and tokens](/api-reference/deposit-service/utilities/list-supported-chains-and-tokens) endpoint.
 </Info>
 
 ## Which should you use?

--- a/docs.json
+++ b/docs.json
@@ -402,6 +402,7 @@
               "deposits/api/initial-setup",
               "deposits/api/account-registration",
               "deposits/api/deposit-processing",
+              "deposits/api/onramp",
               "deposits/api/fees",
               "deposits/api/sponsorship",
               "deposits/api/status-tracking"

--- a/styles/config/vocabularies/Rhinestone/accept.txt
+++ b/styles/config/vocabularies/Rhinestone/accept.txt
@@ -180,3 +180,10 @@ struct
 bool
 null
 undefined
+
+# Fiat on-ramp (Swapped)
+CEX
+KYC
+iframes?
+WebViews?
+prefill(s|ed)?


### PR DESCRIPTION
## What

The deposit service's Swapped on-ramp shipped with endpoint docs only — the generated API reference covers `/onramp/swapped/*`, but the Deposits guide tab had no narrative coverage and the webhook reference didn't document `onramp-order`.

- **New page — `deposits/api/onramp` ("Fiat and CEX on-ramp")**: minting signed checkout/Connect URLs (fetch examples + field tables), embedding the widget (iframe permissions, in-app browser guidance, the no-redirect-parameter behavior and abandoned-checkout caveat), the normalized order lifecycle, status polling, and integration gotchas (session coverage of Base, deposit whitelist interplay, same-chain targets).
- **`deposits/api/status-tracking`**: documents the `onramp-order` event — field table, example payload, at-least-once + forward-only delivery semantics — and extends the ordering bullet plus the conventions section (on-ramp amounts are decimal strings, not raw units).
- **`docs.json`**: registers the page in Deposits → API, between Deposit processing and Fees.
- **Vale vocabulary**: adds CEX, KYC, iframe(s), WebView(s), prefill.
- **Drive-by fix** (own commit, easy to drop): the overview page linked the old `info/` API-reference group for "List supported chains and tokens" (now `utilities/`) — the repo's only `mintlify broken-links` failure.

## Verification

- `bunx mintlify broken-links`: **no broken links found** (was 1 before the drive-by fix).
- Rendered locally with `mintlify dev`: tables, code blocks, and the `<Warning>` render correctly; sidebar placement and cross-page anchors verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)