### PR TITLE
docs: document customDeadline transaction/intent option

### DIFF
--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -165,6 +165,27 @@ const payload = {
 ```
 </CodeGroup>
 
+## Custom fill deadline
+
+An intent's on-chain fill deadline defaults to 2 minutes. For **same-chain intents that settle without bridging**, extend it with `options.customDeadline` — an absolute unix timestamp in seconds. Use it when the user needs longer to approve, or you're fetching a quote now to submit later.
+
+<CodeGroup dropdown>
+```ts {5} Custom fill deadline
+const payload = {
+  // …
+  options: {
+    customDeadline: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+  },
+};
+```
+</CodeGroup>
+
+The value must be between `now + 120s` and `now + 86400s` (24 hours); outside that range the request is rejected with a `400`. When honored, the intent's fill deadline and its claim/nonce expiry extend to match.
+
+<Note>
+  `customDeadline` is honored only on same-chain intents that settle without bridging. On any other route — cross-chain, or a same-chain swap that requires funding — it is silently ignored and the default 2-minute deadline applies. The only signal is a nearer expiry on the returned quote.
+</Note>
+
 ## Source chain / token
 
 Select which tokens and/or chains to use as the source of funds via `accountAccessList`.

--- a/smart-wallet/core/create-first-transaction.mdx
+++ b/smart-wallet/core/create-first-transaction.mdx
@@ -73,6 +73,26 @@ const result = await rhinestoneAccount.waitForExecution(transaction)
 
 <Note>To deploy the account on a specific chain before transacting, call `await rhinestoneAccount.deploy(chain)` first. Otherwise, any transaction triggers deployment as part of the intent — token transfers, contract calls, approvals, anything.</Note>
 
+## Custom fill deadline
+
+A transaction's on-chain fill deadline defaults to 2 minutes. For a **same-chain transaction that settles without bridging**, extend it with `customDeadline` — an absolute unix timestamp in seconds. Useful when a user needs longer to approve, or you prepare a quote now and submit it later.
+
+```ts
+const prepared = await rhinestoneAccount.prepareTransaction({
+  chain: baseSepolia,
+  calls: [
+    /* … */
+  ],
+  customDeadline: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+})
+```
+
+The value must be between `now + 120s` and `now + 86400s` (24 hours); outside that range the request is rejected.
+
+<Note>
+  `customDeadline` is honored only on same-chain transactions that settle without bridging. On cross-chain transactions it is ignored and the default 2-minute deadline applies.
+</Note>
+
 ## Next steps
 
 <CardGroup cols={3}>


### PR DESCRIPTION
Documents the new **`customDeadline`** option (SDK 1.11.0 / orchestrator).

Adds a "Custom fill deadline" section to two pages, matching the existing option-section style:
- **Intents API guide** (`intents/guides/getting-a-quote.mdx`) — `options.customDeadline` on the `/quotes` payload.
- **Smart Wallet tutorial** (`smart-wallet/core/create-first-transaction.mdx`) — `customDeadline` on the SDK `prepareTransaction` / `sendTransaction` input.

Both cover: absolute unix seconds, bounds `now + 120s … now + 86400s` (24h), and that it's honored only on same-chain intents that settle without bridging (silently ignored otherwise).

### Note — separate pre-existing gap (not fixed here)
The **API Reference** tab's OpenAPI source in `docs.json` points at the openapi repo's top-level `orchestrator.json`, which has been frozen since 2026-06-25 (orphaned when the orchestrator moved to per-version `orchestrator/{alps,blanc}.json`). So the auto-generated API Reference won't show `customDeadline` — or anything merged since June — until that source is repointed. Flagging separately.