### PR TITLE
docs: cover runtime chain catalog migration

### DIFF
--- a/intents/use-cases/automated-zaps.mdx
+++ b/intents/use-cases/automated-zaps.mdx
@@ -45,7 +45,6 @@ Since the user's EOA is the sole owner, the account is fully non-custodial. Your
 Define multi-chain sessions scoped to the vault contracts your app supports. The session key is controlled by your app's service.
 
 ```ts
-import { toSession } from "@rhinestone/sdk/smart-sessions";
 import { erc20Abi } from "viem";
 import { arbitrum, optimism } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
@@ -53,8 +52,8 @@ import { privateKeyToAccount } from "viem/accounts";
 // Session key controlled by your app's service
 const sessionOwnerAccount = privateKeyToAccount(appSessionKey);
 
-const sessions = [
-  toSession({
+const sessions = await Promise.all([
+  rhinestone.createSession({
     chain: arbitrum,
     owners: {
       type: "ecdsa",
@@ -84,7 +83,7 @@ const sessions = [
       },
     ],
   }),
-  toSession({
+  rhinestone.createSession({
     chain: optimism,
     owners: {
       type: "ecdsa",
@@ -104,7 +103,7 @@ const sessions = [
       // Plus the ERC-20 permissions, as above.
     ],
   }),
-];
+]);
 ```
 
 The user signs once to authorize all sessions across all chains:

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -111,6 +111,8 @@ const session = toSession(definition, {
 })
 ```
 
+<Info>For normal online usage, prefer [`RhinestoneSDK.createSession`](/sdk-reference/rhinestone-sdk/create-session) so the SDK resolves the wrapped-native token for you.</Info>
+
 ### Session policies are declarative
 
 In 1.x, each `action` carried a raw `policies` array that you assembled by hand. Those arrays are gone — policies are now expressed through fields on the permission's function config, and `createSession` compiles them into the right on-chain policies:

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -40,11 +40,9 @@ const result = await rhinestoneAccount.submitTransaction(signed)
 
 ### Session permissions are ABI-driven
 
-`Session.actions` is gone. Build sessions with `toSession({ chain, owners, permissions })` instead — an ABI-driven definition the SDK resolves into a low-level `Session`. Each permission is an `{ abi, address, functions }` entry; function selectors and param calldata offsets are derived from the ABI, and param value types are checked against ABI input types:
+`Session.actions` is gone. Build sessions with `rhinestone.createSession({ chain, owners, permissions })` instead — an ABI-driven definition the SDK resolves into a low-level `Session`. Each permission is an `{ abi, address, functions }` entry; function selectors and param calldata offsets are derived from the ABI, and param value types are checked against ABI input types:
 
 ```ts
