### PR TITLE
docs: parse passkey coordinates through the SDK helper

### DIFF
--- a/smart-wallet/advanced/recovery.mdx
+++ b/smart-wallet/advanced/recovery.mdx
@@ -104,18 +104,14 @@ This prompts a signature from each guardian account and submits a transaction on
 
 To recover access to the account:
 
-```ts {6-11,28-31}
-import { slice } from 'viem'
+```ts {6-7,24-27}
 import { recoverPasskeyOwnership } from '@rhinestone/sdk/actions/recovery'
+import { parsePublicKey } from '@rhinestone/sdk/signing/passkeys'
 
 // The account's complete current credential set. The validator stores
 // credentials hashed, so the set cannot be read back onchain.
-const currentCredentials = [
-  {
-    pubKeyX: BigInt(slice(passkeyAccountA.publicKey, 0, 32)),
-    pubKeyY: BigInt(slice(passkeyAccountA.publicKey, 32, 64)),
-  },
-]
+const { x, y } = parsePublicKey(passkeyAccountA.publicKey)
+const currentCredentials = [{ pubKeyX: x, pubKeyY: y }]
 
 const recoveryCalls = await recoverPasskeyOwnership({
   accountAddress: rhinestoneAccount.getAddress(),


### PR DESCRIPTION
The passkey recovery snippet derived coordinates by stripping `0x` and slicing from byte 0:

```ts
pubKeyX: BigInt(slice(passkeyAccountA.publicKey, 0, 32)),
pubKeyY: BigInt(slice(passkeyAccountA.publicKey, 32, 64)),
```

Uncompressed SEC1 public keys are 65 bytes with an `0x04` prefix, so both coordinates shift by a byte. Anyone copying this made recovery install a credential that can't authenticate and then remove the working one — leaving the account with no usable passkey.

Now uses `parsePublicKey` from `@rhinestone/sdk/signing/passkeys`, which already handles the prefix, and drops the `viem` `slice` import:

```ts
const { x, y } = parsePublicKey(passkeyAccountA.publicKey)
const currentCredentials = [{ pubKeyX: x, pubKeyY: y }]
```

Mirrors the SDK fix in rhinestonewtf/sdk#707. Verified with `vale` and `mintlify broken-links`; line-highlight ranges recomputed for the shorter block.

Closes [RHI-5124](https://linear.app/rhinestone/issue/RHI-5124)

🤖 Generated with [Claude Code](https://claude.com/claude-code)