### PR TITLE
docs: managed accounts for the deposit/withdraw modals

### DIFF
--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -101,12 +101,14 @@ The `allowedRoutes` prop accepts `{ sourceChains?: number[], sourceTokens?: stri
 
 ## Session configuration
 
-Sessions allow the widget to execute bridging on behalf of the user's smart account. These props control session behavior.
+From v0.9.0 the modal uses **service-managed accounts**: the deposit account is
+owned by Rhinestone and settles to your `recipient`, so there is no session key
+to configure and the user is never asked to sign during setup. The
+`signerAddress` and `sessionChainIds` props were removed in that release.
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `sessionChainIds` | `number[]` | All supported chains | Restrict which chains get session keys |
-| `forceRegister` | `boolean` | `false` | Force session re-creation even if the account is already registered |
+| `forceRegister` | `boolean` | `false` | Re-register even if the account already exists (bypasses the local cache; the call itself is idempotent) |
 
 ## Destination token routing
 
@@ -210,6 +212,43 @@ and proxies requests to the deposit processor. `backendUrl` defaults to the
 Rhinestone-hosted instance; point it at your own deployment to keep user traffic
 on your infrastructure.
 
+### Required routes
+
+Your proxy must forward every route the modal calls, attaching your
+`x-api-key` to the upstream request. Missing a route doesn't degrade the
+flow — the request 404s and that part of the modal stops working.
+
+| Method | Route | Used for |
+|---|---|---|
+| `POST` | `/register-managed` | Registering the deposit account. **Required from modal v0.9.0** |
+| `POST` | `/quotes/preview` | Indicative fee/time quote on the review screen |
+| `GET` | `/check/:address` | Registration + target lookup |
+| `GET` | `/portfolio/:address` | EVM balances |
+| `GET` | `/portfolio/solana/:address` | Solana balances |
+| `GET` | `/deposits` | Deposit status + history |
+| `GET` | `/liquidity` | Route liquidity check |
+| `GET` | `/prices` | USD pricing |
+| `GET` | `/setup` | Your client config (source-token allowlist, minimums) |
+| `GET` | `/tokens` | Static top-tokens list for the QR flow |
+| `POST` | `/safe/withdraw` | Withdraw modal |
+| `POST` | `/polymarket/withdraw` | Polymarket withdrawals |
+| `POST` | `/onramp/swapped/widget-url` | Fiat on-ramp |
+| `POST` | `/onramp/swapped/connect-url` | Exchange connect |
+| `GET` | `/onramp/swapped/connect-exchanges` | Exchange list |
+| `GET` | `/onramp/swapped/status/:smartAccount` | On-ramp order status |
+
+<Warning>
+**Upgrading to modal v0.9.0** — v0.9.0 moves to service-managed accounts and
+registers through `POST /register-managed` instead of `POST /setup-account` +
+`POST /register`. Deploy a proxy that forwards it **before** shipping the new
+modal, or registration 404s and deposits cannot start. Keep the old two routes
+while any earlier modal version is still in use.
+</Warning>
+
+Only `GET /setup` is proxied, never `POST /setup` — that is an admin write
+(it rotates the webhook secret and sponsorship config) and must not be
+reachable from a browser.
+
 ### Version header pass-through
 
 Every request the modal makes carries its own package version:
@@ -310,13 +349,11 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 | `dappImports` | `DappImportsConfig` | — | [Import balances](#import-from-other-apps) from third-party apps (e.g. `{ polymarket: true }`) |
 | `initialDappImport` | `keyof DappImportsConfig` | — | Open the modal pre-routed into a dapp import (e.g. `"polymarket"`), skipping the home screen. Must name an enabled `dappImports` key. |
 
-### Session
+### Account
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `sessionChainIds` | `number[]` | All supported | Chain IDs for session key creation |
-| `forceRegister` | `boolean` | `false` | Force session re-creation |
-| `signerAddress` | `Address` | Default signer | Session signer address |
+| `forceRegister` | `boolean` | `false` | Re-register even if the account already exists |
 | `rhinestoneApiKey` | `string` | — | API key for account setup |
 
 ### Backend

--- a/deposits/widget/withdraw-modal.mdx
+++ b/deposits/widget/withdraw-modal.mdx
@@ -97,13 +97,11 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 | `defaultAmount` | `string` | — | Pre-filled withdrawal amount |
 | `allowedRoutes` | `RouteConfig` | — | Restrict available routes |
 
-### Session
+### Account
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `sessionChainIds` | `number[]` | All supported | Chain IDs for session key creation |
-| `forceRegister` | `boolean` | `false` | Force session re-creation |
-| `signerAddress` | `Address` | Default signer | Session signer address |
+| `forceRegister` | `boolean` | `false` | Re-register even if the account already exists |
 | `rhinestoneApiKey` | `string` | — | API key for account setup |
 
 ### Backend


### PR DESCRIPTION
[skip-linear]

Docs for `@rhinestone/deposit-modal` v0.9.0 ([deposit-modal#89](https://github.com/rhinestonewtf/deposit-modal/pull/89)), which moves to service-managed accounts.

## Required routes for a self-hosted proxy — new

There was **no route list in these docs before**, so anyone writing a custom proxy had to read `deposit-widget-proxy`'s source to work out what to forward. Added the full table, with `POST /register-managed` called out as required from v0.9.0 and a warning about deploy ordering: a missing route **404s rather than degrading**, so a proxy that lags the modal release breaks registration outright.

Also documented that only `GET /setup` is proxied and never the `POST` — it's an admin write that rotates the webhook secret and sponsorship config, so it must not be browser-reachable.

## Removed props

`signerAddress` and `sessionChainIds` are gone in v0.9.0 and are dropped from both modals' prop tables. There are no session keys any more — the account is owned by the service and settles to `recipient`, so setup never asks the user to sign. The "Session" sections are now "Account".

Companion PRs: [deposit-widget-proxy#7](https://github.com/rhinestonewtf/deposit-widget-proxy/pull/7) (adds the route), [deposit-modal#89](https://github.com/rhinestonewtf/deposit-modal/pull/89) (the modal change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)