### PR TITLE
docs: point orchestrator API reference at the maintained blanc spec

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -434,7 +434,7 @@
           {
             "group": "Intents",
             "openapi": {
-              "source": "https://raw.githubusercontent.com/rhinestonewtf/openapi/refs/heads/main/orchestrator.json",
+              "source": "https://raw.githubusercontent.com/rhinestonewtf/openapi/refs/heads/main/orchestrator/blanc.json",
               "directory": "api-reference/orchestrator"
             }
           },


### PR DESCRIPTION
The **API Reference → Intents** group generated from the openapi repo's top-level `orchestrator.json`, which is a **legacy/orphaned stub**: the orchestrator CI now publishes per-version specs under `orchestrator/<version>.json` and stopped updating the top-level file (last touched 2026-06-25; it no longer even contains `/quotes`). That's why https://docs.rhinestone.dev/api-reference/orchestrator/quotes/create-quote is stale and missing `options.customDeadline`.

**Fix:** point the source at `orchestrator/blanc.json` — the `2026-04.blanc` version the guides already use, actively updated by orchestrator CI on every `v1` push.

- Same `operationId` (`createQuote`) and tag (`Quotes`) → page URLs preserved (`…/quotes/create-quote`).
- The reference now reflects the current API, including `options.customDeadline`.

No content-page changes — Mintlify regenerates the endpoint pages from the new source on deploy.