### PR TITLE
docs: bring the deposit widget docs up to 0.9.0, and lead with the widget

### DIFF
--- a/deposits/api/quickstart.mdx
+++ b/deposits/api/quickstart.mdx
@@ -5,6 +5,12 @@ description: "Set up the Deposit API and process your first cross-chain deposit.
 
 Register a managed account, deposit USDC on one chain, and receive it on another.
 
+<Tip>
+Building in React? The [deposit widget](/deposits/widget/quickstart) ships this flow as
+a component — UI, funding methods, withdrawals and refunds included — on top of the
+same API.
+</Tip>
+
 ## Prerequisites
 
 - A Rhinestone API key

--- a/deposits/overview.mdx
+++ b/deposits/overview.mdx
@@ -11,27 +11,29 @@ It supports a wide range of EVM chains and Solana — see [supported chains and 
 
 ## Two ways to integrate
 
+**Start with the widget.** It ships the whole deposit UI — funding methods, chain and token selection, status screens, withdrawals and refunds — and it uses the same API underneath, so nothing is closed off later. Reach for the API directly when you're not building in React, or when you want a deposit flow that doesn't look like a modal.
+
 <Tabs>
-<Tab title="Deposit API">
-
-A headless backend service for programmatic deposit handling. You register accounts, configure webhooks, and process deposits server-side. Full control over the deposit flow.
-
-<Frame caption="Example of an integration into a mobile app">
-  <video src="/images/deposits_api_integration.mp4" muted loop controls className="rounded-2xl" style={{ maxHeight: "500px", margin: "0 auto" }} />
-</Frame>
-
-[Get started with the Deposit API →](/deposits/api/quickstart)
-
-</Tab>
 <Tab title="Deposit Widget">
 
-A drop-in React modal that handles wallet connection, chain selection, and deposit execution out of the box. Minimal frontend effort for a polished deposit experience. It can also [import balances from other apps](/deposits/widget/deposit-modal#import-from-other-apps) (e.g. Polymarket) so users fund a deposit without transferring first.
+A React modal that handles funding method, chain and token selection, and deposit execution out of the box. Also covers [fiat and exchange funding](/deposits/widget/deposit-modal#funding-methods), [withdrawals](/deposits/widget/withdraw-modal), [refunds](/deposits/widget/claim-modal), and [migrating balances from other apps](/deposits/widget/deposit-modal#migrate-assets-from-other-apps) (e.g. Polymarket).
 
 <Frame caption="Widget UI">
   <video src="/images/deposits_widget_ui.mp4" muted loop controls className="rounded-2xl" style={{ maxHeight: "500px", margin: "0 auto" }} />
 </Frame>
 
 [Get started with the Deposit Widget →](/deposits/widget/quickstart)
+
+</Tab>
+<Tab title="Deposit API">
+
+A headless backend service for programmatic deposit handling. You register accounts, configure webhooks, and process deposits server-side, and you build the UI. Use it for native mobile, non-React frontends, or fully custom flows.
+
+<Frame caption="Example of an integration into a mobile app">
+  <video src="/images/deposits_api_integration.mp4" muted loop controls className="rounded-2xl" style={{ maxHeight: "500px", margin: "0 auto" }} />
+</Frame>
+
+[Get started with the Deposit API →](/deposits/api/quickstart)
 
 </Tab>
 </Tabs>
@@ -78,7 +80,7 @@ Under the hood, Rhinestone aggregates multiple bridging providers, solvers, and 
 
 From the user's perspective, depositing is a simple token transfer — send tokens to an address on any supported chain. There's no bridging UI, no gas token management, and no chain switching.
 
-With the **widget**, the experience is even more streamlined: the user connects their wallet, selects a chain and token, and confirms the deposit — all within a single modal. The widget also supports withdrawals.
+With the **widget**, the user picks how to fund — connected wallet, QR transfer, card, or an exchange — then confirms, all in one modal. Withdrawals and refunds have their own modals.
 
 With the **API**, you control the UX entirely. The user interacts with your app however you design it, and the deposit service handles everything behind the scenes.
 
@@ -135,9 +137,14 @@ Rhinestone Deposits supports a wide range of EVM chains plus Solana. Each chain 
 
 ## Which should you use?
 
-|                    | Deposit API                          | Deposit Widget                          |
-| ------------------ | ------------------------------------ | --------------------------------------- |
-| Integration effort | Moderate — backend + webhook handler | Low — drop in a React component         |
-| UI control         | Full — build your own                | Themed modal with customization options |
-| Deposit triggers   | Any transfer to the smart account    | User-initiated via the modal            |
-| Withdrawal support | Manual                               | Built-in withdraw modal                 |
+|                     | Deposit Widget                                                      | Deposit API                          |
+| ------------------- | ------------------------------------------------------------------- | ------------------------------------ |
+| Frontend            | React component, themeable, modal or inline                         | You build it                         |
+| Backend             | A [proxy holding your API key](/deposits/widget/backend) — ours or your own | Your service, holding the key        |
+| Deposit triggers    | Any transfer to the deposit account, plus in-modal funding          | Any transfer to the deposit account  |
+| Fiat / exchange     | Card, Apple Pay, bank and CEX funding, UI included                  | [Endpoints](/deposits/api/onramp); you build the UI |
+| Withdrawals         | [Withdraw modal](/deposits/widget/withdraw-modal); your app signs the transfer | You build it                         |
+| Refunds             | [Claim modal](/deposits/widget/claim-modal) for users, plus the dashboard | Dashboard, or build your own         |
+| Status              | Lifecycle callbacks in the browser                                  | [Webhooks](/deposits/api/status-tracking) server-side |
+
+Both need a backend, and both see the same deposits — a user who sends funds to the deposit address never touches your UI either way. Most widget integrations also want [webhooks](/deposits/widget/backend#webhooks), for fulfilment that can't depend on the modal being open.

--- a/deposits/troubleshooting.mdx
+++ b/deposits/troubleshooting.mdx
@@ -27,6 +27,12 @@ If retry keeps failing, the funds may not be automatically recoverable — refun
 
 Refunds return a failed deposit's funds to an address you choose. Only Owners and Admins can refund.
 
+<Tip>
+To let users recover their own failed deposits without going through you, embed the
+[claim modal](/deposits/widget/claim-modal) — the user pastes the deposit's
+transaction hash and your app authorizes the refund.
+</Tip>
+
 <Steps>
 <Step title="Open the deposit and press Refund">
 

--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -47,8 +47,8 @@ const ROUTES: [method: "get" | "post", path: string][] = [
   ["post", "/onramp/swapped/connect-url"],
   ["get", "/onramp/swapped/connect-exchanges"],
   ["get", "/onramp/swapped/status/:smartAccount"],
-  // Add ["post", "/deposits/refund"] only if you run the claim flow, and
-  // ["post", "/safe/withdraw"] only if your onSendTransaction relays through it.
+  // Add ["post", "/safe/withdraw"] only if your onSendTransaction relays through
+  // it. Do NOT add /deposits/refund here — see below.
 ];
 
 const app = new Hono();
@@ -86,6 +86,22 @@ every write on the upstream — including `POST /setup`, which rotates your webh
 secret and sponsorship config. The route list is what stops that.
 </Warning>
 
+### Refunds are not a route-table entry
+
+`POST /deposits/refund` cannot be forwarded like the routes above. Every route in
+that loop passes the browser's body straight through with your API key attached —
+which for a refund means anyone could return any of your recoverable deposits to an
+address they chose.
+
+It needs a handler that authorizes the specific refund, and derives the upstream
+call from that authorization rather than from the request body:
+
+- **your own route** — use [`createRefundHandler`](/deposits/widget/claim-modal#implementing-the-endpoint), which checks the deposit belongs to the caller before spending the key
+- **a proxy** — verify a per-refund `x-user-token` and take *every* upstream field from the token, ignoring the body
+
+Register it only when that verification is in place. See
+[claim modal](/deposits/widget/claim-modal#why-your-app-authorizes-it).
+
 ## Required routes
 
 Missing a route doesn't degrade the flow — the request 404s and that part of the modal stops working.
@@ -102,7 +118,7 @@ Missing a route doesn't degrade the flow — the request 404s and that part of t
 | `GET` | `/prices` | USD pricing |
 | `GET` | `/setup` | Your client config (source-token allowlist, minimums) |
 | `GET` | `/tokens` | Static top-tokens list for the QR flow |
-| `POST` | `/deposits/refund` | [Self-service refunds](/deposits/widget/claim-modal). Opt-in — register it only when you've set a token secret, and accept `x-user-token` on this route alone |
+| `POST` | `/deposits/refund` | [Self-service refunds](/deposits/widget/claim-modal). **Not a plain passthrough** — needs a token-verifying handler, see [above](#refunds-are-not-a-route-table-entry) |
 | `POST` | `/polymarket/withdraw` | Polymarket withdrawals |
 | `POST` | `/onramp/swapped/widget-url` | Fiat on-ramp |
 | `POST` | `/onramp/swapped/connect-url` | Exchange connect |

--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -20,7 +20,7 @@ service. If you never set it, you were using ours — set it now. See
 
 ## Minimal proxy
 
-A proxy is a route table plus a header.
+A proxy is an explicit route table plus a header. The allowlist is the security boundary — see the warning below.
 
 ```ts
 import { Hono } from "hono";
@@ -29,33 +29,62 @@ import { cors } from "hono/cors";
 const UPSTREAM = "https://v1.orchestrator.rhinestone.dev/deposit-processor";
 const MODAL_VERSION_HEADER = "x-deposit-modal-version";
 
+// Every route the modal calls, and nothing else. `:param` segments are matched
+// by Hono, so a request can only reach a shape you listed here.
+const ROUTES: [method: "get" | "post", path: string][] = [
+  ["post", "/register-managed"],
+  ["post", "/quotes/preview"],
+  ["get", "/check/:address"],
+  ["get", "/portfolio/:address"],
+  ["get", "/portfolio/solana/:address"],
+  ["get", "/deposits"],
+  ["get", "/liquidity"],
+  ["get", "/prices"],
+  ["get", "/setup"],
+  ["get", "/tokens"],
+  ["post", "/polymarket/withdraw"],
+  ["post", "/onramp/swapped/widget-url"],
+  ["post", "/onramp/swapped/connect-url"],
+  ["get", "/onramp/swapped/connect-exchanges"],
+  ["get", "/onramp/swapped/status/:smartAccount"],
+  // Add ["post", "/deposits/refund"] only if you run the claim flow, and
+  // ["post", "/safe/withdraw"] only if your onSendTransaction relays through it.
+];
+
 const app = new Hono();
 app.use("*", cors());
 
-app.all("/*", async (c) => {
-  const url = new URL(c.req.url);
+for (const [method, path] of ROUTES) {
+  app[method](path, async (c) => {
+    const url = new URL(c.req.url);
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "x-api-key": process.env.RHINESTONE_API_KEY!,
-  };
-  const modalVersion = c.req.header(MODAL_VERSION_HEADER);
-  if (modalVersion) headers[MODAL_VERSION_HEADER] = modalVersion;
+    // A fresh header set, never the incoming one: the browser must not be able
+    // to set `x-api-key` itself.
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "x-api-key": process.env.RHINESTONE_API_KEY!,
+    };
+    const modalVersion = c.req.header(MODAL_VERSION_HEADER);
+    if (modalVersion) headers[MODAL_VERSION_HEADER] = modalVersion;
 
-  const res = await fetch(`${UPSTREAM}${url.pathname}${url.search}`, {
-    method: c.req.method,
-    headers,
-    body: c.req.method === "GET" ? undefined : await c.req.text(),
+    const res = await fetch(`${UPSTREAM}${url.pathname}${url.search}`, {
+      method: c.req.method,
+      headers,
+      body: method === "get" ? undefined : await c.req.text(),
+    });
+    return new Response(res.body, { status: res.status });
   });
-  return new Response(res.body, { status: res.status });
-});
+}
 
 export default app;
 ```
 
-Note that it builds a **fresh** header set rather than passing the incoming ones through — the browser must not be able to set `x-api-key` itself.
-
-Forward only the routes below, rather than everything. A blanket passthrough also exposes the admin writes on the same upstream.
+<Warning>
+Do **not** replace that loop with a wildcard passthrough (`app.all("/*", …)`). The
+proxy attaches your API key to whatever reaches it, so a wildcard hands the browser
+every write on the upstream — including `POST /setup`, which rotates your webhook
+secret and sponsorship config. The route list is what stops that.
+</Warning>
 
 ## Required routes
 

--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -3,18 +3,20 @@ title: "Backend"
 description: "The widget needs a proxy holding your Rhinestone API key. Write one, or deploy Rhinestone's."
 ---
 
-The widget runs in the browser, so it can't hold your Rhinestone API key — the key authorizes writes against your project, from registering accounts to spending sponsorship. Every request the modal makes goes to a proxy **you** run, which attaches the key and forwards to the deposit processor. Point the modals at it with `backendUrl`.
+The widget runs in the browser, so it can't hold your Rhinestone API key — the key authorizes writes against your project, from registering accounts to spending sponsorship. Every request the modal makes goes to a proxy **you** run, which attaches the key and forwards to the deposit processor.
+
+All three modals take it as a required `backendUrl`. There is deliberately no default: a Rhinestone-operated fallback would mean your users' deposits ride our key.
 
 Two ways to get one:
 
 - **Write your own.** A route table and a header — see [minimal proxy](#minimal-proxy).
 - **Deploy Rhinestone's.** We're open-sourcing the proxy we run for clients, so you can deploy it as-is. Coming soon.
 
-<Warning>
-`backendUrl` is typed as optional, but treat it as required. The built-in default is a
-Rhinestone-internal service running on our API key, not a client endpoint. Set
-`backendUrl` before you ship anything, including staging.
-</Warning>
+<Note>
+Before v0.9.0 `backendUrl` was optional and defaulted to a Rhinestone-internal
+service. If you never set it, you were using ours — set it now. See
+[migration](/deposits/widget/migration).
+</Note>
 
 ## Minimal proxy
 

--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -1,0 +1,111 @@
+---
+title: "Backend"
+description: "The widget needs a proxy holding your Rhinestone API key. Write one, or deploy Rhinestone's."
+---
+
+The widget runs in the browser, so it can't hold your Rhinestone API key — the key authorizes writes against your project, from registering accounts to spending sponsorship. Every request the modal makes goes to a proxy **you** run, which attaches the key and forwards to the deposit processor. Point the modals at it with `backendUrl`.
+
+Two ways to get one:
+
+- **Write your own.** A route table and a header — see [minimal proxy](#minimal-proxy).
+- **Deploy Rhinestone's.** We're open-sourcing the proxy we run for clients, so you can deploy it as-is. Coming soon.
+
+<Warning>
+`backendUrl` is typed as optional, but treat it as required. The built-in default is a
+Rhinestone-internal service running on our API key, not a client endpoint. Set
+`backendUrl` before you ship anything, including staging.
+</Warning>
+
+## Minimal proxy
+
+A proxy is a route table plus a header.
+
+```ts
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+const UPSTREAM = "https://v1.orchestrator.rhinestone.dev/deposit-processor";
+const MODAL_VERSION_HEADER = "x-deposit-modal-version";
+
+const app = new Hono();
+app.use("*", cors());
+
+app.all("/*", async (c) => {
+  const url = new URL(c.req.url);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": process.env.RHINESTONE_API_KEY!,
+  };
+  const modalVersion = c.req.header(MODAL_VERSION_HEADER);
+  if (modalVersion) headers[MODAL_VERSION_HEADER] = modalVersion;
+
+  const res = await fetch(`${UPSTREAM}${url.pathname}${url.search}`, {
+    method: c.req.method,
+    headers,
+    body: c.req.method === "GET" ? undefined : await c.req.text(),
+  });
+  return new Response(res.body, { status: res.status });
+});
+
+export default app;
+```
+
+Note that it builds a **fresh** header set rather than passing the incoming ones through — the browser must not be able to set `x-api-key` itself.
+
+Forward only the routes below, rather than everything. A blanket passthrough also exposes the admin writes on the same upstream.
+
+## Required routes
+
+Missing a route doesn't degrade the flow — the request 404s and that part of the modal stops working.
+
+| Method | Route | Used for |
+|---|---|---|
+| `POST` | `/register-managed` | Registering the deposit account. **Required from modal v0.9.0** |
+| `POST` | `/quotes/preview` | Indicative fee/time quote on the review screen |
+| `GET` | `/check/:address` | Registration + target lookup |
+| `GET` | `/portfolio/:address` | EVM balances |
+| `GET` | `/portfolio/solana/:address` | Solana balances |
+| `GET` | `/deposits` | Deposit status + history |
+| `GET` | `/liquidity` | Route liquidity check |
+| `GET` | `/prices` | USD pricing |
+| `GET` | `/setup` | Your client config (source-token allowlist, minimums) |
+| `GET` | `/tokens` | Static top-tokens list for the QR flow |
+| `POST` | `/deposits/refund` | [Self-service refunds](/deposits/widget/claim-modal). Opt-in — register it only when you've set a token secret, and accept `x-user-token` on this route alone |
+| `POST` | `/polymarket/withdraw` | Polymarket withdrawals |
+| `POST` | `/onramp/swapped/widget-url` | Fiat on-ramp |
+| `POST` | `/onramp/swapped/connect-url` | Exchange connect |
+| `GET` | `/onramp/swapped/connect-exchanges` | Exchange list |
+| `GET` | `/onramp/swapped/status/:smartAccount` | On-ramp order status |
+| `POST` | `/safe/withdraw` | Relaying a signed Safe transfer with sponsored gas. **Not used by the modal from v0.9.0** — proxy it only if your own [`onSendTransaction`](/deposits/widget/withdraw-modal#executing-the-transfer) relays through it |
+
+<Warning>
+Proxy `GET /setup` only, never `POST /setup`. The POST is an admin write — it rotates
+your webhook secret and sponsorship config — and must not be reachable from a browser.
+</Warning>
+
+## CORS and the version header
+
+All three modals send `x-deposit-modal-version` on every request. Browsers reject a request carrying a header the server didn't allow on the preflight, so an explicit allow-list must include it:
+
+```ts
+allowHeaders: ["Content-Type", "x-deposit-modal-version"]
+```
+
+Bare `cors()` in Hono is fine — with no `allowHeaders` it reflects whatever the preflight asks for.
+
+<Warning>
+This bites on upgrade, not on first deploy. A modal version that starts sending a new
+header fails the **whole request** at preflight against a proxy with a fixed
+allow-list, not just the header. Deploy proxy changes before the modal that needs them.
+</Warning>
+
+The header tells us which versions are live, so we can warn you about one with a known bug and reproduce issues against the build you're running. Forwarding it upstream is optional. To read the value in your own app, for a bug report:
+
+```ts
+import { MODAL_VERSION } from "@rhinestone/deposit-modal/constants";
+```
+
+## Webhooks
+
+The widget's [lifecycle callbacks](/deposits/widget/status-tracking) fire only while the modal is open, so a user who closes it mid-bridge leaves your app unaware the deposit completed. Anything that must happen regardless — crediting a balance, sending a receipt — belongs on a [webhook](/deposits/api/status-tracking) handler. Configure it once with `POST /setup`.

--- a/deposits/widget/claim-modal.mdx
+++ b/deposits/widget/claim-modal.mdx
@@ -1,0 +1,197 @@
+---
+title: "Claim modal"
+description: "Let a user recover a failed or rejected deposit by pasting its transaction hash — no wallet connection."
+---
+
+The `ClaimModal` returns a failed or rejected EVM deposit to the user, on the chain it came from. The user pastes the deposit's transaction hash; the modal looks it up and asks your app to authorize the refund.
+
+No wallet is involved, and there is no source chain to pick — the hash is looked up across every chain, so a deposit that landed on a chain your deposit flow doesn't offer is still claimable.
+
+<Note>
+New in v0.9.0, on the `./claim` subpath. Applies to deposits in `failed` or `rejected`
+status; see [troubleshooting](/deposits/troubleshooting) for the dashboard equivalent.
+</Note>
+
+## Why your app authorizes it
+
+Deposit accounts are [service-managed](/deposits/widget/deposit-modal#account-setup), so no user wallet can sign for a refund, and an exchange-funded deposit has no signable sender either. Only your app knows which of its users a deposit belongs to, so `refundEndpoint` points at something you control.
+
+Two shapes, depending on where that endpoint lives:
+
+<Tabs>
+<Tab title="Your own route (same-origin)">
+
+The browser's session cookie travels with the request, so your route authenticates the user the way it always does. No token needed — omit `getUserToken`.
+
+```tsx
+import { ClaimModal } from "@rhinestone/deposit-modal/claim";
+import "@rhinestone/deposit-modal/styles.css";
+
+<ClaimModal
+  isOpen={isOpen}
+  onClose={() => setIsOpen(false)}
+  refundEndpoint="/api/refund"
+/>
+```
+
+</Tab>
+<Tab title="A deposit-widget-proxy (cross-origin)">
+
+The cookie won't travel cross-origin, so `getUserToken` mints a short-lived token that the modal sends as `x-user-token`.
+
+The proxy takes **every** field of the upstream refund from the signed token and ignores the request body, so the token must carry the whole refund — not just the user's identity.
+
+The route registers only when `REFUND_TOKEN_SECRET` is set. That's a registration gate rather than a 401 inside the handler, so bumping the proxy version can't silently expose an endpoint that spends your API key.
+
+```tsx
+import { ClaimModal } from "@rhinestone/deposit-modal/claim";
+import "@rhinestone/deposit-modal/styles.css";
+
+<ClaimModal
+  isOpen={isOpen}
+  onClose={() => setIsOpen(false)}
+  refundEndpoint="https://proxy.example.com/deposits/refund"
+  getUserToken={async (request) => {
+    const res = await fetch("/api/refund-token", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+    return (await res.json()).token;
+  }}
+/>
+```
+
+<Warning>
+Bind the token to **this specific refund**, not to the user alone. An
+identity-only token is a bearer credential that can be spent on any destination —
+mint it from the `RefundRequest` you were handed and sign over its fields,
+including the destination.
+</Warning>
+
+</Tab>
+</Tabs>
+
+## Implementing the endpoint
+
+`@rhinestone/deposit-modal/server` exports `createRefundHandler`, which does everything except decide who the caller is. It verifies the deposit belongs to the recipient you name before spending your API key.
+
+```ts
+// app/api/refund/route.ts
+import { createRefundHandler } from "@rhinestone/deposit-modal/server";
+
+export const POST = createRefundHandler({
+  apiKey: process.env.RHINESTONE_API_KEY!,
+  async authorize(request) {
+    const session = await getSession(request);
+    return session ? { recipient: session.depositRecipient } : null;
+  },
+});
+```
+
+It returns a `(Request) => Promise<Response>`, so it mounts in any fetch-based runtime — Next.js route handlers, Hono, `Bun.serve`, Cloudflare Workers.
+
+<Warning>
+Import from `@rhinestone/deposit-modal/server` only. It holds your API key and must
+never reach the browser.
+</Warning>
+
+### authorize
+
+Return the recipient the caller owns, or `null` to reject with 401.
+
+| Field | Type | Description |
+|---|---|---|
+| `recipient` | `string` | The in-app recipient this user owns — the same value you pass the deposit modal. The deposit is checked against it |
+| `destination` | `string` | Optional. Overrides the destination the browser asked for |
+
+Set `destination` whenever you already know where the user's money should go. Without it the page picks, and it could pick anything.
+
+<Warning>
+Never refund to an exchange deposit address. Exchanges don't credit arbitrary
+incoming transfers, so the funds **may be lost**. This is why the modal never defaults
+the destination to the deposit's sender.
+</Warning>
+
+### Request body
+
+The modal POSTs a `RefundRequest`. It comes from the page, so treat it as untrusted.
+
+| Field | Type | Description |
+|---|---|---|
+| `chain` | `string` | CAIP-2 source chain of the deposit, e.g. `"eip155:8453"` |
+| `txHash` | `string` | The deposit transaction the user pasted |
+| `account` | `string` | Managed account that received the deposit |
+| `token` | `string` | Source token address |
+| `destination` | `string` | Where the refunded funds should go, on the source chain |
+
+## Props reference
+
+### Required
+
+| Prop | Type | Description |
+|---|---|---|
+| `isOpen` | `boolean` | Controls modal visibility |
+| `onClose` | `() => void` | Called when the user closes the modal |
+| `refundEndpoint` | `string` | Endpoint the modal POSTs the refund to |
+
+### Authorization
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `getUserToken` | `(request: RefundRequest) => Promise<string>` | — | Mints a token authorizing exactly this refund, sent as `x-user-token`. Required when `refundEndpoint` is cross-origin |
+
+### Prefills
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `defaultTxHash` | `string` | — | Prefills the lookup field |
+| `defaultRecipient` | `Address` | — | Prefills the refund destination. Otherwise left empty |
+
+### Backend
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `backendUrl` | `string` | — | Your [backend proxy](/deposits/widget/backend). Treat as required — the default is Rhinestone-internal |
+| `rpcUrls` | `RpcUrlMap` | Chain defaults | Per-chain RPC overrides keyed by EVM chain id |
+
+### Display
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `inline` | `boolean` | `false` | Render without modal overlay |
+| `closeOnOverlayClick` | `boolean` | `true` | Close modal on backdrop click |
+| `className` | `string` | — | CSS class for the modal container |
+| `theme` | `DepositModalTheme` | — | [Theme configuration](/deposits/widget/customization#theme) |
+| `uiConfig` | `DepositModalUIConfig` | — | [UI configuration](/deposits/widget/customization#ui-configuration) |
+| `debug` | `boolean` | `false` | Enable debug logging |
+
+### Callbacks
+
+| Prop | Type | Description |
+|---|---|---|
+| `onReady` | `() => void` | Modal initialized |
+| `onLifecycle` | `(event: ClaimLifecycleEvent) => void` | Claim lifecycle — switch on `event.type` |
+| `onError` | `(data: ErrorEventData) => void` | Error at any stage |
+| `onEvent` | `(event: ClaimAnalyticsEvent) => void` | [Analytics event](/deposits/widget/status-tracking#analytics) |
+
+## Lifecycle events
+
+| `event.type` | Payload | Fired when |
+|---|---|---|
+| `lookup` | `txHash`, `matches` | The pasted hash was looked up. `matches` is how many deposits it resolved to |
+| `refund_requested` | `account`, `destination`, `chain` | The refund was submitted to your endpoint |
+| `complete` | `txHash`, `account`, `destination`, `chain`, `token`, `amount` | The refund succeeded |
+| `failed` | `status`, `error` | The refund failed. `status` is the HTTP status from your endpoint, or `0` if it was unreachable |
+
+```tsx
+<ClaimModal
+  // ...required props
+  onLifecycle={(event) => {
+    if (event.type === "complete") {
+      trackRefund(event.txHash, event.amount);
+    }
+  }}
+/>
+```
+
+`ClaimLifecycleEvent` shares no variants with the deposit or withdraw unions, so don't reuse a handler across them.

--- a/deposits/widget/claim-modal.mdx
+++ b/deposits/widget/claim-modal.mdx
@@ -31,6 +31,7 @@ import "@rhinestone/deposit-modal/styles.css";
   isOpen={isOpen}
   onClose={() => setIsOpen(false)}
   refundEndpoint="/api/refund"
+  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL}
 />
 ```
 
@@ -51,6 +52,7 @@ import "@rhinestone/deposit-modal/styles.css";
   isOpen={isOpen}
   onClose={() => setIsOpen(false)}
   refundEndpoint="https://proxy.example.com/deposits/refund"
+  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL}
   getUserToken={async (request) => {
     const res = await fetch("/api/refund-token", {
       method: "POST",
@@ -83,7 +85,7 @@ export const POST = createRefundHandler({
   apiKey: process.env.RHINESTONE_API_KEY!,
   async authorize(request) {
     const session = await getSession(request);
-    return session ? { recipient: session.depositRecipient } : null;
+    return session ? { depositRecipient: session.depositRecipient } : null;
   },
 });
 ```
@@ -97,14 +99,16 @@ never reach the browser.
 
 ### authorize
 
-Return the recipient the caller owns, or `null` to reject with 401.
+Return the deposit recipient the caller owns, or `null` to reject with 401.
 
 | Field | Type | Description |
 |---|---|---|
-| `recipient` | `string` | The in-app recipient this user owns — the same value you pass the deposit modal. The deposit is checked against it |
-| `destination` | `string` | Optional. Overrides the destination the browser asked for |
+| `depositRecipient` | `string` | The deposit `recipient` this user owns — the same value you pass `<DepositModal>`. Used **only** to prove the deposit is theirs |
+| `refundDestination` | `string` | Optional. Where the refund is paid, overriding whatever the browser asked for |
 
-Set `destination` whenever you already know where the user's money should go. Without it the page picks, and it could pick anything.
+`depositRecipient` does not decide where money goes. The handler lists deposits settling to it and rejects a `txHash` that isn't among them — that's the whole job. One value covers every deposit account the user has, since the account salt includes the target chain and token.
+
+Set `refundDestination` whenever you already know where the user's money should go. Without it the page picks, and it could pick anything.
 
 <Warning>
 Never refund to an exchange deposit address. Exchanges don't credit arbitrary
@@ -133,6 +137,7 @@ The modal POSTs a `RefundRequest`. It comes from the page, so treat it as untrus
 | `isOpen` | `boolean` | Controls modal visibility |
 | `onClose` | `() => void` | Called when the user closes the modal |
 | `refundEndpoint` | `string` | Endpoint the modal POSTs the refund to |
+| `backendUrl` | `string` | Your [backend proxy](/deposits/widget/backend), which holds your API key |
 
 ### Authorization
 
@@ -145,13 +150,12 @@ The modal POSTs a `RefundRequest`. It comes from the page, so treat it as untrus
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `defaultTxHash` | `string` | — | Prefills the lookup field |
-| `defaultRecipient` | `Address` | — | Prefills the refund destination. Otherwise left empty |
+| `defaultRefundDestination` | `Address` | — | Prefills the refund destination — a seed the user can edit, unlike `refundDestination`. Otherwise left empty |
 
 ### Backend
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `backendUrl` | `string` | — | Your [backend proxy](/deposits/widget/backend). Treat as required — the default is Rhinestone-internal |
 | `rpcUrls` | `RpcUrlMap` | Chain defaults | Per-chain RPC overrides keyed by EVM chain id |
 
 ### Display

--- a/deposits/widget/customization.mdx
+++ b/deposits/widget/customization.mdx
@@ -63,4 +63,10 @@ Toggle UI elements, set deposit constraints, and control fee display via `uiConf
 | `maxDepositUsd` | `number` | — | Maximum deposit amount in USD |
 | `feeSponsored` | `boolean` | `false` | When `true`, the network/protocol fee renders struck-through on the review, processing, and result screens, with a tooltip explaining the sponsorship |
 | `feeTooltip` | `string` | — | Custom copy for the fee info tooltip. Defaults to a generic message based on `feeSponsored`. |
-| `checkLiquidity` | `boolean` | `false` | When `true`, runs an orchestrator liquidity check as the user continues from the amount step and surfaces an "unavailable / check failed" warning on the review screen. Does not block the deposit |
+
+<Note>
+`checkLiquidity` was removed in v0.9.0. It cost an orchestrator round trip per
+continue to compute a warning the review screen never rendered. The liquidity cap
+is still checked and shown where it matters — on the QR / transfer screen. See
+[migration](/deposits/widget/migration).
+</Note>

--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -35,6 +35,7 @@ import "@rhinestone/deposit-modal/styles.css";
   targetChain={8453}
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
+  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL}
   reownAppId="YOUR_REOWN_PROJECT_ID"
   onLifecycle={(event) => event.type === "complete" && console.log(event)}
 />
@@ -56,6 +57,7 @@ import "@rhinestone/deposit-modal/styles.css";
   targetChain={8453}
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
+  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL}
   walletClient={walletClient}
   publicClient={publicClient}
   onLifecycle={(event) => event.type === "complete" && console.log(event)}
@@ -86,6 +88,7 @@ import "@rhinestone/deposit-modal/styles.css";
   targetChain={8453}
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
+  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL}
   enableQrTransfer
   onLifecycle={(event) => event.type === "complete" && console.log(event)}
 />
@@ -318,6 +321,7 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 | `targetChain` | `Chain \| number \| "solana"` | Destination chain (viem `Chain` object, chain ID, or `"solana"`) |
 | `targetToken` | `Address \| string` | Token address on the destination chain |
 | `recipient` | `Address \| string` | Where funds are delivered on the target chain |
+| `backendUrl` | `string` | Your [backend proxy](/deposits/widget/backend), which holds your API key |
 
 ### Wallet
 
@@ -362,7 +366,6 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `backendUrl` | `string` | — | Your [backend proxy](/deposits/widget/backend). Treat as required — the default is Rhinestone-internal |
 | `rpcUrls` | `RpcUrlMap` | — | Per-chain RPC overrides keyed by EVM chain id or the literal `"solana"` key (e.g. `{ 8453: "https://…", solana: "https://…" }`). Applied to EVM public clients, the connected wallet, HyperEVM, and the Solana connection; chains left unset use their default RPC |
 
 ### Display

--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -3,24 +3,27 @@ title: "Deposit modal"
 description: "Configure the deposit modal for different wallet connection modes and deposit flows."
 ---
 
-The `DepositModal` component handles the full deposit flow: wallet connection, source chain and token selection, amount input, and cross-chain bridging. It supports three wallet integration modes depending on how your app manages wallets.
+The `DepositModal` component handles the full deposit flow: funding method, source chain and token selection, amount input, and cross-chain bridging.
 
-## recipient vs dappAddress
+## Where the funds go
 
-Two props look similar but serve different purposes:
+`recipient` (required) is the address that receives the bridged funds on the target chain.
 
-- **`recipient`** (required) — the address that receives the bridged funds on the target chain. This is a pure delivery target.
-- **`dappAddress`** (embedded wallet & QR modes) — the address that owns the deposit. The modal uses it to derive the smart account and, by default, as the delivery target. It is the user's identity in the flow, not a destination.
+The deposit account is [service-managed](#account-setup) and derived from `(recipient, targetChain, targetToken)`, so it doesn't depend on which wallet the user pays from — or on a wallet existing at all. Changing the target changes the deposit address.
 
-In external wallet mode, the connected wallet is the owner, so only `recipient` is needed. In embedded and QR modes, you must pass `dappAddress` because the modal has no other way to know who owns the deposit.
+<Note>
+Before v0.9.0 the account was derived from the connected wallet, and a `dappAddress`
+prop carried the user's identity through the flow. Both are gone — see
+[migration](/deposits/widget/migration).
+</Note>
 
-## Integration modes
+## Connecting a wallet
 
-### External wallet
+Three options. The wallet is optional in all of them.
 
-The user connects their own wallet via Reown (WalletConnect). The modal manages the wallet connection UI internally. Use this when your app doesn't have existing wallet infrastructure.
+### The modal connects one
 
-Pass a `reownAppId` to enable external wallet connection.
+The user connects their own wallet via Reown (WalletConnect). The modal manages the connection UI internally. Use this when your app has no wallet infrastructure of its own.
 
 ```tsx
 import { DepositModal } from "@rhinestone/deposit-modal";
@@ -37,33 +40,11 @@ import "@rhinestone/deposit-modal/styles.css";
 />
 ```
 
-### Embedded wallet
+### You supply one
 
-Your app manages the wallet (e.g. via Privy, Dynamic, or Turnkey) and passes the owner address to the modal. The modal skips its own wallet connection UI and uses your app's wallet context.
+Your app already has a wallet connected (via Privy, Dynamic, Turnkey, wagmi, or anything else). Pass its viem `walletClient` and the modal reuses that session instead of opening its own connect step.
 
-Pass `dappAddress` with the wallet owner address, and `onRequestConnect` to trigger your app's login flow when the modal needs a connected wallet.
-
-```tsx
-import { DepositModal } from "@rhinestone/deposit-modal";
-import "@rhinestone/deposit-modal/styles.css";
-
-<DepositModal
-  isOpen={isOpen}
-  onClose={() => setIsOpen(false)}
-  targetChain={8453}
-  targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-  recipient="0xYOUR_RECIPIENT_ADDRESS"
-  dappAddress={embeddedWalletAddress}
-  onRequestConnect={() => login()}
-  onLifecycle={(event) => event.type === "complete" && console.log(event)}
-/>
-```
-
-### QR code deposit
-
-The modal displays a deposit address and QR code. The user sends funds from any wallet externally — no wallet connection is required inside the modal.
-
-Pass `dappAddress` without `onRequestConnect` or `reownAppId`.
+The modal reads the address off `walletClient.account`, so it cannot disagree with what your app thinks the user is connected as.
 
 ```tsx
 import { DepositModal } from "@rhinestone/deposit-modal";
@@ -75,10 +56,74 @@ import "@rhinestone/deposit-modal/styles.css";
   targetChain={8453}
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
-  dappAddress={ownerAddress}
+  walletClient={walletClient}
+  publicClient={publicClient}
   onLifecycle={(event) => event.type === "complete" && console.log(event)}
 />
 ```
+
+Pass `onRequestConnect` as well if your app needs to run a login flow when the user picks the wallet row before one is connected.
+
+To disconnect a wallet the modal connected, call the exported `disconnectWallet()`. It no-ops with a warning if `@reown/appkit` isn't installed.
+
+<Tip>
+`walletClient={undefined}` is not the same as omitting the prop. Passing it while your
+wallet connects tells the modal one is coming, so it waits instead of deciding there
+is none.
+</Tip>
+
+### No wallet at all
+
+QR transfer, the fiat on-ramp and exchange connect need no wallet. Supply neither `walletClient` nor `reownAppId` and the modal opens straight into whichever [funding methods](#funding-methods) you enabled.
+
+```tsx
+import { DepositModal } from "@rhinestone/deposit-modal";
+import "@rhinestone/deposit-modal/styles.css";
+
+<DepositModal
+  isOpen={isOpen}
+  onClose={() => setIsOpen(false)}
+  targetChain={8453}
+  targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  recipient="0xYOUR_RECIPIENT_ADDRESS"
+  enableQrTransfer
+  onLifecycle={(event) => event.type === "complete" && console.log(event)}
+/>
+```
+
+## Funding methods
+
+Each method is a row on the modal's home screen. When exactly one is enabled there is nothing to choose, and the modal opens directly into it.
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `enableWallet` | `boolean` | `true` | Offer the connected wallet as a source. Turn off for a flow with no wallet even when a `walletClient` or `reownAppId` is supplied |
+| `enableQrTransfer` | `boolean` | `true` | Offer the "Transfer crypto" row — a deposit address and QR code the user sends to from anywhere |
+| `enableFiatOnramp` | `boolean` | `false` | Offer card / bank / Apple Pay payment via Swapped's embedded iframe |
+| `fiatMethods` | `FiatMethodsConfig` | all | Restrict which Swapped payment groups the on-ramp offers |
+| `enableExchangeConnect` | `boolean` | `false` | Offer "Connect exchange" — the user picks their CEX inside Swapped's iframe and withdraws from it |
+| `assetMigrations` | `AssetMigrationsConfig` | none | Offer [migrating balances](#migrate-assets-from-other-apps) the user already holds in a supported third-party app |
+
+`enableFiatOnramp` and `enableExchangeConnect` require Swapped keys on your backend.
+
+### Restricting fiat payment methods
+
+`fiatMethods` is a boolean map keyed by Swapped `payment_group`. Omit it to offer all of them, which also tracks Swapped's lineup without you redeploying.
+
+```tsx
+<DepositModal
+  // ...required props
+  enableFiatOnramp
+  fiatMethods={{ creditcard: true, "apple-pay": true }}
+/>
+```
+
+Valid keys are `creditcard`, `bank-transfer`, and `apple-pay`. Enabling one does not advertise the others.
+
+<Warning>
+An empty or all-false `fiatMethods` offers **no** payment methods, not all of them.
+To offer everything, omit the prop.
+</Warning>
 
 ## Transfer configuration
 
@@ -92,14 +137,31 @@ Control the deposit destination and optionally pre-fill source parameters.
 | `defaultAmount` | `string` | No | Pre-filled deposit amount. A USD number string (e.g. `"25"`) or the sentinel `"max"` to fill the full available balance. |
 | `sourceChain` | `Chain \| number` | No | Pre-selected source chain |
 | `sourceToken` | `Address` | No | Pre-selected source token |
-| `allowedRoutes` | `RouteConfig` | No | Restrict available source chains and tokens |
 | `outputTokenRules` | `OutputTokenRule[]` | No | Route the deposit to a different final token based on what the user deposited |
 | `rejectUnmapped` | `boolean` | No | Reject deposits that don't match any routing rule instead of falling back to `targetToken` |
 | `appBalanceUsd` | `number` | No | The user's current in-app balance (USD). When set, the amount screen shows a "Balance after deposit" row (`appBalanceUsd + amount`). |
 
-The `allowedRoutes` prop accepts `{ sourceChains?: number[], sourceTokens?: string[] }` to limit what the user can select. For supported chains and tokens, see [supported chains](/deposits/overview#supported-chains-and-tokens).
+For supported chains and tokens, see [supported chains](/deposits/overview#supported-chains-and-tokens).
 
-## Session configuration
+### HyperCore destinations
+
+HyperCore is `targetChain: 1337` (exported as `HYPERCORE_CHAIN_ID`), accepts USDC only, and **requires an EOA `recipient`**. The modal pre-screens the recipient on HyperEVM and shows an error if it's a contract; the orchestrator rejects it regardless, so a smart-account recipient cannot work here.
+
+The check fails open — an RPC error lets the flow continue rather than false-blocking a valid EOA.
+
+### Restricting which sources you accept
+
+Which chains and tokens you accept is your project's **deposit whitelist**, set via `POST /setup` and enforced by the processor when a deposit arrives. Configure it there rather than in the modal.
+
+<Note>
+The `allowedRoutes` prop was removed in v0.9.0. It filtered the pickers on the
+client only, with no enforcement behind it — so a whitelist and an `allowedRoutes`
+list that drifted apart would offer the user a source the processor then rejected.
+To offer a restricted subset, use an API key whose whitelist matches. See
+[migration](/deposits/widget/migration).
+</Note>
+
+## Account setup
 
 From v0.9.0 the modal uses **service-managed accounts**: the deposit account is
 owned by Rhinestone and settles to your `recipient`, so there is no session key
@@ -133,49 +195,59 @@ Deliver a different final token depending on what the user deposits. Pass `outpu
 
 When several rules match the same deposit, the most specific one wins: `chain + token` outranks `chain + symbol`, which outranks `token`, then `symbol`, then `chain` alone. See [token routing](/deposits/api/account-registration#optional-token-routing) for the full rule semantics, priority order, and additional examples.
 
-## Import from other apps
+## Migrate assets from other apps
 
 The modal can pull balances a user already holds in a supported third-party app
-and fund the deposit from there — no manual transfer first. Each source is
-**off by default**; opt in per source via `dappImports`.
+and fund the deposit from there — no manual transfer first. Each provider is
+**off by default**; opt in per provider via `assetMigrations`.
 
 ```tsx
 <DepositModal
   // ...required props
-  dappImports={{ polymarket: true }}
+  assetMigrations={{ polymarket: true }}
 />
 ```
 
-When enabled and the connected wallet has a balance in that app, a new row
-(e.g. "Transfer from Polymarket") appears on the deposit entry screen. The
-user picks it, and the modal pulls the funds into their smart account and
-bridges them to `targetChain` / `targetToken` like any other source.
+When at least one provider is enabled, a **Migrate assets** row appears on the
+deposit entry screen and opens a picker over that provider's positions. The user
+picks one, and the modal pulls the funds into their smart account and bridges
+them to `targetChain` / `targetToken` like any other source.
+
+| Key | Status |
+|---|---|
+| `polymarket` | Live |
+| `hyperliquid` | Coming soon |
+| `aave` | Coming soon |
+| `morpho` | Coming soon |
+
+Only the providers you enable are listed. Enabling one that isn't live yet shows it
+as a disabled "Coming soon" row rather than hiding it.
 
 ### Polymarket
 
-Set `dappImports={{ polymarket: true }}`. The modal looks up the connected
+Set `assetMigrations={{ polymarket: true }}`. The modal looks up the connected
 EOA's Polymarket proxy wallet on Polygon and surfaces any pUSD or USDC.e
 balance. pUSD is unwrapped to USDC.e on the way out; USDC.e is what lands in the
 smart account and what the orchestrator bridges from.
 
 Polymarket exposes two wallet types and the modal handles both: some transfer
 on-chain directly from the user's signed transaction, while others are relayed
-through your configured [`backendUrl`](#backend). The default Rhinestone
-backend handles both with no extra setup.
+through your [backend proxy](/deposits/widget/backend), which must forward
+`POST /polymarket/withdraw`.
 
 #### Open directly into Polymarket
 
 To skip the deposit-method home screen and land the user straight on the
-Polymarket transfer, pass `initialDappImport="polymarket"` alongside
-`dappImports={{ polymarket: true }}`. While balances load the modal shows a
+Polymarket transfer, pass `initialAssetMigration="polymarket"` alongside
+`assetMigrations={{ polymarket: true }}`. While balances load the modal shows a
 skeleton; if there's no account, no balance, or no connected wallet it falls
 back to the home screen.
 
 ```tsx
 <DepositModal
   // ...required props
-  dappImports={{ polymarket: true }}
-  initialDappImport="polymarket"
+  assetMigrations={{ polymarket: true }}
+  initialAssetMigration="polymarket"
 />
 ```
 
@@ -205,98 +277,20 @@ Returns `null` only when the EOA has no Polymarket account. A transient failure
 account". Pass `rpcUrl` to override the default public Polygon RPC, or a
 `signal` (`AbortSignal`) to cancel the lookup.
 
-## Self-hosted backend
+## Package entry points
 
-The modal talks to a deposit-widget backend, which holds your Rhinestone API key
-and proxies requests to the deposit processor. `backendUrl` defaults to the
-Rhinestone-hosted instance; point it at your own deployment to keep user traffic
-on your infrastructure.
+Everything is on the root entry; the subpaths exist so you only bundle what you use.
 
-### Required routes
-
-Your proxy must forward every route the modal calls, attaching your
-`x-api-key` to the upstream request. Missing a route doesn't degrade the
-flow — the request 404s and that part of the modal stops working.
-
-| Method | Route | Used for |
-|---|---|---|
-| `POST` | `/register-managed` | Registering the deposit account. **Required from modal v0.9.0** |
-| `POST` | `/quotes/preview` | Indicative fee/time quote on the review screen |
-| `GET` | `/check/:address` | Registration + target lookup |
-| `GET` | `/portfolio/:address` | EVM balances |
-| `GET` | `/portfolio/solana/:address` | Solana balances |
-| `GET` | `/deposits` | Deposit status + history |
-| `GET` | `/liquidity` | Route liquidity check |
-| `GET` | `/prices` | USD pricing |
-| `GET` | `/setup` | Your client config (source-token allowlist, minimums) |
-| `GET` | `/tokens` | Static top-tokens list for the QR flow |
-| `POST` | `/safe/withdraw` | Relaying a signed Safe transfer with sponsored gas. **Not used by the modal from v0.9.0** — proxy it only if your own [`onSendTransaction`](/deposits/widget/withdraw-modal#executing-the-transfer) relays through it |
-| `POST` | `/polymarket/withdraw` | Polymarket withdrawals |
-| `POST` | `/onramp/swapped/widget-url` | Fiat on-ramp |
-| `POST` | `/onramp/swapped/connect-url` | Exchange connect |
-| `GET` | `/onramp/swapped/connect-exchanges` | Exchange list |
-| `GET` | `/onramp/swapped/status/:smartAccount` | On-ramp order status |
-
-<Warning>
-**Upgrading to modal v0.9.0** — v0.9.0 moves to service-managed accounts and
-registers through `POST /register-managed` instead of `POST /setup-account` +
-`POST /register`. Deploy a proxy that forwards it **before** shipping the new
-modal, or registration 404s and deposits cannot start. Keep the old two routes
-while any earlier modal version is still in use.
-</Warning>
-
-Only `GET /setup` is proxied, never `POST /setup` — that is an admin write
-(it rotates the webhook secret and sponsorship config) and must not be
-reachable from a browser.
-
-### Version header pass-through
-
-Every request the modal makes carries its own package version:
-
-```http
-x-deposit-modal-version: 0.9.0
-```
-
-Rhinestone uses this to see which modal versions are live, so we can warn you
-about a version with a known bug and reproduce issues against the build you are
-actually running.
-
-Rhinestone's deposit-widget-backend handles both steps below for you. A custom
-proxy needs to apply them itself.
-
-**Allow the header (required).** Add it to your CORS allow-list. Browsers reject
-a request carrying a header the server did not allow on the preflight, so the
-modal cannot talk to a proxy that omits this:
-
-```ts
-allowHeaders: ["Content-Type", "x-api-key", "x-deposit-modal-version"]
-```
-
-**Forward it upstream (optional).** Copy it onto the request you make to the
-deposit processor:
-
-```ts
-const upstreamHeaders: Record<string, string> = {
-  "Content-Type": "application/json",
-  "x-api-key": process.env.RHINESTONE_API_KEY!,
-};
-
-const modalVersion = request.headers.get("x-deposit-modal-version");
-if (modalVersion) {
-  upstreamHeaders["x-deposit-modal-version"] = modalVersion;
-}
-```
-
-Skipping the forward breaks nothing — deposits work exactly the same, your
-traffic just shows up as an unknown modal version on our side.
-
-The same header is sent by the withdraw and claim modals, since all three share
-one backend client. To read the value in your own app (for a bug report, say),
-import it:
-
-```ts
-import { MODAL_VERSION } from "@rhinestone/deposit-modal/constants";
-```
+| Import | Contains |
+|---|---|
+| `@rhinestone/deposit-modal` | All three modals, types, chain and token helpers |
+| `@rhinestone/deposit-modal/deposit` | `DepositModal` and its types |
+| `@rhinestone/deposit-modal/withdraw` | `WithdrawModal` and its types |
+| `@rhinestone/deposit-modal/claim` | [`ClaimModal`](/deposits/widget/claim-modal) and its types |
+| `@rhinestone/deposit-modal/server` | `createRefundHandler`. **Server-only** — holds your API key |
+| `@rhinestone/deposit-modal/constants` | `MODAL_VERSION`, chain registry, token and explorer helpers |
+| `@rhinestone/deposit-modal/polymarket` | [`getPolymarketAccount`](#headless-account-lookup), headless |
+| `@rhinestone/deposit-modal/styles.css` | Stylesheet, required |
 
 ## Display modes
 
@@ -329,10 +323,10 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `reownAppId` | `string` | — | Reown project ID. Enables external wallet connection. |
-| `dappAddress` | `Address` | — | Owner address for embedded wallet or QR code flows |
-| `dappWalletClient` | `WalletClient` | — | Host-provided viem wallet client for signing |
-| `dappPublicClient` | `PublicClient` | — | Host-provided viem public client |
+| `reownAppId` | `string` | — | Reown project ID. Lets the modal connect a wallet itself. |
+| `walletClient` | `WalletClient \| null` | — | A wallet your app already has connected. The modal reuses the session and reads the address off `.account` |
+| `publicClient` | `PublicClient \| null` | — | Read client paired with `walletClient`. Defaults to the modal's own |
+| `enableWallet` | `boolean` | `true` | Offer the connected wallet as a funding source at all |
 | `onRequestConnect` | `() => void` | — | Called when the modal needs the user to connect a wallet |
 
 ### Transfer
@@ -343,24 +337,32 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 | `sourceChain` | `Chain \| number` | — | Pre-selected source chain |
 | `sourceToken` | `Address` | — | Pre-selected source token |
 | `appBalanceUsd` | `number` | — | In-app USD balance; enables the "Balance after deposit" row |
-| `allowedRoutes` | `RouteConfig` | — | `{ sourceChains?, sourceTokens? }` to restrict selection |
 | `outputTokenRules` | `OutputTokenRule[]` | — | Per-deposit output token routing rules |
 | `rejectUnmapped` | `boolean` | `false` | Reject deposits that don't match any `outputTokenRules` entry |
-| `dappImports` | `DappImportsConfig` | — | [Import balances](#import-from-other-apps) from third-party apps (e.g. `{ polymarket: true }`) |
-| `initialDappImport` | `keyof DappImportsConfig` | — | Open the modal pre-routed into a dapp import (e.g. `"polymarket"`), skipping the home screen. Must name an enabled `dappImports` key. |
+
+### Funding
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `enableWallet` | `boolean` | `true` | [Offer the connected wallet](#funding-methods) as a source |
+| `enableQrTransfer` | `boolean` | `true` | Offer the "Transfer crypto" deposit-address / QR row |
+| `enableFiatOnramp` | `boolean` | `false` | Offer fiat payment via Swapped's iframe. Requires backend Swapped keys |
+| `fiatMethods` | `FiatMethodsConfig` | all | [Restrict payment groups](#restricting-fiat-payment-methods) — `{ creditcard?, "bank-transfer"?, "apple-pay"? }`. Empty means none |
+| `enableExchangeConnect` | `boolean` | `false` | Offer "Connect exchange". Requires backend Swapped keys |
+| `assetMigrations` | `AssetMigrationsConfig` | — | [Migrate balances](#migrate-assets-from-other-apps) from third-party apps (e.g. `{ polymarket: true }`) |
+| `initialAssetMigration` | `keyof AssetMigrationsConfig` | — | Open the modal pre-routed into a migration provider (e.g. `"polymarket"`), skipping the home screen. Must name an enabled `assetMigrations` key. |
 
 ### Account
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `forceRegister` | `boolean` | `false` | Re-register even if the account already exists |
-| `rhinestoneApiKey` | `string` | — | API key for account setup |
 
 ### Backend
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `backendUrl` | `string` | Rhinestone production URL | URL of your deposit-widget-backend instance. Self-hosting a custom proxy? See [version header pass-through](#version-header-pass-through) |
+| `backendUrl` | `string` | — | Your [backend proxy](/deposits/widget/backend). Treat as required — the default is Rhinestone-internal |
 | `rpcUrls` | `RpcUrlMap` | — | Per-chain RPC overrides keyed by EVM chain id or the literal `"solana"` key (e.g. `{ 8453: "https://…", solana: "https://…" }`). Applied to EVM public clients, the connected wallet, HyperEVM, and the Solana connection; chains left unset use their default RPC |
 
 ### Display
@@ -385,8 +387,27 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 
 See [status tracking](/deposits/widget/status-tracking) for lifecycle event payloads.
 
-### Solana
+<Note>
+`enableSolana` was removed in v0.9.0. Solana sources follow your project's deposit
+whitelist like every other source, so there is no separate client-side toggle.
+</Note>
 
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `enableSolana` | `boolean` | `true` | Enable Solana wallet support and QR flows |
+## Content security policy
+
+The modal loads chain, token and exchange logos from Rhinestone's asset CDN. **If your app sets an explicit `img-src` policy, it must allow the CDN:**
+
+```
+img-src 'self' data: https://s3.rhinestone.dev;
+```
+
+<Warning>
+A blocked image fails **silently** — the icon renders blank with no console error
+naming the policy, so this is easy to misread as a modal bug. Apps with no explicit
+`img-src` (or `img-src *`) need no change.
+</Warning>
+
+If you enable the [fiat on-ramp or exchange connect](#funding-methods), the modal embeds Swapped's widget in an iframe, which needs `frame-src`:
+
+```
+frame-src https://widget.swapped.com https://sandbox.swapped.com https://connect.swapped.com;
+```

--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -105,6 +105,25 @@ checked and shown on the QR / transfer screen.
 belongs on your [backend proxy](/deposits/widget/backend), which attaches it upstream.
 Delete it; nothing consumed it.
 
+**`backendUrl` is now required** on all three modals, and the `DEFAULT_BACKEND_URL`
+export is gone. The old default pointed at a Rhinestone-internal service running on
+**our** API key, so any integration that omitted the prop was silently routing its
+users' deposits through it.
+
+```diff
+  <DepositModal
+    targetChain={8453}
+    targetToken={USDC}
+    recipient={userAddress}
++   backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL}
+  />
+```
+
+If you already set `backendUrl`, nothing changes. If you didn't, you were on our key
+and need a [proxy](/deposits/widget/backend) before upgrading. TypeScript flags the
+omission; each modal also logs a `console.error` when the value is missing, empty or
+whitespace, since `backendUrl={process.env.X ?? ""}` typechecks fine.
+
 **`fiatOnrampMethods` becomes `fiatMethods`**, a boolean map keyed by Swapped
 `payment_group` instead of a list of row descriptors:
 

--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -1,18 +1,26 @@
 ---
 title: "Migration guide"
-description: "Upgrade @rhinestone/deposit-modal to v0.9.0, and from v0.1.x / v0.2.x to v0.3.0."
+description: "Upgrade @rhinestone/deposit-modal to v0.9.0 — managed accounts, the withdraw callback, and renamed props. Plus v0.1.x / v0.2.x to v0.3.0."
 ---
 
 ## v0.8.x → v0.9.0
 
-v0.9.0 moves both modals onto service-managed accounts and hands the withdrawal
-transfer to your app.
+v0.9.0 moves both modals onto service-managed accounts, hands the withdrawal
+transfer to your app, and renames or removes props that no longer described what
+they did. The account and withdraw changes need code; the
+[prop renames](#renamed-and-removed-props) are mechanical.
+
+<Warning>
+If you run your own proxy, deploy `POST /register-managed` **before** shipping the
+new modal. Registration 404s without it, which means no deposit address and no QR
+code — the flow does not degrade, it stops.
+</Warning>
 
 **Both modals** — the `signerAddress` and `sessionChainIds` props are gone,
 along with the `DEFAULT_SIGNER_ADDRESS`, `EnableSessionDetails`, and
 `AccountInitData` exports. Registration now goes through
 `POST /register-managed`, which a self-hosted proxy **must** forward before you
-ship — see [required routes](/deposits/widget/deposit-modal#required-routes).
+ship — see [required routes](/deposits/widget/backend#required-routes).
 There is no session key and no signature prompt during setup.
 
 **`<WithdrawModal>`** no longer moves funds. It previously built and submitted a
@@ -45,9 +53,117 @@ Also on `<WithdrawModal>`: `onRequestConnect` is removed (the modal needs no
 wallet, so there is no connect step — it opens on the withdraw form), the
 `SafeTransactionRequest` export is replaced by `WithdrawTransferRequest`, and
 the `"submitted"` lifecycle event renames `safeAddress` to `accountAddress`.
-`<DepositModal>` keeps all of its wallet props.
 
 `POST /safe/withdraw` still exists — the modal simply stopped calling it.
+
+### Renamed and removed props
+
+Renames, plus the removal of config the server already owns. Nothing here changes
+what the modal can do.
+
+| Before | After |
+| --- | --- |
+| `dappWalletClient` | `walletClient` |
+| `dappPublicClient` | `publicClient` |
+| `dappImports` | `assetMigrations` |
+| `initialDappImport` | `initialAssetMigration` |
+| `fiatOnrampMethods` | `fiatMethods` |
+| `DappImportsConfig` (type) | `AssetMigrationsConfig` |
+
+```diff
+  <DepositModal
+-   dappWalletClient={walletClient}
+-   dappPublicClient={publicClient}
+-   dappAddress={userAddress}
++   walletClient={walletClient}
++   publicClient={publicClient}
+-   dappImports={{ polymarket: true }}
+-   initialDappImport="polymarket"
++   assetMigrations={{ polymarket: true }}
++   initialAssetMigration="polymarket"
+  />
+```
+
+**`dappAddress` is removed with no replacement.** The modal reads the address off
+`walletClient.account`, which nothing previously validated it against — so the modal
+could read balances for one address while the user was connected as another.
+
+**`allowedRoutes` and the `RouteConfig` type are removed** from both modals. They
+filtered the pickers client-side with nothing enforcing it, so a list that drifted
+from your deposit whitelist offered the user a source the processor then rejected.
+Set the whitelist via `POST /setup`; to offer a restricted subset, use an API key
+whose whitelist matches.
+
+**`enableSolana` is removed** for the same reason — Solana sources follow the deposit
+whitelist.
+
+**`uiConfig.checkLiquidity` is removed.** It cost an orchestrator round trip per
+continue to compute a warning the review screen never rendered. The cap is still
+checked and shown on the QR / transfer screen.
+
+**`rhinestoneApiKey` is removed** from both modals. It was never read — the key
+belongs on your [backend proxy](/deposits/widget/backend), which attaches it upstream.
+Delete it; nothing consumed it.
+
+**`fiatOnrampMethods` becomes `fiatMethods`**, a boolean map keyed by Swapped
+`payment_group` instead of a list of row descriptors:
+
+```diff
+  <DepositModal
+    enableFiatOnramp
+-   fiatOnrampMethods={[
+-     { method: "creditcard", label: "Debit/Credit card", sublabel: "Instant - $10,000 limit", icon: "card" },
+-   ]}
++   fiatMethods={{ creditcard: true }}
+  />
+```
+
+The old prop made you supply each row's `label`, `sublabel` and `icon`, which meant
+pasting our copy and freezing a claim like `"Instant - $10,000 limit"` into your
+bundle.
+
+<Warning>
+`fiatOnrampMethods={[]}` used to fall through to offering **every** payment method.
+An empty or all-false `fiatMethods` now offers none. If you computed the list
+dynamically and could produce an empty one, check which you wanted.
+</Warning>
+
+### Optional where it was mandatory
+
+`<WithdrawModal>`'s `targetChain` and `targetToken` are now optional. They only ever
+seeded the form — the user can pick any supported destination — so omitting them
+opens on a same-chain, same-token withdrawal.
+
+`@reown/appkit` and `@reown/appkit-adapter-wagmi` are now **optional** peer
+dependencies. An app that passes its own `walletClient` never opens AppKit and no
+longer needs it installed. See [install](/deposits/widget/quickstart#install).
+
+### New
+
+- **`enableWallet?: boolean`** (default `true`) on `<DepositModal>` — turn off to
+  present a flow with no wallet even when a `walletClient` or `reownAppId` is supplied.
+- **[`<ClaimModal>`](/deposits/widget/claim-modal)** and the `./claim` subpath — a user
+  pastes a failed or rejected deposit's transaction hash and gets the funds returned.
+  Also adds `@rhinestone/deposit-modal/server` for the endpoint that authorizes it.
+
+### Behavior changes worth checking
+
+- **`connected` no longer fires for flows with no wallet** (QR, fiat, exchange). It
+  previously reported the declared address as though a wallet had connected. If you
+  used it as a "flow started" signal, switch to `onReady`.
+- **A QR-only integration no longer auto-locks to the wallet.** The connect step's
+  auto-skip never accounted for `enableQrTransfer` or asset migrations, so it could
+  skip past the only funding option you had enabled.
+- **Logos load from Rhinestone's asset CDN.** Apps with an explicit `img-src` CSP must
+  allow `https://s3.rhinestone.dev` — a blocked image fails silently. See
+  [content security policy](/deposits/widget/deposit-modal#content-security-policy).
+
+### Removed prop warnings
+
+Both modals log a `console.error` naming the replacement when passed any prop removed
+in this release. TypeScript already catches these; the runtime warning is for plain
+JavaScript hosts, spread props, and loosely typed call sites, where several of the
+removals fail silently rather than visibly.
 
 ---
 
@@ -208,7 +324,8 @@ New in v0.3.0; existing code keeps working:
   deposit" row (`appBalanceUsd + amount`) instead of fetching a portfolio
   balance.
 - **`dappImports?: DappImportsConfig`** on `<DepositModal>` — pull balances from
-  third-party apps. See [import from other apps](/deposits/widget/deposit-modal#import-from-other-apps).
+  third-party apps. Renamed to `assetMigrations` in v0.9.0; see
+  [migrate assets from other apps](/deposits/widget/deposit-modal#migrate-assets-from-other-apps).
 - **`defaultAmount: "max"`** — defaults the input to the user's full
   source-token balance.
 - **Solana destinations** — `targetChain: Chain | number | "solana"`,
@@ -224,8 +341,10 @@ New in v0.3.0; existing code keeps working:
 keep their names and signatures.
 
 <Note>
-Scoped to v0.3.0. v0.9.0 later removed `onRequestConnect`, `dappWalletClient`,
-`dappPublicClient`, and `reownAppId` from `<WithdrawModal>` and replaced
-`onSignTransaction` with `onSendTransaction` — see the v0.9.0 section at the top
-of this page. `<DepositModal>` still has all of them.
+Scoped to v0.3.0 — several of these changed again in v0.9.0. On `<WithdrawModal>`,
+`onRequestConnect`, `dappWalletClient`, `dappPublicClient` and `reownAppId` were
+removed and `onSignTransaction` became `onSendTransaction`. On `<DepositModal>`,
+`dappWalletClient` / `dappPublicClient` were renamed to `walletClient` /
+`publicClient`; `reownAppId`, `onRequestConnect` and the styles export are unchanged.
+See the v0.9.0 section at the top of this page.
 </Note>

--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -343,8 +343,7 @@ New in v0.3.0; existing code keeps working:
   deposit" row (`appBalanceUsd + amount`) instead of fetching a portfolio
   balance.
 - **`dappImports?: DappImportsConfig`** on `<DepositModal>` — pull balances from
-  third-party apps. Renamed to `assetMigrations` in v0.9.0; see
-  [migrate assets from other apps](/deposits/widget/deposit-modal#migrate-assets-from-other-apps).
+  third-party apps. See [migrating assets](/deposits/widget/deposit-modal#migrate-assets-from-other-apps).
 - **`defaultAmount: "max"`** — defaults the input to the user's full
   source-token balance.
 - **Solana destinations** — `targetChain: Chain | number | "solana"`,
@@ -360,10 +359,6 @@ New in v0.3.0; existing code keeps working:
 keep their names and signatures.
 
 <Note>
-Scoped to v0.3.0 — several of these changed again in v0.9.0. On `<WithdrawModal>`,
-`onRequestConnect`, `dappWalletClient`, `dappPublicClient` and `reownAppId` were
-removed and `onSignTransaction` became `onSendTransaction`. On `<DepositModal>`,
-`dappWalletClient` / `dappPublicClient` were renamed to `walletClient` /
-`publicClient`; `reownAppId`, `onRequestConnect` and the styles export are unchanged.
-See the v0.9.0 section at the top of this page.
+Scoped to v0.3.0. Several of these changed again in v0.9.0 — see the v0.8.x → v0.9.0
+section at the top of this page.
 </Note>

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -5,25 +5,41 @@ description: "Add the deposit widget to your React app and accept cross-chain de
 
 Install the `@rhinestone/deposit-modal` package, render the modal, and handle a completed deposit.
 
-This quickstart uses **external wallet mode** with Reown for wallet connection. If you don't want to set up Reown, the modal also supports [QR code deposits](/deposits/widget/deposit-modal#qr-code-deposit) (no wallet connection) and [embedded wallets](/deposits/widget/deposit-modal#embedded-wallet) (Privy, Dynamic, Turnkey, etc.).
+This quickstart has the modal connect the wallet itself, via Reown. If you don't want to set up Reown, the modal also works with [a wallet your app already has connected](/deposits/widget/deposit-modal#you-supply-one) (Privy, Dynamic, Turnkey, wagmi) or [with no wallet at all](/deposits/widget/deposit-modal#no-wallet-at-all) — QR transfer, fiat on-ramp, or exchange connect.
 
 ## Prerequisites
 
 - A React 18+ app (Next.js, Vite, or similar)
 - A [Rhinestone API key](https://tally.so/r/wg22x4)
-- A [Reown](https://cloud.reown.com/) project ID (for wallet connection)
+- A [Reown](https://cloud.reown.com/) project ID, if the modal is connecting the wallet
 
 ## Install
 
 ```bash
-npm install @rhinestone/deposit-modal viem wagmi @tanstack/react-query @reown/appkit @reown/appkit-adapter-wagmi @solana/web3.js @solana/spl-token
+npm install @rhinestone/deposit-modal viem wagmi @tanstack/react-query
+```
+
+Add Reown only if you want the modal to connect the wallet — these are optional peer dependencies, so skip them when you pass your own `walletClient` or run a flow with no wallet:
+
+```bash
+npm install @reown/appkit @reown/appkit-adapter-wagmi
+```
+
+For Solana sources or destinations, add:
+
+```bash
+npm install @reown/appkit-adapter-solana @solana/web3.js @solana/spl-token
 ```
 
 <Note>
-`@solana/web3.js` and `@solana/spl-token` are required even for EVM-only apps because Solana support is enabled by default. To drop these dependencies, pass `enableSolana={false}` on the modal.
+All five of the above are **optional** peers as of v0.9.0. An app that supplies its
+own wallet client never loads Reown — the modal imports it lazily, so it stays out
+of your bundle entirely.
 </Note>
 
 The modal ships with its own `wagmi` and `@tanstack/react-query` providers — you do not need to wrap your app with `WagmiProvider` or `QueryClientProvider`.
+
+The package ships no `"use client"` directive, so in the Next.js App Router put it in a component that has one.
 
 <Steps>
 
@@ -86,11 +102,20 @@ Add the `onLifecycle` callback and react to the `"complete"` event when tokens a
 
 </Steps>
 
+## Before production
+
+Two things this quickstart skips, both covered in [backend](/deposits/widget/backend):
+
+- **A proxy** on `backendUrl`. The modal can't hold your API key, and the built-in default is Rhinestone-internal.
+- **Webhooks**, for anything that must happen whether or not the modal is still open.
+
+See it running in the [live demo](https://demo.rhinestone.dev), whose [source](https://github.com/rhinestonewtf/deposit-widget-demo) is a working integration you can read.
+
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Deposit modal" icon="arrow-down-to-line" href="/deposits/widget/deposit-modal">
-    Integration modes, transfer configuration, and full props reference.
+    Wallet options, funding methods, transfer configuration, and full props reference.
   </Card>
   <Card title="Customization" icon="palette" href="/deposits/widget/customization">
     Theme and UI configuration.
@@ -99,6 +124,9 @@ Add the `onLifecycle` callback and react to the `"complete"` event when tokens a
     Lifecycle events, callbacks, and error handling.
   </Card>
   <Card title="Withdraw modal" icon="arrow-up-from-line" href="/deposits/widget/withdraw-modal">
-    Withdraw tokens from a Safe to any supported chain.
+    Withdraw tokens to any supported chain, with your app performing the transfer.
+  </Card>
+  <Card title="Claim modal" icon="rotate-ccw" href="/deposits/widget/claim-modal">
+    Let users recover a failed or rejected deposit from its transaction hash.
   </Card>
 </CardGroup>

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -64,6 +64,7 @@ function App() {
         targetChain={8453}
         targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
         recipient="0xYOUR_RECIPIENT_ADDRESS"
+        backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL!}
         reownAppId={process.env.NEXT_PUBLIC_REOWN_PROJECT_ID!}
       />
     </>
@@ -86,6 +87,7 @@ Add the `onLifecycle` callback and react to the `"complete"` event when tokens a
   targetChain={8453}
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
+  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL!}
   reownAppId={process.env.NEXT_PUBLIC_REOWN_PROJECT_ID!}
   onLifecycle={(event) => {
     if (event.type === "complete") {
@@ -104,10 +106,9 @@ Add the `onLifecycle` callback and react to the `"complete"` event when tokens a
 
 ## Before production
 
-Two things this quickstart skips, both covered in [backend](/deposits/widget/backend):
+`backendUrl` above has to point at a real proxy — one you run, holding your API key. There is no default, because a default would put your users on someone else's key. See [backend](/deposits/widget/backend) for a minimal one and the routes it must forward.
 
-- **A proxy** on `backendUrl`. The modal can't hold your API key, and the built-in default is Rhinestone-internal.
-- **Webhooks**, for anything that must happen whether or not the modal is still open.
+You'll also want [webhooks](/deposits/widget/backend#webhooks) for anything that must happen whether or not the modal is still open.
 
 See it running in the [live demo](https://demo.rhinestone.dev), whose [source](https://github.com/rhinestonewtf/deposit-widget-demo) is a working integration you can read.
 

--- a/deposits/widget/status-tracking.mdx
+++ b/deposits/widget/status-tracking.mdx
@@ -16,8 +16,8 @@ sequenceDiagram
     participant Chain as Blockchain
 
     Modal->>App: onReady
-    Note over Modal: User connects wallet
-    Modal->>App: onLifecycle "connected"
+    Note over Modal: User picks a funding method
+    Modal->>App: onLifecycle "connected" (wallet only)
     Note over Modal: User selects chain, token, amount
     Modal->>Chain: Submit deposit tx
     Modal->>App: onLifecycle "submitted"
@@ -27,9 +27,8 @@ sequenceDiagram
 ```
 
 1. The modal initializes and fires `onReady`
-2. The user connects a wallet (or is connected via an embedded wallet). The
-   modal creates a smart account and emits `"connected"` with the EOA `address`
-   and `smartAccount` address.
+2. If the user funds from a wallet, `"connected"` fires with the EOA `address` and
+   the `smartAccount` the deposit lands on
 3. The user selects a source chain, token, and amount, then confirms
 4. The modal submits the transaction on the source chain and emits `"submitted"`
 5. The bridge routes funds to the target chain. Once they arrive, the modal
@@ -37,6 +36,13 @@ sequenceDiagram
 
 If the bridge fails after submission, `"failed"` is emitted instead of
 `"complete"`.
+
+<Warning>
+`"connected"` fires only for wallet funding. QR transfer, fiat on-ramp and exchange
+connect involve no wallet, so it never fires — use `onReady` if you need a "flow
+started" signal. Before v0.9.0 it fired with the declared address as though a wallet
+had connected.
+</Warning>
 
 ## onLifecycle
 
@@ -79,14 +85,19 @@ import type { DepositLifecycleEvent } from "@rhinestone/deposit-modal";
 
 | `event.type` | Fields | Description |
 |---|---|---|
-| `"connected"` | `address: Address`, `smartAccount: Address` | Smart account created for the deposit |
-| `"submitted"` | `txHash: string`, `sourceChain: ChainId \| "unknown"`, `amount: string` | Deposit transaction submitted on the source chain |
-| `"complete"` | `txHash: string`, `destinationTxHash?: string`, `amount: string`, `sourceChain: ChainId \| "unknown"`, `sourceToken?: string`, `targetChain: number \| "solana"`, `targetToken: string` | Tokens arrived on the target chain |
+| `"connected"` | `address: Address`, `smartAccount: Address` | A wallet was connected as the funding source |
+| `"submitted"` | `txHash: string`, `sourceChain: ChainId \| "unknown"`, `amount: string`, `sourceDecimals?: number`, `amountUsd?: string` | Deposit transaction submitted on the source chain |
+| `"complete"` | `txHash: string`, `destinationTxHash?: string`, `amount: string`, `sourceChain: ChainId \| "unknown"`, `sourceToken?: string`, `sourceDecimals?: number`, `amountUsd?: string`, `targetChain: number \| "solana"`, `targetToken: string` | Tokens arrived on the target chain |
 | `"failed"` | `txHash: string`, `error?: string` | Bridge or transfer failed after submission |
 | `"balance-changed"` | `totalUsd: number` | The user's total portfolio balance (USD) changed |
 | `"smart-account-changed"` | `evm: Address \| null`, `solana: string \| null` | The resolved smart account addresses changed |
 
-`amount` is the deposit amount in the token's smallest unit.
+`amount` is in the source token's base units — divide by `sourceDecimals` to display
+it. `sourceDecimals` is omitted when the token isn't recognised, which happens for a
+QR deposit of an unlisted token.
+
+`amountUsd` is the USD value as entered in the modal. It is omitted for flows with no
+amount input: QR transfer, fiat on-ramp, and exchange connect.
 
 <Warning>
 `sourceChain: "unknown"` is deposit-only. When a webhook-detected deposit
@@ -100,7 +111,13 @@ explorer URL.
 `WithdrawLifecycleEvent` carries the same `type` values minus `"balance-changed"`
 and `"smart-account-changed"`. Its `txHash` is `Hex`, `sourceChain` is always a
 `number`, `sourceToken` / `targetToken` are `Address`, and `"submitted"` adds an
-`accountAddress: Address` field.
+`accountAddress: Address` field. `"connected"` means the deposit account for the
+chosen target is registered and fundable, not that a wallet connected.
+
+### Claim events
+
+`ClaimLifecycleEvent` is a separate union — `lookup`, `refund_requested`, `complete`,
+`failed`. See [claim modal](/deposits/widget/claim-modal#lifecycle-events).
 
 ## onReady
 
@@ -126,7 +143,19 @@ onError={(data) => console.error(`[${data.code}] ${data.message}`)}
 | `message` | `string` | Error description |
 | `code` | `string \| undefined` | Error code, if available |
 
-For bridge-level error codes, see [deposit processing error codes](/deposits/api/deposit-processing#error-codes).
+### Codes
+
+| `code` | Meaning |
+|---|---|
+| `HYPERCORE_RECIPIENT_NOT_EOA` | [HyperCore](/deposits/widget/deposit-modal#hypercore-destinations) target with a contract `recipient`. The deposit cannot settle |
+| `WITHDRAW_MISSING_SEND_TRANSACTION` | `<WithdrawModal>` opened without an `onSendTransaction` function |
+| `WITHDRAW_REGISTER_FAILED` | Registering the withdrawal's deposit account failed |
+| `WITHDRAW_FLOW_ERROR` | The withdrawal failed after the form was submitted |
+| `CLAIM_LOOKUP_FAILED` | `<ClaimModal>` could not look up the pasted transaction hash |
+| `CLAIM_FAILED` | The refund request failed |
+| `SWAPPED_CONNECT_EXCHANGES_FAILED` | The exchange list could not be fetched |
+
+Errors without a code carry only `message`. For bridge-level codes, see [deposit processing error codes](/deposits/api/deposit-processing#error-codes).
 
 ## Error handling
 
@@ -144,8 +173,8 @@ After the source chain transaction confirms, the deposit service may
 ## Analytics
 
 The `onEvent` callback fires on granular user interactions for your analytics
-pipeline. Its payload type is `DepositAnalyticsEvent` (or
-`WithdrawAnalyticsEvent`).
+pipeline. Its payload type is `DepositAnalyticsEvent`, `WithdrawAnalyticsEvent`, or
+`ClaimAnalyticsEvent`.
 
 ```tsx
 import type { DepositAnalyticsEvent } from "@rhinestone/deposit-modal";

--- a/deposits/widget/withdraw-modal.mdx
+++ b/deposits/widget/withdraw-modal.mdx
@@ -17,6 +17,7 @@ import "@rhinestone/deposit-modal/styles.css";
   isOpen={isOpen}
   onClose={() => setIsOpen(false)}
   accountAddress="0xACCOUNT_HOLDING_THE_FUNDS"
+  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL}
   sourceChain={8453}
   sourceToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   targetChain={10}
@@ -103,6 +104,7 @@ Before v0.9.0 the modal did all of this internally, behind a `safeAddress` prop 
 | `sourceChain` | `Chain \| number` | Chain where the account holds funds |
 | `sourceToken` | `Address` | Token to withdraw |
 | `onSendTransaction` | `(request: WithdrawTransferRequest) => Promise<{ txHash: Hex }>` | Performs the transfer and returns its on-chain hash |
+| `backendUrl` | `string` | Your [backend proxy](/deposits/widget/backend), which holds your API key |
 
 ### Transfer
 
@@ -130,7 +132,6 @@ release; see [migration](/deposits/widget/migration).
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `backendUrl` | `string` | — | Your [backend proxy](/deposits/widget/backend). Treat as required — the default is Rhinestone-internal |
 | `rpcUrls` | `RpcUrlMap` | Chain defaults | Per-chain RPC overrides keyed by EVM chain id. Used for balance reads; chains left unset use their default RPC |
 
 ### Display

--- a/deposits/widget/withdraw-modal.mdx
+++ b/deposits/widget/withdraw-modal.mdx
@@ -102,30 +102,35 @@ Before v0.9.0 the modal did all of this internally, behind a `safeAddress` prop 
 | `accountAddress` | `Address` | Account holding the funds being withdrawn |
 | `sourceChain` | `Chain \| number` | Chain where the account holds funds |
 | `sourceToken` | `Address` | Token to withdraw |
-| `targetChain` | `Chain \| number` | Default destination chain — the user can change it |
-| `targetToken` | `Address` | Default token to receive — the user can change it |
 | `onSendTransaction` | `(request: WithdrawTransferRequest) => Promise<{ txHash: Hex }>` | Performs the transfer and returns its on-chain hash |
 
 ### Transfer
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
+| `targetChain` | `Chain \| number` | `sourceChain` | Seeds the destination chain; the user can change it |
+| `targetToken` | `Address` | `sourceToken` | Seeds the token to receive; the user can change it |
 | `recipient` | `Address` | — | Pre-fills the delivery address; the user can edit it |
 | `defaultAmount` | `string` | — | Pre-filled withdrawal amount |
-| `allowedRoutes` | `RouteConfig` | — | Restrict available routes |
+
+<Note>
+`targetChain` and `targetToken` became **optional** in v0.9.0 — they only ever
+seeded the form, which lets the user pick any supported destination. Omit them to
+open on a same-chain, same-token withdrawal. `allowedRoutes` was removed in the same
+release; see [migration](/deposits/widget/migration).
+</Note>
 
 ### Account
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `forceRegister` | `boolean` | `false` | Re-register even if the account already exists |
-| `rhinestoneApiKey` | `string` | — | API key for account setup |
 
 ### Backend
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `backendUrl` | `string` | Rhinestone production URL | URL of your deposit-widget-backend instance. Self-hosting a custom proxy? See [version header pass-through](/deposits/widget/deposit-modal#version-header-pass-through) |
+| `backendUrl` | `string` | — | Your [backend proxy](/deposits/widget/backend). Treat as required — the default is Rhinestone-internal |
 | `rpcUrls` | `RpcUrlMap` | Chain defaults | Per-chain RPC overrides keyed by EVM chain id. Used for balance reads; chains left unset use their default RPC |
 
 ### Display

--- a/docs.json
+++ b/docs.json
@@ -397,7 +397,20 @@
         "tab": "Deposits",
         "pages": [
           "deposits/overview",
-          "deposits/demo",
+          {
+            "group": "Widget",
+            "pages": [
+              "deposits/widget/quickstart",
+              "deposits/widget/backend",
+              "deposits/widget/deposit-modal",
+              "deposits/widget/withdraw-modal",
+              "deposits/widget/claim-modal",
+              "deposits/widget/customization",
+              "deposits/widget/status-tracking",
+              "deposits/widget/migration",
+              "deposits/demo"
+            ]
+          },
           {
             "group": "API",
             "pages": [
@@ -409,17 +422,6 @@
               "deposits/api/fees",
               "deposits/api/sponsorship",
               "deposits/api/status-tracking"
-            ]
-          },
-          {
-            "group": "Widget",
-            "pages": [
-              "deposits/widget/quickstart",
-              "deposits/widget/deposit-modal",
-              "deposits/widget/withdraw-modal",
-              "deposits/widget/customization",
-              "deposits/widget/status-tracking",
-              "deposits/widget/migration"
             ]
           },
           "deposits/troubleshooting"


### PR DESCRIPTION
The widget docs still described the pre-0.9.0 API. Every integration-mode example used `dappAddress`, the props tables listed `allowedRoutes` / `dappImports` / `enableSolana` / `uiConfig.checkLiquidity`, and the quickstart told people to pass `enableSolana={false}` to drop the Solana dependencies. **Copy-pasting our own quickstart did not compile.**

Rewritten around what 0.9.0 actually does: the account is derived from `(recipient, targetChain, targetToken)` and service-managed, so a wallet is one funding source among several rather than the user's identity. "Integration modes" becomes "Connecting a wallet" — modal connects one / you supply one / none at all.

## Gaps that were never documented, not just stale

- **Funding methods.** `enableFiatOnramp`, `enableQrTransfer`, `enableExchangeConnect`, `fiatMethods`, `enableWallet` had **zero** mentions anywhere in the docs.
- **`ClaimModal`.** A public component and `./claim` subpath with no page. Adds one — including `createRefundHandler` and why the host app authorizes rather than the user signing.
- **Backend.** New page. The widget can't hold an API key, so it needs a proxy: write your own, or deploy the one we're open-sourcing. The route table and CORS notes **moved** here from `deposit-modal.mdx` rather than being duplicated.
- **`sourceDecimals` / `amountUsd`** on the deposit events. The docs said `amount` is in base units but never named the field you need to render it, or that both are omitted in specific cases.
- **Error codes.** All seven the modal emits, enumerated from source.
- **HyperCore.** Requires an EOA `recipient` — decides whether an integration can work at all.
- **Asset migration providers.** Four keys, only Polymarket live.
- **CSP.** `img-src` for the icon CDN (a blocked image fails *silently*) and `frame-src` for Swapped.

The lifecycle narrative also still claimed the modal creates a smart account from the connected wallet, and `connected` no longer fires for flows with no wallet.

## Leading with the widget

Widget group above API in the sidebar; widget tab first in the overview with an explicit recommendation; demo moved into the Widget group since it demos the widget; a Tip on the API quickstart for React users.

**The comparison table had four inaccuracies, two of which undersold the widget:**

| Claim | Reality |
| --- | --- |
| "Low — drop in a React component" | The widget needs a backend too |
| "Deposit triggers: user-initiated via the modal" | Any transfer to the deposit account is detected, same as the API |
| "Withdrawal support: built-in" | 0.9.0 handed the transfer to the host app |
| — | Fiat, refunds and status were missing rows |

## `backendUrl`

Its default is a Rhinestone-**internal** service running on our API key. Three props tables described it as "Rhinestone production URL". Corrected, and the backend page says to treat the prop as required. Worth noting the shipped default still points there — docs can warn, but only changing the constant prevents a client silently riding our key.

## Verification

- All 10 changed pages plus the 2 new ones render under `mintlify dev`
- `mintlify broken-links` reports the same **9 pre-existing** failures as `main` and nothing new. All 9 are OpenAPI-generated `api-reference` pages that **return 200 in production** — a local-tooling artifact, so that command is permanently noisy for this repo.
- Every `ts`/`tsx` snippet in the widget docs was checked against the modal's real source: **27 snippets — 12 imports, 63 prop names, 12 lifecycle event strings, 9 theme/uiConfig keys, zero problems.** Name-level only; it wouldn't catch a snippet that compiles but does the wrong thing.
- US spelling and no filler, per `AGENTS.md`

**Vale isn't installed locally** and it gates docs PRs, so that check runs here for the first time.

Context: [RHI-5125](https://linear.app/rhinestone/issue/RHI-5125) — its "Done when" includes "the docs no longer reference the removed props", which this completes (the ticket was closed on the code PRs alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)