### PR TITLE
docs: SDK token inputs are addresses, not symbols

### DIFF
--- a/intents/use-cases/automated-zaps.mdx
+++ b/intents/use-cases/automated-zaps.mdx
@@ -163,6 +163,9 @@ Once funded, the companion account executes the crosschain intent using the sess
 ```ts
 import { encodeFunctionData, erc20Abi } from "viem";
 
+// USDC on Arbitrum — token inputs are addresses, not symbols
+const usdc = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+
 const prepared = await companionAccount.prepareTransaction({
   sourceChains: [ethereum],
   targetChain: arbitrum,
@@ -187,7 +190,7 @@ const prepared = await companionAccount.prepareTransaction({
   ],
   tokenRequests: [
     {
-      address: "USDC",
+      address: usdc,
       amount: depositAmount,
     },
   ],
@@ -258,6 +261,9 @@ await companionAccount.submitTransaction(signedPull);
 **Execute the crosschain intent** (bridge + vault deposit):
 
 ```ts
+// USDC on Arbitrum — token inputs are addresses, not symbols
+const usdc = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+
 const preparedExecute = await companionAccount.prepareTransaction({
   sourceChains: [ethereum],
   targetChain: arbitrum,
@@ -281,7 +287,7 @@ const preparedExecute = await companionAccount.prepareTransaction({
   ],
   tokenRequests: [
     {
-      address: "USDC",
+      address: usdc,
       amount: depositAmount,
     },
   ],
@@ -304,11 +310,14 @@ This two-step flow can potentially be simplified to a single step using source c
 You can sponsor the gas and bridging costs for the intent execution by passing `sponsored: true`:
 
 ```ts
+// USDC on Arbitrum — token inputs are addresses, not symbols
+const usdc = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+
 const data = await companionAccount.prepareTransaction({
   sourceChains: [ethereum],
   targetChain: arbitrum,
   calls: vaultDepositCalls,
-  tokenRequests: [{ address: "USDC", amount: depositAmount }],
+  tokenRequests: [{ address: usdc, amount: depositAmount }],
   sponsored: true,
   signers: sessionSigners,
 });

--- a/smart-wallet/advanced/batch-transactions.mdx
+++ b/smart-wallet/advanced/batch-transactions.mdx
@@ -8,6 +8,7 @@ You can make multiple calls in a single transaction:
 import { baseSepolia } from 'viem/chains'
 
 const chain = baseSepolia
+const usdc = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' // USDC on Base Sepolia
 const usdcAmount = 1n
 const ethAmount = 2n
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
@@ -16,7 +17,7 @@ const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
     {
-      to: 'USDC',
+      to: usdc,
       data: encodeFunctionData({
         abi: erc20Abi,
         functionName: 'transfer',

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -301,6 +301,21 @@ const response = await fetch('https://v1.orchestrator.rhinestone.dev/chains', {
 const chains = await response.json()
 ```
 
+### Token inputs are addresses
+
+SDK token inputs no longer accept symbols like `'USDC'` — pass the token's **address** for the relevant chain. This applies to `calls[].to`, `tokenRequests[].address`, `sourceAssets` (both the token-list and per-chain-map forms), and cross-chain permit legs (`from` / `to`).
+
+```ts
+// Before
+tokenRequests: [{ address: 'USDC', amount }]
+
+// After — use the token's address on the target chain
+const usdc = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // USDC on Base
+tokenRequests: [{ address: usdc, amount }]
+```
+
+Look up token addresses per chain from the orchestrator's `/chains` endpoint (see [Token registry helpers removed](#token-registry-helpers-removed)).
+
 ### `deployAccountsForOwners` removed
 
 Create a backend deployer account, take a view-only reference to each user account, and submit a sponsored intent that calls `deploy(userAccount)`. Pass multiple `deploy(...)` calls in one intent to batch deployments.
@@ -819,12 +834,15 @@ Now, you can call `prepareTransaction`:
 ```ts
 const usdcAmount = 2n;
 const recipient = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+// Token inputs are addresses now (symbols are no longer accepted).
+// Look up the token address for your target chain via GET /chains.
+const usdcAddress = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'; // USDC on Base
 
 const transactionData = await rhinestoneAccount.prepareTransaction({
   targetChain,
   calls: [
     {
-      to: 'USDC',
+      to: usdcAddress,
       data: encodeFunctionData({
         abi: erc20Abi,
         functionName: 'transfer',
@@ -834,7 +852,7 @@ const transactionData = await rhinestoneAccount.prepareTransaction({
   ],
   tokenRequests: [
     {
-      address: 'USDC',
+      address: usdcAddress,
       amount: usdcAmount,
     },
   ],

--- a/smart-wallet/advanced/multi-factor-authentication.mdx
+++ b/smart-wallet/advanced/multi-factor-authentication.mdx
@@ -167,12 +167,13 @@ const rhinestoneAccount = await rhinestone.createAccount({
 })
 
 const usdcAmount = parseUnits('0.1', 6)
+const usdc = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' // USDC on Arbitrum
 const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
     {
-      to: 'USDC',
+      to: usdc,
       value: 0n,
       data: encodeFunctionData({
         abi: erc20Abi,
@@ -181,7 +182,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
       }),
     },
   ],
-  tokenRequests: [{ address: 'USDC', amount: usdcAmount }],
+  tokenRequests: [{ address: usdc, amount: usdcAmount }],
   // Provide both factors. `id` is each validator's index in the list above.
   signers: {
     type: 'owner',

--- a/smart-wallet/chain-abstraction/multi-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/multi-chain-intent.mdx
@@ -16,6 +16,7 @@ Learn more about how Rhinestone intents work [here](../../home/introduction/rhin
 We will make a cross-chain token transfer using multi-chain intents.
 
 ```tsx
+const usdcOnArbitrum = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' // Arbitrum
 const amount = parseUnits('100', 6) // 100 USDC
 
 const prepared = await rhinestoneAccount.prepareTransaction({
@@ -23,7 +24,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
   targetChain: arbitrum,
   calls: [
     {
-      to: 'USDC',
+      to: usdcOnArbitrum,
       data: encodeFunctionData({
         abi: erc20Abi,
         functionName: 'transfer',
@@ -33,7 +34,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
   ],
   tokenRequests: [
     {
-      address: 'USDC',
+      address: usdcOnArbitrum,
       amount,
     },
   ],
@@ -74,7 +75,10 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 
 You can specify what token (or tokens) to use as an input asset:
 
-```ts {10}
+```ts {13}
+const usdc = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // Base
+const eth = '0x0000000000000000000000000000000000000000' // Native ETH
+
 const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
@@ -84,13 +88,15 @@ const transaction = await rhinestoneAccount.prepareTransaction({
   tokenRequests: [
     // …
   ],
-  sourceAssets: ['USDC', 'ETH']
+  sourceAssets: [usdc, eth]
 })
 ```
 
 You can also specify source assets on a per-chain basis:
 
-```ts {9-12}
+```ts {11-14}
+const usdc = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // Base
+
 const transaction = await rhinestoneAccount.prepareTransaction({
   targetChain: arbitrum,
   calls: [
@@ -100,7 +106,7 @@ const transaction = await rhinestoneAccount.prepareTransaction({
     // …
   ],
   sourceAssets: {
-    [base.id]: ['USDC'],
+    [base.id]: [usdc],
     [optimism.id]: ['0x4200000000000000000000000000000000000006'], // WETH
   },
 })

--- a/smart-wallet/chain-abstraction/single-chain-intent.mdx
+++ b/smart-wallet/chain-abstraction/single-chain-intent.mdx
@@ -14,11 +14,13 @@ Relayers execute single-chain intents through the intent executor module. For a 
 Here's how you can make a token transfer:
 
 ```ts
+const usdc = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // Base
+
 const prepared = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
     {
-      to: 'USDC',
+      to: usdc,
       data: encodeFunctionData({
         abi: erc20Abi,
         functionName: 'transfer',
@@ -52,7 +54,10 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 
 You can specify what token (or tokens) to use as an input asset:
 
-```ts {9}
+```ts {12}
+const usdc = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // Base
+const eth = '0x0000000000000000000000000000000000000000' // Native ETH
+
 const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
@@ -61,7 +66,7 @@ const transaction = await rhinestoneAccount.prepareTransaction({
   tokenRequests: [
     // …
   ],
-  sourceAssets: ['USDC', 'ETH']
+  sourceAssets: [usdc, eth]
 })
 ```
 

--- a/smart-wallet/chain-abstraction/source-token-amount.mdx
+++ b/smart-wallet/chain-abstraction/source-token-amount.mdx
@@ -8,21 +8,24 @@ This can be helpful if you want to limit the amount of tokens to bridge, or if y
 
 To bridge a specific amount of tokens:
 
-```ts  {4-10}
+```ts  {7-13}
+const usdcOnOptimism = '0x0b2c639c533813F4AA9D7837CAF62653d097Ff85' // Optimism
+const usdcOnBase = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // Base
+
 const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism],
   targetChain: base,
   sourceAssets: [
     {
       chain: optimism,
-      address: 'USDC',
+      address: usdcOnOptimism,
       amount: parseUnits('10', 6),
     }
   ],
   tokenRequests: [
     {
       // Note: no amount specified for the target token
-      address: 'USDC',
+      address: usdcOnBase,
     },
   ],
 })
@@ -34,10 +37,11 @@ This will bridge 10 USDC from Optimism to Base.
 
 To bridge the entire balance of a token:
 
-```ts {9-14,23}
+```ts {10-15,24}
 const sourceChain = optimism
 const targetChain = base
-const usdcOnOptimism = '0x0b2c639c533813F4AA9D7837CAF62653d097Ff85'
+const usdcOnOptimism = '0x0b2c639c533813F4AA9D7837CAF62653d097Ff85' // Optimism
+const usdcOnBase = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // Base
 
 const publicClient = createPublicClient({
   chain: sourceChain,
@@ -56,13 +60,13 @@ const transaction = await rhinestoneAccount.prepareTransaction({
   sourceAssets: [
     {
       chain: sourceChain,
-      address: 'USDC',
+      address: usdcOnOptimism,
       amount: usdcBalance,
     },
   ],
   tokenRequests: [
     {
-      address: 'USDC',
+      address: usdcOnBase,
     },
   ],
 })
@@ -74,25 +78,29 @@ This will sweep the user's USDC balance on Optimism to Base.
 
 You can specify exact source amounts from multiple source chains:
 
-```ts {4-15}
+```ts {8-19}
+const usdcOnOptimism = '0x0b2c639c533813F4AA9D7837CAF62653d097Ff85' // Optimism
+const usdcOnBase = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // Base
+const usdcOnArbitrum = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' // Arbitrum
+
 const transaction = await rhinestoneAccount.prepareTransaction({
   sourceChains: [optimism, base],
   targetChain: arbitrum,
   sourceAssets: [
     {
       chain: optimism,
-      address: 'USDC',
+      address: usdcOnOptimism,
       amount: parseUnits('50', 6),
     },
     {
       chain: base,
-      address: 'USDC',
+      address: usdcOnBase,
       amount: parseUnits('30', 6),
     },
   ],
   tokenRequests: [
     {
-      address: 'USDC',
+      address: usdcOnArbitrum,
     },
   ],
 })

--- a/smart-wallet/chain-abstraction/swaps.mdx
+++ b/smart-wallet/chain-abstraction/swaps.mdx
@@ -14,6 +14,7 @@ Request ETH on the target chain via `tokenRequests`. If the user only holds anot
 ```ts
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
+const eth = '0x0000000000000000000000000000000000000000' // Native ETH
 const ethAmount = 2n
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
@@ -28,7 +29,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
   ],
   tokenRequests: [
     {
-      address: 'ETH',
+      address: eth,
       amount: ethAmount,
     },
   ],

--- a/smart-wallet/core/create-first-transaction.mdx
+++ b/smart-wallet/core/create-first-transaction.mdx
@@ -14,13 +14,14 @@ import { encodeFunctionData, erc20Abi } from 'viem'
 import { baseSepolia } from 'viem/chains'
 
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
+const usdc = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' // USDC on Base Sepolia
 const usdcAmount = 1n
 
 const prepared = await rhinestoneAccount.prepareTransaction({
   chain: baseSepolia,
   calls: [
     {
-      to: 'USDC',
+      to: usdc,
       value: 0n,
       data: encodeFunctionData({
         abi: erc20Abi,
@@ -44,12 +45,14 @@ Swap `chain` for `sourceChains` + `targetChain`. The SDK handles bridging and ro
 ```ts
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
+const usdc = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' // USDC on Arbitrum Sepolia
+
 const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [baseSepolia],
   targetChain: arbitrumSepolia,
   calls: [
     {
-      to: 'USDC',
+      to: usdc,
       value: 0n,
       data: encodeFunctionData({
         abi: erc20Abi,
@@ -60,7 +63,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
   ],
   tokenRequests: [
     {
-      address: 'USDC',
+      address: usdc,
       amount: usdcAmount,
     },
   ],

--- a/smart-wallet/core/multisig.mdx
+++ b/smart-wallet/core/multisig.mdx
@@ -74,12 +74,13 @@ const account = await rhinestone.createAccount({
 })
 
 const usdcAmount = parseUnits('0.1', 6)
+const usdc = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' // USDC on Arbitrum
 const prepared = await account.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
     {
-      to: 'USDC',
+      to: usdc,
       value: 0n,
       data: encodeFunctionData({
         abi: erc20Abi,
@@ -88,7 +89,7 @@ const prepared = await account.prepareTransaction({
       }),
     },
   ],
-  tokenRequests: [{ address: 'USDC', amount: usdcAmount }],
+  tokenRequests: [{ address: usdc, amount: usdcAmount }],
   // Sign from a single device
   signers: {
     type: 'owner',
@@ -113,13 +114,14 @@ When the threshold is greater than one, you need signatures from several owners.
 If every key is available in the same environment, sign with a subset of owners in a single call. List the signing owners under `signers` and call `signTransaction` once — the SDK requests a signature from each account in the list in parallel and packs them into the account's multisig signature. Every listed key must be reachable in this environment; if the owners sign from separate devices, use [independent signing](#independent-signing) instead.
 
 ```ts
+const usdc = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' // USDC on Arbitrum
 const prepared = await account.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
     // …
   ],
-  tokenRequests: [{ address: 'USDC', amount: usdcAmount }],
+  tokenRequests: [{ address: usdc, amount: usdcAmount }],
   // Two of the three owners sign to meet the 2-of-3 threshold
   signers: {
     type: 'owner',
@@ -138,13 +140,14 @@ When owners are separate parties on different devices, each signs the same prepa
 
 ```ts
 // Coordinator: prepare once, then share `prepared` with each owner
+const usdc = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' // USDC on Arbitrum
 const prepared = await account.prepareTransaction({
   sourceChains: [base],
   targetChain: arbitrum,
   calls: [
     // …
   ],
-  tokenRequests: [{ address: 'USDC', amount: usdcAmount }],
+  tokenRequests: [{ address: usdc, amount: usdcAmount }],
 })
 
 // Each owner signs in their own environment

--- a/smart-wallet/core/signers/dynamic.mdx
+++ b/smart-wallet/core/signers/dynamic.mdx
@@ -275,6 +275,8 @@ import { useState } from 'react'
 import { encodeFunctionData, parseUnits, erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
+const usdc = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' // USDC on Arbitrum Sepolia
+
 function CrossChainTransfer({ rhinestoneAccount }) {
   const [isTransacting, setIsTransacting] = useState(false)
   const [txResult, setTxResult] = useState(null)
@@ -293,7 +295,7 @@ function CrossChainTransfer({ rhinestoneAccount }) {
         targetChain: arbitrumSepolia,
         calls: [
           {
-            to: "USDC", // This resolves to the USDC address on the target chain
+            to: usdc,
             data: encodeFunctionData({
               abi: erc20Abi,
               functionName: "transfer",
@@ -303,7 +305,7 @@ function CrossChainTransfer({ rhinestoneAccount }) {
         ],
         tokenRequests: [
           {
-            address: "USDC",
+            address: usdc,
             amount: parseUnits("10", 6),
           },
         ],

--- a/smart-wallet/core/signers/external-wallet-signer.mdx
+++ b/smart-wallet/core/signers/external-wallet-signer.mdx
@@ -120,13 +120,15 @@ export function WalletConnector() {
 ## Cross-Chain Transaction Example
 
 ```tsx
+const usdc = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' // USDC on Base Sepolia
+
 async function sendCrossChainTransaction(rhinestoneAccount) {
   const prepared = await rhinestoneAccount.prepareTransaction({
     sourceChains: [arbitrumSepolia],
     targetChain: baseSepolia,
     calls: [
       {
-        to: "USDC",
+        to: usdc,
         data: encodeFunctionData({
           abi: erc20Abi,
           functionName: "transfer",
@@ -136,7 +138,7 @@ async function sendCrossChainTransaction(rhinestoneAccount) {
     ],
     tokenRequests: [
       {
-        address: "USDC",
+        address: usdc,
         amount: parseUnits("10", 6),
       },
     ],

--- a/smart-wallet/core/signers/magic.mdx
+++ b/smart-wallet/core/signers/magic.mdx
@@ -349,13 +349,15 @@ Once initialized, both wallet types use the same Rhinestone API:
 import { encodeFunctionData, parseUnits, erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
+const usdc = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' // USDC on Arbitrum Sepolia
+
 async function handleCrossChainTransfer(rhinestoneAccount) {
   const prepared = await rhinestoneAccount.prepareTransaction({
     sourceChains: [baseSepolia],
     targetChain: arbitrumSepolia,
     calls: [
       {
-        to: "USDC",
+        to: usdc,
         data: encodeFunctionData({
           abi: erc20Abi,
           functionName: "transfer",
@@ -365,7 +367,7 @@ async function handleCrossChainTransfer(rhinestoneAccount) {
     ],
     tokenRequests: [
       {
-        address: "USDC",
+        address: usdc,
         amount: parseUnits("10", 6),
       },
     ],

--- a/smart-wallet/core/signers/openfort.mdx
+++ b/smart-wallet/core/signers/openfort.mdx
@@ -288,6 +288,8 @@ import { useState } from 'react'
 import { encodeFunctionData, parseUnits, erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
+const usdc = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' // USDC on Arbitrum Sepolia
+
 function CrossChainTransfer({ rhinestoneAccount }) {
   const [isTransacting, setIsTransacting] = useState(false)
   const [txResult, setTxResult] = useState(null)
@@ -306,7 +308,7 @@ function CrossChainTransfer({ rhinestoneAccount }) {
         targetChain: arbitrumSepolia,
         calls: [
           {
-            to: "USDC", // This resolves to the USDC address on the target chain
+            to: usdc,
             data: encodeFunctionData({
               abi: erc20Abi,
               functionName: "transfer",
@@ -316,7 +318,7 @@ function CrossChainTransfer({ rhinestoneAccount }) {
         ],
         tokenRequests: [
           {
-            address: "USDC",
+            address: usdc,
             amount: parseUnits("10", 6),
           },
         ],

--- a/smart-wallet/core/signers/para.mdx
+++ b/smart-wallet/core/signers/para.mdx
@@ -177,11 +177,13 @@ Once initialized, use the Rhinestone account for cross-chain transactions:
 import { encodeFunctionData, parseUnits, erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
+const usdc = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' // USDC on Arbitrum Sepolia
+
 const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [baseSepolia],
   targetChain: arbitrumSepolia,
   calls: [{
-    to: "USDC",
+    to: usdc,
     data: encodeFunctionData({
       abi: erc20Abi,
       functionName: "transfer",
@@ -189,7 +191,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
     }),
   }],
   tokenRequests: [{
-    address: "USDC",
+    address: usdc,
     amount: parseUnits("10", 6),
   }],
   sponsored: true,

--- a/smart-wallet/core/signers/privy.mdx
+++ b/smart-wallet/core/signers/privy.mdx
@@ -228,13 +228,15 @@ import { encodeFunctionData, parseUnits } from 'viem'
 import { erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
+const usdc = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' // USDC on Arbitrum Sepolia
+
 async function handleCrossChainTransfer(rhinestoneAccount) {
   const prepared = await rhinestoneAccount.prepareTransaction({
     sourceChains: [baseSepolia],
     targetChain: arbitrumSepolia,
     calls: [
       {
-        to: "USDC",
+        to: usdc,
         data: encodeFunctionData({
           abi: erc20Abi,
           functionName: "transfer",
@@ -244,7 +246,7 @@ async function handleCrossChainTransfer(rhinestoneAccount) {
     ],
     tokenRequests: [
       {
-        address: "USDC",
+        address: usdc,
         amount: parseUnits("10", 6),
       },
     ],

--- a/smart-wallet/core/signers/turnkey.mdx
+++ b/smart-wallet/core/signers/turnkey.mdx
@@ -105,12 +105,14 @@ The Rhinestone account will automatically use the Turnkey signer for all transac
 import { encodeFunctionData, parseUnits, erc20Abi } from 'viem'
 import { baseSepolia, arbitrumSepolia } from 'viem/chains'
 
+const usdc = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' // USDC on Arbitrum Sepolia
+
 const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [baseSepolia],
   targetChain: arbitrumSepolia,
   calls: [
     {
-      to: "USDC",
+      to: usdc,
       data: encodeFunctionData({
         abi: erc20Abi,
         functionName: "transfer",
@@ -120,7 +122,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
   ],
   tokenRequests: [
     {
-      address: "USDC",
+      address: usdc,
       amount: parseUnits("10", 6),
     },
   ],

--- a/smart-wallet/quickstart.mdx
+++ b/smart-wallet/quickstart.mdx
@@ -117,13 +117,14 @@ Transfer USDC on the target chain, sourced from the ETH you funded on the source
 
 ```ts
 const usdcAmount = parseUnits('0.1', 6)
+const usdc = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' // USDC on Arbitrum Sepolia
 
 const prepared = await rhinestoneAccount.prepareTransaction({
   sourceChains: [sourceChain],
   targetChain,
   calls: [
     {
-      to: 'USDC',
+      to: usdc,
       value: 0n,
       data: encodeFunctionData({
         abi: erc20Abi,
@@ -134,7 +135,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
   ],
   tokenRequests: [
     {
-      address: 'USDC',
+      address: usdc,
       amount: usdcAmount,
     },
   ],


### PR DESCRIPTION
## What

Follows the merged SDK v2 change [require token addresses, drop symbol inputs (`sdk#669`)], which makes token **symbols** (`'USDC'`, `'ETH'`, …) invalid as SDK inputs. Updates the docs so copy-pasted examples work.

- **18 files** — every `smart-wallet/**` SDK example plus `intents/use-cases/automated-zaps` now passes chain-specific token **addresses** (named `usdc`/`eth` constants) for `to`, `tokenRequests[].address`, `sourceAssets` (list + per-chain-map forms), and permit legs.
- **Migration guide** — added a `### Token inputs are addresses` section (points at `/chains` for lookups, consistent with the existing "Token registry helpers removed" section) and fixed the orchestrator-migration example.

## Out of scope (intentionally left)

- Raw-orchestrator-API examples (`intents/guides/*`, `multi-input-bridge.mdx`) — they call `/quotes` directly via `fetch`, not the SDK, so the SDK change doesn't affect them.
- Deposit-API `match: { symbol }` and response/display `"symbol"` fields — not SDK token inputs.

## Verification

- Full-tree grep: no token symbols remain in any SDK **input** position (only the intentional `// Before` example and the raw-API JSON bodies remain).
- All substituted addresses are canonical USDC per the example's target chain (Base, Base Sepolia, Arbitrum, Arbitrum Sepolia) and the zero address for native ETH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)