### PR TITLE
docs: withdraw modal executes through a host-app callback

### DIFF
--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -230,7 +230,7 @@ flow — the request 404s and that part of the modal stops working.
 | `GET` | `/prices` | USD pricing |
 | `GET` | `/setup` | Your client config (source-token allowlist, minimums) |
 | `GET` | `/tokens` | Static top-tokens list for the QR flow |
-| `POST` | `/safe/withdraw` | Withdraw modal |
+| `POST` | `/safe/withdraw` | Relaying a signed Safe transfer with sponsored gas. **Not used by the modal from v0.9.0** — proxy it only if your own [`onSendTransaction`](/deposits/widget/withdraw-modal#executing-the-transfer) relays through it |
 | `POST` | `/polymarket/withdraw` | Polymarket withdrawals |
 | `POST` | `/onramp/swapped/widget-url` | Fiat on-ramp |
 | `POST` | `/onramp/swapped/connect-url` | Exchange connect |

--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -1,7 +1,57 @@
 ---
 title: "Migration guide"
-description: "Upgrade @rhinestone/deposit-modal from v0.1.x / v0.2.x to v0.3.0."
+description: "Upgrade @rhinestone/deposit-modal to v0.9.0, and from v0.1.x / v0.2.x to v0.3.0."
 ---
+
+## v0.8.x → v0.9.0
+
+v0.9.0 moves both modals onto service-managed accounts and hands the withdrawal
+transfer to your app.
+
+**Both modals** — the `signerAddress` and `sessionChainIds` props are gone,
+along with the `DEFAULT_SIGNER_ADDRESS`, `EnableSessionDetails`, and
+`AccountInitData` exports. Registration now goes through
+`POST /register-managed`, which a self-hosted proxy **must** forward before you
+ship — see [required routes](/deposits/widget/deposit-modal#required-routes).
+There is no session key and no signature prompt during setup.
+
+**`<WithdrawModal>`** no longer moves funds. It previously built and submitted a
+Safe `execTransaction`, which only worked for apps whose funds sat in a Safe. It
+now asks your app to perform one transfer:
+
+```diff
+  <WithdrawModal
+-   safeAddress={userSafe}
++   accountAddress={userAccount}
+-   dappWalletClient={walletClient}
+-   dappPublicClient={publicClient}
+-   dappAddress={ownerEoa}
+-   reownAppId={projectId}
+-   onSignTransaction={async (request) => ({
+-     signature: await signer.signTypedData(request.typedData),
+-   })}
++   onSendTransaction={async ({ chainId, token, amount, to }) => ({
++     txHash: await myWallet.sendTransfer({ chainId, token, amount, to }),
++   })}
+  />
+```
+
+Send to `to` exactly, and return the **on-chain transaction hash** — not a
+userOp hash. See [executing the
+transfer](/deposits/widget/withdraw-modal#executing-the-transfer) for both rules
+and a Safe-backed example, including how to keep gas sponsored.
+
+Also on `<WithdrawModal>`: `onRequestConnect` is removed (the modal needs no
+wallet, so there is no connect step — it opens on the withdraw form), the
+`SafeTransactionRequest` export is replaced by `WithdrawTransferRequest`, and
+the `"submitted"` lifecycle event renames `safeAddress` to `accountAddress`.
+`<DepositModal>` keeps all of its wallet props.
+
+`POST /safe/withdraw` still exists — the modal simply stopped calling it.
+
+---
+
+## v0.1.x / v0.2.x → v0.3.0
 
 v0.3.0 collapses each modal's per-event callbacks into a single `onLifecycle`
 callback, renames the analytics event types, removes the `/reown` and `/safe`
@@ -75,7 +125,7 @@ the same names as before.
 +        trackConnected(event.address, event.smartAccount);
 +        break;
 +      case "submitted":
-+        trackSubmitted(event.txHash, event.sourceChain, event.amount, event.safeAddress);
++        trackSubmitted(event.txHash, event.sourceChain, event.amount, event.accountAddress);
 +        break;
 +      case "complete":
 +        trackComplete(event.txHash, event.destinationTxHash);
@@ -105,7 +155,7 @@ against both.
 | `sourceToken` on complete         | `string`, optional       | `Address`, required      |
 | `targetChain` on complete         | `number \| "solana"`     | `number`                 |
 | `targetToken` on complete         | `string`                 | `Address`                |
-| `safeAddress` on submit           | not present              | `Address`                |
+| `accountAddress` on submit        | not present              | `Address`                |
 | `"balance-changed"` variant       | yes                      | no                       |
 | `"smart-account-changed"` variant | yes                      | no                       |
 
@@ -143,8 +193,8 @@ renamed. The payload shape is unchanged.
   - import { DepositModal, disconnectWallet } from "@rhinestone/deposit-modal/reown";
   + import { DepositModal, disconnectWallet } from "@rhinestone/deposit-modal";
 
-  - import type { SafeTransactionRequest } from "@rhinestone/deposit-modal/safe";
-  + import type { SafeTransactionRequest } from "@rhinestone/deposit-modal";
+  - import type { WithdrawModalProps } from "@rhinestone/deposit-modal/safe";
+  + import type { WithdrawModalProps } from "@rhinestone/deposit-modal";
   ```
 
   The `./deposit`, `./withdraw`, `./constants`, and `./styles.css` subpaths
@@ -172,3 +222,10 @@ New in v0.3.0; existing code keeps working:
 `dappWalletClient` / `dappPublicClient` / `reownAppId`, `<WithdrawModal>`'s
 `onSignTransaction`, and the `@rhinestone/deposit-modal/styles.css` export all
 keep their names and signatures.
+
+<Note>
+Scoped to v0.3.0. v0.9.0 later removed `onRequestConnect`, `dappWalletClient`,
+`dappPublicClient`, and `reownAppId` from `<WithdrawModal>` and replaced
+`onSignTransaction` with `onSendTransaction` — see the v0.9.0 section at the top
+of this page. `<DepositModal>` still has all of them.
+</Note>

--- a/deposits/widget/status-tracking.mdx
+++ b/deposits/widget/status-tracking.mdx
@@ -99,8 +99,8 @@ explorer URL.
 
 `WithdrawLifecycleEvent` carries the same `type` values minus `"balance-changed"`
 and `"smart-account-changed"`. Its `txHash` is `Hex`, `sourceChain` is always a
-`number`, `sourceToken` / `targetToken` are `Address`, and `"submitted"` adds a
-`safeAddress: Address` field.
+`number`, `sourceToken` / `targetToken` are `Address`, and `"submitted"` adds an
+`accountAddress: Address` field.
 
 ## onReady
 

--- a/deposits/widget/withdraw-modal.mdx
+++ b/deposits/widget/withdraw-modal.mdx
@@ -1,29 +1,29 @@
 ---
 title: "Withdraw modal"
-description: "Let users withdraw tokens from a Safe to any supported chain using the withdraw modal."
+description: "Let users withdraw tokens from any account to any supported chain. Your app executes the transfer."
 ---
 
-<Warning>
-The withdraw modal currently only supports 1/1 Safe wallets.
-</Warning>
+The `WithdrawModal` component handles outbound transfers. The user selects a destination chain and token, enters a recipient and an amount, and the modal registers the account that routes the funds — then asks your app to perform one transfer.
 
-The `WithdrawModal` component handles outbound transfers from a Safe. The user selects a destination chain and token, enters an amount, and the modal constructs and signs the withdrawal transaction.
+The modal never holds a key and never moves funds itself, so it works with any account model: an EOA, a smart account, an embedded or in-app wallet, or a relayer.
 
 ## Basic usage
 
 ```tsx
-import { WithdrawModal } from "@rhinestone/deposit-modal";
+import { WithdrawModal } from "@rhinestone/deposit-modal/withdraw";
 import "@rhinestone/deposit-modal/styles.css";
 
 <WithdrawModal
   isOpen={isOpen}
   onClose={() => setIsOpen(false)}
-  safeAddress="0xYOUR_SAFE_ADDRESS"
+  accountAddress="0xACCOUNT_HOLDING_THE_FUNDS"
   sourceChain={8453}
   sourceToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   targetChain={10}
   targetToken="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
-  reownAppId="YOUR_REOWN_PROJECT_ID"
+  onSendTransaction={async ({ chainId, token, amount, to }) => ({
+    txHash: await myWallet.sendTransfer({ chainId, token, amount, to }),
+  })}
   onLifecycle={(event) => {
     if (event.type === "complete") {
       console.log("Withdrawal complete:", event.destinationTxHash);
@@ -32,36 +32,63 @@ import "@rhinestone/deposit-modal/styles.css";
 />
 ```
 
-## Transaction signing
+`accountAddress` is the account holding the funds. The modal reads its balance and stops the user sending to themselves; it never transacts from it.
 
-By default, the modal uses Reown for wallet connection and signing. If your app manages wallets directly (e.g. Privy embedded wallets), pass `onSignTransaction` to handle Safe transaction signing yourself.
+## Executing the transfer
 
-The callback receives a `SafeTransactionRequest` containing the `safeTxHash` and EIP-712 typed data. Return a signature.
+`onSendTransaction` is required. The modal calls it once, when the user confirms on the review screen, with everything needed for a single transfer:
+
+```ts
+onSendTransaction: (request: WithdrawTransferRequest) => Promise<{ txHash: Hex }>
+
+interface WithdrawTransferRequest {
+  chainId: number;  // source chain to send from
+  token: Address;   // source token; NATIVE_TOKEN_ADDRESS for the native asset
+  amount: bigint;   // in the token's base units
+  to: Address;      // send here
+}
+```
+
+Two rules, both silent-failure modes if missed:
+
+<Warning>
+**Send to `to`, and nothing else.** It is the Rhinestone account that receives the funds and bridges them on to the recipient — except on a same-route withdrawal (source chain and token identical to the target), where the modal skips the bridge and `to` is the recipient directly. Substituting an address of your own either bypasses the bridge or strands the funds.
+
+**Return the on-chain transaction hash.** Progress is tracked by looking the deposit up by that hash. An ERC-4337 wallet must await the receipt and return the bundled transaction hash, **not** the userOp hash — returning the wrong one leaves the modal waiting on a withdrawal that already succeeded.
+</Warning>
+
+Reject the promise to surface a failure in the modal. The user can retry from the review screen.
+
+### If your funds are in a Safe
+
+A 1/1 Safe signs with `personal_sign` over the `SafeTx` hash, relayed by whoever pays the gas. Build the EIP-712 `SafeTx`, sign it, and submit `execTransaction`:
 
 ```tsx
-<WithdrawModal
-  // ...required props
-  dappAddress={embeddedWalletAddress}
-  onSignTransaction={async (request) => {
-    const provider = await getEmbeddedWalletProvider();
+onSendTransaction={async ({ chainId, token, amount, to }) => {
+  const safeTx = await buildSafeTransaction({ chainId, token, amount, to });
 
-    // Sign the Safe transaction hash
-    const signature = await provider.request({
-      method: "personal_sign",
-      params: [request.safeTxHash, embeddedWalletAddress],
-    });
+  const signature = await provider.request({
+    method: "personal_sign",
+    params: [safeTx.safeTxHash, ownerAddress],
+  });
 
-    // Adjust v value for Safe's eth_sign verification
-    const v = parseInt(signature.slice(-2), 16);
-    const adjusted = signature.slice(0, -2) + (v + 4).toString(16);
+  // Adjust v for Safe's eth_sign verification
+  const v = parseInt(signature.slice(-2), 16);
+  const adjusted = signature.slice(0, -2) + (v + 4).toString(16);
 
-    return { signature: adjusted };
-  }}
-/>
+  const { txHash } = await relaySafeTransaction(safeTx, adjusted);
+  return { txHash };
+}}
 ```
 
 <Note>
 Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` signature. This adjustment is specific to Safe's signature verification — see the [Safe docs](https://docs.safe.global/advanced/smart-account-signatures#eth_sign-signature) for details.
+</Note>
+
+To keep gas sponsored, relay the signed transaction through `POST /safe/withdraw` on your proxy rather than submitting `execTransaction` from the user's wallet. Note that a relayed transaction cannot use Safe's pre-validated (`v = 1`) signature shortcut: that only validates when `msg.sender` is the owner, and for a relayed call the sender is the relayer.
+
+<Note>
+Before v0.9.0 the modal did all of this internally, behind a `safeAddress` prop and an `onSignTransaction` callback. See [migration](/deposits/widget/migration) if you are upgrading.
 </Note>
 
 ## Props reference
@@ -72,28 +99,18 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 |---|---|---|
 | `isOpen` | `boolean` | Controls modal visibility |
 | `onClose` | `() => void` | Called when the user closes the modal |
-| `safeAddress` | `Address` | The 1/1 Safe contract address |
-| `sourceChain` | `Chain \| number` | Chain where the Safe holds funds |
-| `sourceToken` | `Address` | Token to withdraw from the Safe |
-| `targetChain` | `Chain \| number` | Destination chain |
-| `targetToken` | `Address` | Token to receive on the destination chain |
-
-### Wallet
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `reownAppId` | `string` | — | Reown project ID for wallet connection |
-| `dappAddress` | `Address` | — | Owner address for embedded wallet flows |
-| `dappWalletClient` | `WalletClient` | — | Host-provided viem wallet client |
-| `dappPublicClient` | `PublicClient` | — | Host-provided viem public client |
-| `onSignTransaction` | `(request: SafeTransactionRequest) => Promise<{ signature: Hex }>` | — | Custom Safe transaction signer |
-| `onRequestConnect` | `() => void` | — | Called when wallet connection needed |
+| `accountAddress` | `Address` | Account holding the funds being withdrawn |
+| `sourceChain` | `Chain \| number` | Chain where the account holds funds |
+| `sourceToken` | `Address` | Token to withdraw |
+| `targetChain` | `Chain \| number` | Default destination chain — the user can change it |
+| `targetToken` | `Address` | Default token to receive — the user can change it |
+| `onSendTransaction` | `(request: WithdrawTransferRequest) => Promise<{ txHash: Hex }>` | Performs the transfer and returns its on-chain hash |
 
 ### Transfer
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `recipient` | `Address` | Smart account address | Delivery address on target chain |
+| `recipient` | `Address` | — | Pre-fills the delivery address; the user can edit it |
 | `defaultAmount` | `string` | — | Pre-filled withdrawal amount |
 | `allowedRoutes` | `RouteConfig` | — | Restrict available routes |
 
@@ -109,7 +126,7 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `backendUrl` | `string` | Rhinestone production URL | URL of your deposit-widget-backend instance. Self-hosting a custom proxy? See [version header pass-through](/deposits/widget/deposit-modal#version-header-pass-through) |
-| `rpcUrls` | `RpcUrlMap` | Chain defaults | Per-chain RPC overrides keyed by EVM chain id. Applied to EVM public clients and the connected wallet; chains left unset use their default RPC |
+| `rpcUrls` | `RpcUrlMap` | Chain defaults | Per-chain RPC overrides keyed by EVM chain id. Used for balance reads; chains left unset use their default RPC |
 
 ### Display
 
@@ -131,4 +148,4 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 | `onError` | `(data: ErrorEventData) => void` | Error at any stage |
 | `onEvent` | `(event: WithdrawAnalyticsEvent) => void` | [Analytics event](/deposits/widget/status-tracking#analytics) |
 
-`WithdrawLifecycleEvent` has no `balance-changed` or `smart-account-changed` variants, and its payload types differ from the deposit union: `txHash` is `Hex`, `sourceChain` is always a `number`, `sourceToken` / `targetToken` are `Address`, and `"submitted"` carries a `safeAddress`.
+`WithdrawLifecycleEvent` has no `balance-changed` or `smart-account-changed` variants, and its payload types differ from the deposit union: `txHash` is `Hex`, `sourceChain` is always a `number`, `sourceToken` / `targetToken` are `Address`, and `"submitted"` carries an `accountAddress`.


### PR DESCRIPTION
[skip-linear]

Follows #179 (merged) and documents the second half of modal v0.9.0 — rhinestonewtf/deposit-modal#90, merged into the v0.9.0 stack.

#179's title says "deposit/withdraw modals" but it only covered deposits, so `withdraw-modal.mdx` still opens with:

> The withdraw modal currently only supports 1/1 Safe wallets.

That constraint is exactly what v0.9.0 removes. The modal no longer moves funds — it asks the host app to perform one transfer and return the on-chain hash, so any account model works.

## Changes

**`withdraw-modal.mdx`** — the substantive rewrite. Drops the 1/1-Safe warning, rebuilds the intro and basic usage around `accountAddress` + `onSendTransaction`, and replaces "Transaction signing" with "Executing the transfer" covering the two silent-failure rules: send to `to` (the routing account, or the recipient on a same-route withdrawal), and return the **on-chain tx hash, not a userOp hash** — progress is tracked by looking the deposit up by that hash. The six-prop Wallet section is gone (`reownAppId`, `dappAddress`, `dappWalletClient`, `dappPublicClient`, `onSignTransaction`, `onRequestConnect`).

The Safe `personal_sign` + **`v + 4`** gotcha is kept as an "If your funds are in a Safe" subsection rather than deleted — it's still correct for a Safe-backed app implementing the callback, and it's the kind of detail that's expensive to rediscover. Added a note that a relayed call can't use Safe's pre-validated `v = 1` shortcut, since that only validates when `msg.sender` is the owner.

**`deposit-modal.mdx`** — the required-routes table told self-hosters to proxy `POST /safe/withdraw` for the withdraw modal. The modal never calls it from v0.9.0, so that row now says so; it's only needed if the app's own `onSendTransaction` relays through it. Left as-is, someone deploys a route nothing uses.

**`migration.mdx`** — adds a v0.8.x → v0.9.0 section (managed-account prop removals for both modals + the withdraw callback swap) and scopes the v0.3.0 "Unchanged" list, which still promised `onSignTransaction`, `reownAppId`, `dappWalletClient`, `dappPublicClient`, and `onRequestConnect` were stable on `<WithdrawModal>`.

**`status-tracking.mdx`** — `"submitted"` carries `accountAddress`, not `safeAddress`.

## Checks

- Documented prop tables match `WithdrawModalProps` exactly — 25 documented, 25 real, no extras or omissions.
- Every anchor I introduced resolves to a real heading. `#proxied-routes` does **not** exist (the heading is "Required routes"), and I avoided guessing a Mintlify slug for a heading containing dots and an arrow.
- No stale `onSignTransaction` / `SafeTransactionRequest` / `safeAddress` references remain outside `migration.mdx`, where they correctly appear as the *old* side of upgrade diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZaiXxfnoexBJwWcYBFz9C