### PR TITLE
docs(deposits): document that any Swapped payment method is accepted

### DIFF
--- a/deposits/api/onramp.mdx
+++ b/deposits/api/onramp.mdx
@@ -50,7 +50,9 @@ Only `smartAccount` is required — every other field, including `method`, is op
 | `baseCurrencyCode`   | `string` | Fiat currency to charge in (e.g. `"EUR"`)                          |
 | `baseCurrencyAmount` | `number` | Prefilled purchase amount in the fiat currency                     |
 | `locale`             | `string` | Widget language                                                    |
-| `method`             | `string` | **Optional.** Preselects a payment method: `"creditcard"`, `"apple-pay"`, or `"bank-transfer"`. Omit it to let Swapped auto-select the best method for the user. |
+| `method`             | `string` | **Optional.** Preselects a payment method — accepts any method Swapped supports (see the list below). Omit it to let Swapped auto-select the best method for the user. |
+
+`method` takes a Swapped **payment group**. Swapped offers 40+ methods and the set available depends on the user's region — common values include `"creditcard"`, `"apple-pay"`, `"bank-transfer"`, `"skrill"`, `"pix"`, and `"sepa-bank-transfer"`. Pass a method's `payment_group`; the authoritative, up-to-date list for your account is Swapped's [Get Payment Methods](https://docs.swapped.com/swapped-ramp/endpoints/onramp-endpoints/get-payment-methods) endpoint. A value Swapped doesn't support for the user is ignored rather than rejected — the widget falls back to the best available method, so an unrecognized `method` never blocks checkout.
 
 The response carries the signed URL:
 


### PR DESCRIPTION
## What

Expands the on-ramp guide's `method` docs to reflect that **any Swapped payment method is accepted**. This is a follow-up to #170, which merged with only the earlier "optional" clarification — this expansion landed on that branch after it had already merged, so it needs its own PR.

- `method` accepts any Swapped payment method (a `payment_group`), not just card / Apple Pay / bank transfer.
- Lists common values (`creditcard`, `apple-pay`, `bank-transfer`, `skrill`, `pix`, `sepa-bank-transfer`) and links to Swapped's Get Payment Methods as the per-account source of truth.
- Notes that an unsupported value is ignored — the widget falls back to its default — so it never blocks checkout.

## Why

The allowlist gate was removed in rhinestonewtf/deposit-service-processor#559 (merged), so clients can now pass any supported method.

## Verification

The graceful-fallback claim was verified empirically against Swapped's sandbox (Swapped's own published test credentials — no production secret): a bogus method and a *disabled* real method (`google-pay`) each rendered a fully working widget with no error, falling back to the default. `method` is matched client-side against the merchant's enabled list and dropped before order creation.