### PR TITLE
docs: drop experimental_ prefix from smart session API

### DIFF
--- a/deposits/api/account-registration.mdx
+++ b/deposits/api/account-registration.mdx
@@ -137,7 +137,7 @@ const config: RhinestoneAccountConfig = {
     type: "ecdsa",
     accounts: [userSigner],
   },
-  experimental_sessions: { enabled: true },
+  sessions: { enabled: true },
 };
 
 const account = await rhinestone.createAccount(config);
@@ -163,8 +163,8 @@ const sessions = sourceChains.map((chain) => ({
   chain,
 }));
 
-const sessionDetails = await account.experimental_getSessionDetails(sessions);
-const signature = await account.experimental_signEnableSession(sessionDetails);
+const sessionDetails = await account.getSessionDetails(sessions);
+const signature = await account.signEnableSession(sessionDetails);
 
 const enableSessionDetails = {
   hashesAndChainIds: sessionDetails.hashesAndChainIds,
@@ -231,9 +231,9 @@ const newSessions = [
   },
 ];
 const newSessionDetails =
-  await account.experimental_getSessionDetails(newSessions);
+  await account.getSessionDetails(newSessions);
 const newSignature =
-  await account.experimental_signEnableSession(newSessionDetails);
+  await account.signEnableSession(newSessionDetails);
 
 await fetch(`${DEPOSIT_SERVICE_URL}/account/${address}/session`, {
   method: "POST",

--- a/docs.json
+++ b/docs.json
@@ -199,10 +199,10 @@
                 "pages": [
                   "sdk-reference/rhinestone-sdk/rhinestone-sdk",
                   "sdk-reference/rhinestone-sdk/create-account",
-                  "sdk-reference/rhinestone-sdk/create-session",
                   "sdk-reference/rhinestone-sdk/get-intent-status",
                   "sdk-reference/rhinestone-sdk/split-intents",
-                  "sdk-reference/rhinestone-sdk/get-app-fee-balances"
+                  "sdk-reference/rhinestone-sdk/get-app-fee-balances",
+                  "sdk-reference/rhinestone-sdk/create-session"
                 ]
               },
               {
@@ -265,9 +265,9 @@
                   {
                     "group": "Smart sessions",
                     "pages": [
-                      "sdk-reference/account/smart-sessions/experimental-get-session-details",
-                      "sdk-reference/account/smart-sessions/experimental-is-session-enabled",
-                      "sdk-reference/account/smart-sessions/experimental-sign-enable-session"
+                      "sdk-reference/account/smart-sessions/get-session-details",
+                      "sdk-reference/account/smart-sessions/is-session-enabled",
+                      "sdk-reference/account/smart-sessions/sign-enable-session"
                     ]
                   }
                 ]
@@ -316,10 +316,10 @@
                   {
                     "group": "Smart sessions",
                     "pages": [
-                      "sdk-reference/actions/smart-sessions/experimental-enable",
-                      "sdk-reference/actions/smart-sessions/experimental-disable",
-                      "sdk-reference/actions/smart-sessions/experimental-enable-session",
-                      "sdk-reference/actions/smart-sessions/experimental-disable-session"
+                      "sdk-reference/actions/smart-sessions/enable",
+                      "sdk-reference/actions/smart-sessions/disable",
+                      "sdk-reference/actions/smart-sessions/enable-session",
+                      "sdk-reference/actions/smart-sessions/disable-session"
                     ]
                   }
                 ]

--- a/intents/use-cases/automated-zaps.mdx
+++ b/intents/use-cases/automated-zaps.mdx
@@ -32,7 +32,7 @@ const companionAccount = await rhinestone.createAccount({
     type: "ecdsa",
     accounts: [ownerAccount],
   },
-  experimental_sessions: {
+  sessions: {
     enabled: true,
   },
 });
