### PR TITLE
docs: drop @beta from SDK install instructions

### DIFF
--- a/smart-wallet/quickstart.mdx
+++ b/smart-wallet/quickstart.mdx
@@ -16,15 +16,15 @@ Install the SDK:
 <CodeGroup>
 
 ```bash npm
-npm install viem @rhinestone/sdk@beta
+npm install viem @rhinestone/sdk
 ```
 
 ```bash pnpm
-pnpm add viem @rhinestone/sdk@beta
+pnpm add viem @rhinestone/sdk
 ```
 
 ```bash bun
-bun install viem @rhinestone/sdk@beta
+bun install viem @rhinestone/sdk
 ```
 
 </CodeGroup>


### PR DESCRIPTION
v2 (`2.0.0`) is now the npm `@latest` release, so the plain `@rhinestone/sdk` package installs the current SDK. The `@beta` tag now points at older prereleases (`2.0.0-beta.47`), so `@beta` in the quickstart would install a stale version.

Updates the three install snippets (`npm` / `pnpm` / `bun`) in the quickstart.

Relates to [RHI-4729](https://linear.app/rhinestone/issue/RHI-4729/release-v2)