### PR TITLE
docs(deposits): clarify the on-ramp payment method (optional + accepts any Swapped method)

### DIFF
--- a/deposits/api/onramp.mdx
+++ b/deposits/api/onramp.mdx
@@ -33,14 +33,14 @@ const response = await fetch(`${DEPOSIT_SERVICE_URL}/onramp/swapped/widget-url`,
         smartAccount: "0xUSER_ACCOUNT_ADDRESS",
         baseCurrencyCode: "EUR",
         baseCurrencyAmount: 100,
-        method: "apple-pay",
+        method: "apple-pay", // optional — omit to let Swapped choose the best method
     }),
 });
 
 const { url, externalCustomerId, expiresAt } = await response.json();
 ```
 
-Only `smartAccount` is required. The optional fields prefill the widget:
+Only `smartAccount` is required — every other field, including `method`, is optional and simply prefills the widget. If you omit `method`, Swapped auto-selects the best payment method for the user based on their location and other signals:
 
 | Field                | Type     | Description                                                        |
 | -------------------- | -------- | ------------------------------------------------------------------ |
@@ -50,7 +50,7 @@ Only `smartAccount` is required. The optional fields prefill the widget:
 | `baseCurrencyCode`   | `string` | Fiat currency to charge in (e.g. `"EUR"`)                          |
 | `baseCurrencyAmount` | `number` | Prefilled purchase amount in the fiat currency                     |
 | `locale`             | `string` | Widget language                                                    |
-| `method`             | `string` | Preselected payment method: `"creditcard"`, `"apple-pay"`, or `"bank-transfer"` |
+| `method`             | `string` | **Optional.** Preselects a payment method: `"creditcard"`, `"apple-pay"`, or `"bank-transfer"`. Omit it to let Swapped auto-select the best method for the user. |
 
 The response carries the signed URL:
 


### PR DESCRIPTION
## What

Clarifies the `method` (payment method) field on `POST /onramp/swapped/widget-url` in the fiat/CEX on-ramp guide:

- **Optional** — omit it and Swapped auto-selects the best method for the user (based on location + other signals).
- Accepts **any Swapped payment method** (a `payment_group`), not just card / Apple Pay / bank transfer — with common values listed and a link to Swapped's Get Payment Methods as the per-account source of truth.
- An **unsupported value is harmless** — the widget ignores it and falls back to the best available method, so it never blocks checkout.

Reinforced across the intro sentence, the field table, the code example, and a dedicated note.

## Why

An API consumer asked whether the payment method was required, and whether they could pass methods beyond the three we listed ([Slack thread](https://rhinestonewtf.slack.com/archives/C07J3JLULA3/p1784811898376669?thread_ts=1784754838.273099&cid=C07J3JLULA3)). It's optional, and — after rhinestonewtf/deposit-service-processor#559 — any supported method is accepted.

## ⚠️ Merge ordering

The "accepts any method" content reflects behavior enabled by **rhinestonewtf/deposit-service-processor#559** — please merge this **after** #559 deploys. (The "optional" clarification is already true in production.)

## Verification

The graceful-fallback claim was verified empirically against Swapped's sandbox (Swapped's own published test credentials — no production secret): a bogus method and a *disabled* real method (`google-pay`) each rendered a fully working widget with no error, falling back to the default. `method` is matched client-side against the merchant's enabled list; a non-match is dropped before order creation.