@@ -110,10 +110,10 @@ The user signs once to authorize all sessions across all chains:
 
 ```ts
 const sessionDetails =
-  await companionAccount.experimental_getSessionDetails(sessions);
+  await companionAccount.getSessionDetails(sessions);
 
 const enableSignature =
-  await companionAccount.experimental_signEnableSession(sessionDetails);
+  await companionAccount.signEnableSession(sessionDetails);
 ```
 
 Persist the session credentials for your service to use later:
@@ -194,7 +194,7 @@ const prepared = await companionAccount.prepareTransaction({
     },
   ],
   signers: {
-    type: "experimental_session",
+    type: "session",
     session: sessions[0],
     enableData: {
       userSignature: enableSignature,
@@ -248,7 +248,7 @@ const preparedPull = await companionAccount.prepareTransaction({
     },
   ],
   signers: {
-    type: "experimental_session",
+    type: "session",
     session: vaultSession,
     enableData: sessionEnableData,
   },
@@ -291,7 +291,7 @@ const preparedExecute = await companionAccount.prepareTransaction({
     },
   ],
   signers: {
-    type: "experimental_session",
+    type: "session",
     session: vaultSession,
     enableData: sessionEnableData,
   },

--- a/sdk-reference/account/smart-sessions/get-session-details.mdx
+++ b/sdk-reference/account/smart-sessions/get-session-details.mdx
@@ -1,16 +1,14 @@
 ---
-title: "experimental_getSessionDetails"
+title: "getSessionDetails"
 description: "Resolve the smart-session details for a set of sessions."
 ---
-
-<Warning>This API is experimental and may change in a future release.</Warning>
 
 Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
 
 ## Usage
 
 ```ts
-const sessionDetails = await account.experimental_getSessionDetails(sessions)
+const sessionDetails = await account.getSessionDetails(sessions)
 ```
 
 ## Parameters

--- a/sdk-reference/account/smart-sessions/is-session-enabled.mdx
+++ b/sdk-reference/account/smart-sessions/is-session-enabled.mdx
@@ -1,16 +1,14 @@
 ---
-title: "experimental_isSessionEnabled"
+title: "isSessionEnabled"
 description: "Check whether a smart session is enabled on the account."
 ---
-
-<Warning>This API is experimental and may change in a future release.</Warning>
 
 Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
 
 ## Usage
 
 ```ts
-const sessionEnabled = await account.experimental_isSessionEnabled(session)
+const sessionEnabled = await account.isSessionEnabled(session)
 ```
 
 ## Parameters

--- a/sdk-reference/account/smart-sessions/sign-enable-session.mdx
+++ b/sdk-reference/account/smart-sessions/sign-enable-session.mdx
@@ -8,7 +8,7 @@ Method on an account instance returned by [`createAccount`](/sdk-reference/rhine
 ## Usage
 
 ```ts
-const enableSession = await account.signEnableSession(details)
+const signature = await account.signEnableSession(details)
 ```
 
 ## Parameters
@@ -19,6 +19,6 @@ const enableSession = await account.signEnableSession(details)
 
 ## Returns
 
-<ResponseField name="enableSession" type="`0x${string}`">
+<ResponseField name="signature" type="`0x${string}`">
   The enable-session signature
 </ResponseField>

--- a/sdk-reference/account/smart-sessions/sign-enable-session.mdx
+++ b/sdk-reference/account/smart-sessions/sign-enable-session.mdx
@@ -1,16 +1,14 @@
 ---
-title: "experimental_signEnableSession"
+title: "signEnableSession"
 description: "Sign the data required to enable a smart session."
 ---
-
-<Warning>This API is experimental and may change in a future release.</Warning>
 
 Method on an account instance returned by [`createAccount`](/sdk-reference/rhinestone-sdk/create-account).
 
 ## Usage
 
 ```ts
-const signature = await account.experimental_signEnableSession(details)
+const enableSession = await account.signEnableSession(details)
 ```
 
 ## Parameters
@@ -21,6 +19,6 @@ const signature = await account.experimental_signEnableSession(details)
 
 ## Returns
 
-<ResponseField name="signature" type="`0x${string}`">
+<ResponseField name="enableSession" type="`0x${string}`">
   The enable-session signature
 </ResponseField>

--- a/sdk-reference/actions/modules/install-module.mdx
+++ b/sdk-reference/actions/modules/install-module.mdx
@@ -1,6 +1,5 @@
 ---
 title: "installModule"
-description: "Install a custom module"
 ---
 
 ## Import
@@ -21,11 +20,9 @@ const transaction = await account.prepareTransaction({
 ## Parameters
 
 <ParamField path="module" type="ModuleInput" required>
-  Module to install
 </ParamField>
 
 ## Returns
 
 <ResponseField name="call" type="LazyCallInput">
-  Calls to install the module
 </ResponseField>

--- a/sdk-reference/actions/modules/uninstall-module.mdx
+++ b/sdk-reference/actions/modules/uninstall-module.mdx
@@ -1,6 +1,5 @@
 ---
 title: "uninstallModule"
-description: "Uninstall a custom module"
 ---
 
 ## Import
@@ -21,11 +20,9 @@ const transaction = await account.prepareTransaction({
 ## Parameters
 
 <ParamField path="module" type="ModuleInput" required>
-  Module to uninstall
 </ParamField>
 
 ## Returns
 
 <ResponseField name="call" type="LazyCallInput">
-  Calls to uninstall the module
 </ResponseField>

--- a/sdk-reference/actions/smart-sessions/disable-session.mdx
+++ b/sdk-reference/actions/smart-sessions/disable-session.mdx
@@ -1,9 +1,7 @@
 ---
-title: "experimental_disableSession"
+title: "disableSession"
 description: "Disable a smart session"
 ---
-
-<Warning>This API is experimental and may change in a future release.</Warning>
 
 Removes a single session from the smart-session emissary via `removeConfig`.
 The account executes the call itself, so the emissary skips the disable
@@ -15,7 +13,7 @@ the session is being disabled.
 ## Import
 
 ```ts
-import { experimental_disableSession } from '@rhinestone/sdk/actions/smart-sessions'
+import { disableSession } from '@rhinestone/sdk/actions/smart-sessions'
 ```
 
 ## Usage
@@ -23,7 +21,7 @@ import { experimental_disableSession } from '@rhinestone/sdk/actions/smart-sessi
 ```ts
 const transaction = await account.prepareTransaction({
   chain,
-  calls: [experimental_disableSession(session)],
+  calls: [disableSession(session)],
 })
 ```
 

--- a/sdk-reference/actions/smart-sessions/disable.mdx
+++ b/sdk-reference/actions/smart-sessions/disable.mdx
@@ -1,14 +1,12 @@
 ---
-title: "experimental_disable"
+title: "disable"
 description: "Disable smart sessions"
 ---
-
-<Warning>This API is experimental and may change in a future release.</Warning>
 
 ## Import
 
 ```ts
-import { experimental_disable } from '@rhinestone/sdk/actions/smart-sessions'
+import { disable } from '@rhinestone/sdk/actions/smart-sessions'
 ```
 
 ## Usage
@@ -16,7 +14,7 @@ import { experimental_disable } from '@rhinestone/sdk/actions/smart-sessions'
 ```ts
 const transaction = await account.prepareTransaction({
   chain,
-  calls: [experimental_disable()],
+  calls: [disable()],
 })
 ```
 

--- a/sdk-reference/actions/smart-sessions/enable-session.mdx
+++ b/sdk-reference/actions/smart-sessions/enable-session.mdx
@@ -1,9 +1,7 @@
 ---
-title: "experimental_enableSession"
+title: "enableSession"
 description: "Enable a smart session"
 ---
-
-<Warning>This API is experimental and may change in a future release.</Warning>
 
 The `session` must be a resolved `Session` (the return value of
 `toSession(...)`). Re-resolving it here would drop the explicit
@@ -15,7 +13,7 @@ signed in `getSessionDetails`, causing the emissary to reject the enable.
 ## Import
 
 ```ts
-import { experimental_enableSession } from '@rhinestone/sdk/actions/smart-sessions'
+import { enableSession } from '@rhinestone/sdk/actions/smart-sessions'
 ```
 
 ## Usage
@@ -23,7 +21,7 @@ import { experimental_enableSession } from '@rhinestone/sdk/actions/smart-sessio
 ```ts
 const transaction = await account.prepareTransaction({
   chain,
-  calls: [experimental_enableSession(session, enableSessionSignature, hashesAndChainIds, sessionToEnableIndex)],
+  calls: [enableSession(session, enableSessionSignature, hashesAndChainIds, sessionToEnableIndex)],
 })
 ```
 

--- a/sdk-reference/actions/smart-sessions/enable.mdx
+++ b/sdk-reference/actions/smart-sessions/enable.mdx
@@ -1,14 +1,12 @@
 ---
-title: "experimental_enable"
+title: "enable"
 description: "Enable smart sessions"
 ---
-
-<Warning>This API is experimental and may change in a future release.</Warning>
 
 ## Import
 
 ```ts
-import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
+import { enable } from '@rhinestone/sdk/actions/smart-sessions'
 ```
 
 ## Usage
@@ -16,7 +14,7 @@ import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
 ```ts
 const transaction = await account.prepareTransaction({
   chain,
-  calls: [experimental_enable()],
+  calls: [enable()],
 })
 ```
 

--- a/sdk-reference/rhinestone-sdk/create-session.mdx
+++ b/sdk-reference/rhinestone-sdk/create-session.mdx
@@ -13,7 +13,7 @@ const session = await sdk.createSession(definition)
 
 ## Parameters
 
-<ParamField path="definition" type="SessionDefinition<TAbis>" required>
+<ParamField path="definition" type="SessionDefinition" required>
   The session definition
 </ParamField>
 

--- a/sdk-reference/rhinestone-sdk/rhinestone-sdk.mdx
+++ b/sdk-reference/rhinestone-sdk/rhinestone-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "RhinestoneSDK"
-description: "Stateful entry point that holds shared configuration (auth, provider, bundler, paymaster) and creates accounts from it."
+description: "Stateful entry point that holds shared configuration (auth, provider, bundler, paymaster) and creates accounts from it, delegating all work to the SDK-core composition."
 ---
 
 ## Import

--- a/smart-wallet/advanced/migration-guide.mdx
+++ b/smart-wallet/advanced/migration-guide.mdx
@@ -247,6 +247,17 @@ await rhinestoneAccount.waitForExecution(result, false)
 await rhinestoneAccount.waitForExecution(result)
 ```
 
+### `experimental_` prefix dropped from the smart session API
+
+The smart session API is now stable, so the `experimental_` prefix is gone. Drop it across your integration:
+
+| Area | Before | After |
+| --- | --- | --- |
+| Account config | `experimental_sessions` | `sessions` |
+| Signer set | `type: 'experimental_session'` | `type: 'session'` |
+| Account methods | `experimental_getSessionDetails`, `experimental_isSessionEnabled`, `experimental_signEnableSession` | `getSessionDetails`, `isSessionEnabled`, `signEnableSession` |
+| `@rhinestone/sdk/actions/smart-sessions` | `experimental_enable`, `experimental_disable`, `experimental_enableSession`, `experimental_disableSession` | `enable`, `disable`, `enableSession`, `disableSession` |
+
 ### `verifyExecutions` removed from session signers
 
 `SingleSessionSignerSet`, `PerChainSessionSignerSet`, and `ChainSessionConfig` no longer accept `verifyExecutions`. The SDK now derives it from the session shape — sessions with `permissions` use emissary execution validation, claim-only sessions use the EIP-1271 path — so the flag is redundant. Drop it from your signer set:
@@ -262,7 +273,7 @@ const signers = {
 
 // After
 const signers = {
-  type: 'experimental_session',
+  type: 'session',
   session,
   enableData,
 }

--- a/smart-wallet/smart-sessions/multi-session-signature.mdx
+++ b/smart-wallet/smart-sessions/multi-session-signature.mdx
@@ -59,9 +59,9 @@ To enable a session, you need to get the session details and enable data. This s
 
 ```ts
 const sessionDetails =
-  await rhinestoneAccount.experimental_getSessionDetails(sessions)
+  await rhinestoneAccount.getSessionDetails(sessions)
 const enableSignature =
-  await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
+  await rhinestoneAccount.signEnableSession(sessionDetails)
 const sessionIndex = 0 // Which session to enable
 ```
 
@@ -93,7 +93,7 @@ const data = await rhinestoneAccount.prepareTransaction({
     },
   ],
   signers: {
-    type: 'experimental_session',
+    type: 'session',
     session: sessions[sessionIndex],
     enableData: {
       userSignature: enableSignature,
@@ -155,14 +155,14 @@ const sessions = await Promise.all([
 
 // Get the session details and sign once
 const sessionDetails =
-  await rhinestoneAccount.experimental_getSessionDetails(sessions)
+  await rhinestoneAccount.getSessionDetails(sessions)
 const enableSignature =
-  await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
+  await rhinestoneAccount.signEnableSession(sessionDetails)
 
 // Build the per-chain sessions map with enable data
 // The SDK resolves the right session and enable data automatically per chain
 const signers = {
-  type: 'experimental_session' as const,
+  type: 'session' as const,
   sessions: {
     [baseSepolia.id]: {
       session: sessions[0],

--- a/smart-wallet/smart-sessions/overview.mdx
+++ b/smart-wallet/smart-sessions/overview.mdx
@@ -62,8 +62,6 @@ When defining multiple policies within a function, a transaction that passes **e
 
 ## Usage
 
-<Warning>Smart session support is **experimental**. Expect breaking changes.</Warning>
-
 ### Installing the validation
 
 You can install the validator during account deployment:
@@ -74,7 +72,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
     type: 'ecdsa',
     accounts: [ownerAccount],
   },
-  experimental_sessions: {
+  sessions: {
     enabled: true,
   },
 })
@@ -83,22 +81,22 @@ const rhinestoneAccount = await rhinestone.createAccount({
 You can also install it when the account is already deployed:
 
 ```ts
-import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
+import { enable } from '@rhinestone/sdk/actions/smart-sessions'
 
 const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
-  calls: [experimental_enable()],
+  calls: [enable()],
 })
 ```
 
 To uninstall the validator:
 
 ```ts
-import { experimental_disable } from '@rhinestone/sdk/actions/smart-sessions'
+import { disable } from '@rhinestone/sdk/actions/smart-sessions'
 
 const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
-  calls: [experimental_disable()],
+  calls: [disable()],
 })
 ```
 
@@ -193,19 +191,19 @@ See [Cross-chain permits](./policies/cross-chain) for guardrails, recipient safe
 To enable a session:
 
 ```ts
-import { experimental_enableSession } from '@rhinestone/sdk/actions/smart-sessions'
+import { enableSession } from '@rhinestone/sdk/actions/smart-sessions'
 
 const sessions = [session]
 const sessionDetails =
-  await rhinestoneAccount.experimental_getSessionDetails(sessions)
+  await rhinestoneAccount.getSessionDetails(sessions)
 const enableSignature =
-  await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
+  await rhinestoneAccount.signEnableSession(sessionDetails)
 const sessionIndex = 0
 
 const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
   calls: [
-    experimental_enableSession(
+    enableSession(
       session,
       enableSignature,
       sessionDetails.hashesAndChainIds,
@@ -222,7 +220,7 @@ You can also enable session with a signature. See [Multi-Session Signature](./mu
 To check if a session is enabled:
 
 ```ts
-const isEnabled = await rhinestoneAccount.experimental_isSessionEnabled(session)
+const isEnabled = await rhinestoneAccount.isSessionEnabled(session)
 ```
 
 ### Using sessions
@@ -243,7 +241,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
     },
   ],
   signers: {
-    type: 'experimental_session',
+    type: 'session',
     session,
   },
 })
@@ -257,14 +255,14 @@ This will prompt the signature request from the session owner(s) and submit the 
 
 ### Disabling a session
 
-To disable a single enabled session, use `experimental_disableSession`. This only removes a single session: to uninstall the validator entirely (and every session with it), use [`experimental_disable`](#installing-the-validation) instead.
+To disable a single enabled session, use `disableSession`. This only removes a single session: to uninstall the validator entirely (and every session with it), use [`disable`](#installing-the-validation) instead.
 
 ```ts
-import { experimental_disableSession } from '@rhinestone/sdk/actions/smart-sessions'
+import { disableSession } from '@rhinestone/sdk/actions/smart-sessions'
 
 const transaction = await rhinestoneAccount.prepareTransaction({
   chain,
-  calls: [experimental_disableSession(session)],
+  calls: [disableSession(session)],
 })
 ```
 

--- a/smart-wallet/tutorials/session-keys.mdx
+++ b/smart-wallet/tutorials/session-keys.mdx
@@ -9,8 +9,6 @@ This tutorial walks through a one-click trading scenario: the user grants your a
 
 This tutorial builds on the [Quickstart](../quickstart). You'll need a working smart account before continuing.
 
-<Warning>Smart Sessions are **experimental**. Expect breaking changes.</Warning>
-
 ## Prerequisites
 
 - Completed the [Quickstart](../quickstart)
@@ -36,7 +34,7 @@ const rhinestoneAccount = await rhinestone.createAccount({
     type: 'ecdsa',
     accounts: [ownerAccount],
   },
-  experimental_sessions: {
+  sessions: {
     enabled: true,
   },
 })
@@ -45,11 +43,11 @@ const rhinestoneAccount = await rhinestone.createAccount({
 If the account is already deployed, you can install the module in a separate transaction:
 
 ```ts
-import { experimental_enable } from '@rhinestone/sdk/actions/smart-sessions'
+import { enable } from '@rhinestone/sdk/actions/smart-sessions'
 
 const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
-  calls: [experimental_enable()],
+  calls: [enable()],
 })
 const signed = await rhinestoneAccount.signTransaction(transaction)
 const result = await rhinestoneAccount.submitTransaction(signed)
@@ -115,17 +113,17 @@ const session = await rhinestone.createSession({
 The account owner signs to approve the session. This is the one-time approval the user sees:
 
 ```ts
-import { experimental_enableSession } from '@rhinestone/sdk/actions/smart-sessions'
+import { enableSession } from '@rhinestone/sdk/actions/smart-sessions'
 
 const sessions = [session]
-const sessionDetails = await rhinestoneAccount.experimental_getSessionDetails(sessions)
-const enableSignature = await rhinestoneAccount.experimental_signEnableSession(sessionDetails)
+const sessionDetails = await rhinestoneAccount.getSessionDetails(sessions)
+const enableSignature = await rhinestoneAccount.signEnableSession(sessionDetails)
 const sessionIndex = 0
 
 const transaction = await rhinestoneAccount.prepareTransaction({
   chain: base,
   calls: [
-    experimental_enableSession(
+    enableSession(
       session,
       enableSignature,
       sessionDetails.hashesAndChainIds,
@@ -163,7 +161,7 @@ const prepared = await rhinestoneAccount.prepareTransaction({
     },
   ],
   signers: {
-    type: 'experimental_session',
+    type: 'session',
     session,
   },
 })


### PR DESCRIPTION
Companion docs update for the smart-session API rename.

- Regenerated the SDK Reference for the renamed surface (config `sessions`, signer `type: 'session'`, unprefixed account methods and `/actions/smart-sessions` actions) + nav patch
- Swept guides, tutorials, and use cases to the finalized names
- Added a migration-guide section documenting the prefix drop
- Removed the "experimental / expect breaking changes" warnings now that the API is stable

`mintlify broken-links` passes.

SDK PR: rhinestonewtf/sdk#680

Closes [RHI-4965](https://linear.app/rhinestone/issue/RHI-4965)
Relates to [RHI-4960](https://linear.app/rhinestone/issue/RHI-4960)