-import { toSession } from '@rhinestone/sdk/smart-sessions'
-
 // Before
 const session: Session = {
   chain: base,
@@ -72,7 +70,7 @@ const session: Session = {
 }
 
 // After
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: { type: 'ecdsa', accounts: [sessionOwner] },
   permissions: [
@@ -91,11 +89,31 @@ const session = toSession({
 })
 ```
 
-The hand-written shape is now `SessionDefinition`; `Session` is the resolved output of `toSession`.
+The hand-written shape is now `SessionDefinition`; `Session` is the resolved output of `createSession`.
+
+### Session creation resolves wrapped-native tokens
+
+`toSession` no longer reads bundled chain data. Calling `toSession(definition)` without options omits the wrapped-native `deposit()` permission, so a session that later needs to wrap native tokens can fail.
+
+Use the project-scoped `RhinestoneSDK.createSession` method for the normal online flow. It resolves the chain's wrapped-native token from the orchestrator and fails if the chain is unsupported or does not advertise one:
+
+```ts
+const session = await rhinestone.createSession(definition)
+```
+
+For a fully offline flow, keep using `toSession` and pass the wrapped-native token explicitly:
+
+```ts
+import { toSession } from '@rhinestone/sdk/smart-sessions'
+
+const session = toSession(definition, {
+  wrappedNativeToken,
+})
+```
 
 ### Session policies are declarative
 
-In 1.x, each `action` carried a raw `policies` array that you assembled by hand. Those arrays are gone — policies are now expressed through fields on the permission's function config, and `toSession` compiles them into the right on-chain policies:
+In 1.x, each `action` carried a raw `policies` array that you assembled by hand. Those arrays are gone — policies are now expressed through fields on the permission's function config, and `createSession` compiles them into the right on-chain policies:
 
 - `params: { x: { anyOf: [a, b] } }` — allowlist a parameter against several values (compiles to an arg-policy OR chain). A single `{ condition, value }` stays a cheaper universal-action.
 - `maxUses` — cap how many times the function may be called.
@@ -104,7 +122,7 @@ In 1.x, each `action` carried a raw `policies` array that you assembled by hand.
 - `spendingLimit: { token, amount }` — cap cumulative ERC-20 spend (only on `transfer` / `transferFrom` / `approve` / `increaseAllowance`-shaped functions).
 
 ```ts
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: { type: 'ecdsa', accounts: [sessionOwner] },
   permissions: [
@@ -127,12 +145,12 @@ Passing a raw `policies` array on a permission now throws instead of being silen
 
 ### Session policy addresses
 
-The smart session policies were redeployed, and `toSession` now bakes the new addresses into the session digest by default. If an account already enabled sessions against the previous deployments, trying to use the existing session with the new policies results in an onchain revert due to the digest mismatch.
+The smart session policies were redeployed, and `createSession` now bakes the new addresses into the session digest by default. If an account already enabled sessions against the previous deployments, trying to use the existing session with the new policies results in an onchain revert due to the digest mismatch.
 
 Pin the affected policies back to the addresses the account was enabled against via `SessionDefinition.policyAddresses`:
 
 ```ts
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: { type: 'ecdsa', accounts: [sessionOwner] },
   permissions: [/* … */],
@@ -260,6 +278,33 @@ const signers = {
 
 `PortfolioToken` no longer carries a token-level `decimals` or aggregate `balances`. `decimals` now lives on each per-chain `chains[]` entry alongside `address` and `amount`, since the same logical token can have different decimals across chains (e.g., USDC is 6 on Ethereum, 18 on BSC). Read the per-chain entry directly when rendering balances.
 
+### Alchemy provider config removed
+
+The SDK no longer builds Alchemy URLs from an API key. Supply the RPC URLs through the custom provider config, or omit `provider` to use viem's default transport:
+
+```ts
+// Before
+const rhinestone = new RhinestoneSDK({
+  apiKey,
+  provider: {
+    type: 'alchemy',
+    apiKey: alchemyApiKey,
+  },
+})
+
+// After
+const rhinestone = new RhinestoneSDK({
+  apiKey,
+  provider: {
+    type: 'custom',
+    urls: {
+      [base.id]: baseRpcUrl,
+      [arbitrum.id]: arbitrumRpcUrl,
+    },
+  },
+})
+```
+
 ### Permit2 claim policy renames
 
 If you constructed `Permit2ClaimPolicy` values directly, the type tag and field names changed to be chain-aware:
@@ -292,7 +337,9 @@ const policy: Permit2ClaimPolicy = {
 
 ### Token registry helpers removed
 
-`getSupportedTokens`, `getTokenAddress`, `getTokenDecimals`, and `getAllSupportedChainsAndTokens` are removed. Fetch the equivalent data from the orchestrator's `/chains` endpoint:
+The SDK no longer bundles the supported-chain and token registry. `SupportedChain` is now `number`, so code must not assume that the installed SDK contains an exhaustive union of chain IDs.
+
+`getSupportedTokens`, `getTokenAddress`, `getTokenDecimals`, `getAllSupportedChainsAndTokens`, `getWethAddress`, `getTokenSymbol`, and `isTokenAddressSupported` are removed. Fetch the supported chains, token metadata, and `wrappedNativeToken` from the orchestrator's `/chains` endpoint:
 
 ```ts
 const response = await fetch('https://v1.orchestrator.rhinestone.dev/chains', {

--- a/smart-wallet/customize/json-rpc-providers.mdx
+++ b/smart-wallet/customize/json-rpc-providers.mdx
@@ -8,30 +8,7 @@ Many public providers are heavily throttled and are not suitable for high traffi
 
 For production use, we recommend setting up a custom JSON-RPC provider with your own API key.
 
-<Tabs>
-<Tab title="Alchemy">
-
-To use [Alchemy](https://www.alchemy.com), provide an API key during SDK initialization:
-
-```ts {2-5}
-const rhinestone = new RhinestoneSDK({
-  provider: {
-    type: 'alchemy',
-    apiKey: alchemyApiKey,
-  }
-})
-const rhinestoneAccount = await rhinestone.createAccount({
-  owners: {
-    type: 'ecdsa',
-    accounts: [signer],
-  },
-})
-```
-
-</Tab>
-<Tab title="Custom URLs">
-
-To use custom JSON-RPC URLs, provide a mapping of chain IDs to RPC URLs:
+Provide a mapping of chain IDs to full RPC URLs from your provider:
 
 ```ts {2-9}
 const rhinestone = new RhinestoneSDK({
@@ -52,9 +29,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
 })
 ```
 
-</Tab>
-</Tabs>
-
 <Note>
-  Need support for a different RPC provider? [Open an issue](https://github.com/rhinestonewtf/sdk/issues) and we'll take a look.
+  The SDK does not construct provider-specific URLs from an API key. Include the
+  API key in each URL when your provider requires one.
 </Note>

--- a/smart-wallet/smart-sessions/multi-session-signature.mdx
+++ b/smart-wallet/smart-sessions/multi-session-signature.mdx
@@ -25,10 +25,9 @@ First, define your sessions for different chains. Each session can have differen
 
 ```ts
 import { baseSepolia, optimismSepolia } from 'viem/chains'
-import { toSession } from '@rhinestone/sdk/smart-sessions'
 
-const sessions = [
-  toSession({
+const sessions = await Promise.all([
+  rhinestone.createSession({
     chain: baseSepolia,
     owners: {
       type: 'ecdsa',
@@ -36,21 +35,21 @@ const sessions = [
     },
     // Add specific policies and permissions as needed
   }),
-  toSession({
+  rhinestone.createSession({
     chain: baseSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccountB],
     },
   }),
-  toSession({
+  rhinestone.createSession({
     chain: optimismSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccountB],
     },
   }),
-]
+])
 ```
 
 </Step>
@@ -119,7 +118,6 @@ Here's a complete working example that demonstrates the full multi-chain session
 
 ```ts
 import { RhinestoneSDK } from '@rhinestone/sdk'
-import { toSession } from '@rhinestone/sdk/smart-sessions'
 import { zeroAddress } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { baseSepolia, optimismSepolia } from 'viem/chains'
@@ -138,22 +136,22 @@ const rhinestoneAccount = await rhinestone.createAccount({
 })
 
 // Define the sessions, one per chain
-const sessions = [
-  toSession({
+const sessions = await Promise.all([
+  rhinestone.createSession({
     chain: baseSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccount],
     },
   }),
-  toSession({
+  rhinestone.createSession({
     chain: optimismSepolia,
     owners: {
       type: 'ecdsa',
       accounts: [sessionOwnerAccount],
     },
   }),
-]
+])
 
 // Get the session details and sign once
 const sessionDetails =

--- a/smart-wallet/smart-sessions/overview.mdx
+++ b/smart-wallet/smart-sessions/overview.mdx
@@ -104,12 +104,10 @@ const transaction = await rhinestoneAccount.prepareTransaction({
 
 ### Creating Sessions
 
-To create a session, use `toSession`:
+To create a session, use `RhinestoneSDK.createSession`:
 
 ```ts
-import { toSession } from '@rhinestone/sdk/smart-sessions'
-
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -121,7 +119,7 @@ const session = toSession({
 You can also limit the session to specific allowed permissions:
 
 ```ts {7-13}
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -140,7 +138,7 @@ const session = toSession({
 Finally, you can constrain function parameters. The SDK derives the selector and parameter offsets from the ABI, so you reference parameters by name:
 
 ```ts {11-20}
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -169,8 +167,11 @@ const session = toSession({
 
 Use `crossChainPermits` to scope which routes, tokens, amounts, and recipients it may bridge:
 
-```ts {7-12}
-const session = toSession({
+```ts {10-15}
+const usdcOnBase = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const usdcOnArbitrum = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -178,8 +179,8 @@ const session = toSession({
   },
   crossChainPermits: [
     {
-      from: [{ chain: base, token: 'USDC' }],
-      to: [{ chain: arbitrum, token: 'USDC' }],
+      from: [{ chain: base, token: usdcOnBase }],
+      to: [{ chain: arbitrum, token: usdcOnArbitrum }],
     },
   ],
 })

--- a/smart-wallet/smart-sessions/policies/call.mdx
+++ b/smart-wallet/smart-sessions/policies/call.mdx
@@ -24,7 +24,7 @@ To restrict an ERC20 transfer to a single recipient:
 ```ts {15-17}
 const receiver = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -53,7 +53,7 @@ Reference parameters by name — the SDK looks them up in the ABI. Only static t
 Cap the total accumulated value of a param across all session uses with `usageLimit`. Useful for capping cumulative spend across calls.
 
 ```ts {13-19}
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -86,7 +86,7 @@ This caps each transfer at 10 USDC and the total across the session lifetime at 
 To cap the ETH value sent on a single call, use `valueLimitPerUse` at the function level:
 
 ```ts {13}
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',

--- a/smart-wallet/smart-sessions/policies/cross-chain.mdx
+++ b/smart-wallet/smart-sessions/policies/cross-chain.mdx
@@ -11,8 +11,11 @@ You set them at the session level via `crossChainPermits`, not per function. Eac
 
 Restrict a session to only bridge USDC from Base to Arbitrum:
 
-```ts {7-12}
-const session = toSession({
+```ts {10-15}
+const usdcOnBase = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const usdcOnArbitrum = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -20,14 +23,14 @@ const session = toSession({
   },
   crossChainPermits: [
     {
-      from: [{ chain: base, token: 'USDC' }],
-      to: [{ chain: arbitrum, token: 'USDC' }],
+      from: [{ chain: base, token: usdcOnBase }],
+      to: [{ chain: arbitrum, token: usdcOnArbitrum }],
     },
   ],
 })
 ```
 
-A token can be a symbol (resolved to the per-chain address) or an explicit address. Pass a single leg or an array, and omit a side entirely to leave it unrestricted — the settlement-layer allowlist, deadlines, and recipient rules still apply.
+Pass each token's address on its corresponding chain. Pass a single leg or an array, and omit a side entirely to leave it unrestricted — the settlement-layer allowlist, deadlines, and recipient rules still apply.
 
 | Field | Description |
 | --- | --- |
@@ -38,8 +41,11 @@ A token can be a symbol (resolved to the per-chain address) or an explicit addre
 
 Tighten a permit with optional bounds:
 
-```ts {8-14}
-const session = toSession({
+```ts {11-17}
+const usdcOnBase = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const usdcOnArbitrum = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -47,8 +53,8 @@ const session = toSession({
   },
   crossChainPermits: [
     {
-      from: [{ chain: base, token: 'USDC', maxAmount: parseUnits('100', 6) }],
-      to: [{ chain: arbitrum, token: 'USDC' }],
+      from: [{ chain: base, token: usdcOnBase, maxAmount: parseUnits('100', 6) }],
+      to: [{ chain: arbitrum, token: usdcOnArbitrum }],
       validAfter: new Date('2026-01-01'),
       validUntil: new Date('2027-01-01'),
       fillDeadline: [{ chain: arbitrum, max: new Date('2027-01-01') }],
@@ -65,8 +71,11 @@ const session = toSession({
 
 By default a cross-chain permit enforces **bridge-to-self** on-chain: the destination recipient must be the smart account itself. This stops a leaked session key from routing funds to an attacker-controlled address. Opt out explicitly only when you need to bridge to a different recipient:
 
-```ts {10-11}
-const session = toSession({
+```ts {13-14}
+const usdcOnBase = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const usdcOnArbitrum = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -74,8 +83,8 @@ const session = toSession({
   },
   crossChainPermits: [
     {
-      from: [{ chain: base, token: 'USDC' }],
-      to: [{ chain: arbitrum, token: 'USDC', recipient: payoutAddress }],
+      from: [{ chain: base, token: usdcOnBase }],
+      to: [{ chain: arbitrum, token: usdcOnArbitrum, recipient: payoutAddress }],
       allowRecipientNotAccount: true,
     },
   ],
@@ -86,8 +95,11 @@ const session = toSession({
 
 A permit allows any supported settlement layer by default. Pass `settlementLayers` to narrow it to a subset:
 
-```ts {11}
-const session = toSession({
+```ts {14}
+const usdcOnBase = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const usdcOnArbitrum = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',
@@ -95,8 +107,8 @@ const session = toSession({
   },
   crossChainPermits: [
     {
-      from: [{ chain: base, token: 'USDC' }],
-      to: [{ chain: arbitrum, token: 'USDC' }],
+      from: [{ chain: base, token: usdcOnBase }],
+      to: [{ chain: arbitrum, token: usdcOnArbitrum }],
       settlementLayers: ['ECO'],
     },
   ],

--- a/smart-wallet/smart-sessions/policies/spending-limit.mdx
+++ b/smart-wallet/smart-sessions/policies/spending-limit.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Spending limit"
 You can limit the amount of ERC20 tokens transferable through a session function. Attach the policy at the function level — it caps the cumulative amount across all uses of that function.
 
 ```ts {13-16}
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',

--- a/smart-wallet/smart-sessions/policies/sudo.mdx
+++ b/smart-wallet/smart-sessions/policies/sudo.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Sudo"
 Sudo allows any transaction to pass. It's the default — a session with no `permissions` accepts everything.
 
 ```ts
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',

--- a/smart-wallet/smart-sessions/policies/timeframe.mdx
+++ b/smart-wallet/smart-sessions/policies/timeframe.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Timeframe"
 Restrict when a session function can be called. Attach the policy at the function level.
 
 ```ts {13-14}
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',

--- a/smart-wallet/smart-sessions/policies/usage-limit.mdx
+++ b/smart-wallet/smart-sessions/policies/usage-limit.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Usage limit"
 Limit how many times a session function can be called.
 
 ```ts {13}
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',

--- a/smart-wallet/tutorials/session-keys.mdx
+++ b/smart-wallet/tutorials/session-keys.mdx
@@ -76,13 +76,12 @@ const sessionOwnerAccount = privateKeyToAccount(sessionPrivateKey)
 Specify what the session key is allowed to do. Here we restrict it to USDC transfers only, with a 100 USDC spending limit:
 
 ```ts
-import { toSession } from '@rhinestone/sdk/smart-sessions'
 import { erc20Abi, parseUnits } from 'viem'
 import { base } from 'viem/chains'
 
 const usdcAddress = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // USDC on Base
 
-const session = toSession({
+const session = await rhinestone.createSession({
   chain: base,
   owners: {
     type: 'ecdsa',


### PR DESCRIPTION
- Document the SDK runtime chain catalog breaking changes and offline session fallback.
- Update smart-session examples to use `RhinestoneSDK.createSession`, including address-only cross-chain permit inputs.
- Replace the removed Alchemy provider shortcut with custom RPC URL configuration.
- Validated with Mintlify broken-link checks and local page rendering.

Companion: [rhinestonewtf/sdk#672](https://github.com/rhinestonewtf/sdk/pull/672)