### PR TITLE
docs: version history to the migration guide, split asset migrations, clear Vale

### DIFF
--- a/deposits/api/quickstart.mdx
+++ b/deposits/api/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart"
+title: "API quickstart"
 description: "Set up the Deposit API and process your first cross-chain deposit."
 ---
 

--- a/deposits/overview.mdx
+++ b/deposits/overview.mdx
@@ -92,7 +92,7 @@ It supports a wide range of EVM chains and Solana — see [supported chains and 
 <Tabs>
 <Tab title="Deposit Widget">
 
-A React modal that handles funding method, chain and token selection, and deposit execution out of the box. Also covers [fiat and exchange funding](/deposits/widget/deposit-modal#funding-methods), [withdrawals](/deposits/widget/withdraw-modal), [refunds](/deposits/widget/claim-modal), and [migrating balances from other apps](/deposits/widget/deposit-modal#migrate-assets-from-other-apps) (e.g. Polymarket).
+A React modal that handles funding method, chain and token selection, and deposit execution out of the box. Also covers [fiat and exchange funding](/deposits/widget/deposit-modal#funding-methods), [withdrawals](/deposits/widget/withdraw-modal), [refunds](/deposits/widget/claim-modal), and [migrating balances from other apps](/deposits/widget/asset-migrations) (e.g. Polymarket).
 
 <Frame caption="Widget UI">
   <video src="/images/deposits_widget_ui.mp4" muted loop controls className="rounded-2xl" style={{ maxHeight: "500px", margin: "0 auto" }} />

--- a/deposits/widget/asset-migrations.mdx
+++ b/deposits/widget/asset-migrations.mdx
@@ -1,0 +1,131 @@
+---
+title: "Asset migrations"
+description: "Fund a deposit from balances the user already holds in another app."
+---
+
+The modal can pull balances a user already holds in a supported third-party app
+and fund the deposit from there — no manual transfer first. Each provider is
+**off by default**; opt in per provider via `assetMigrations`.
+
+```tsx
+<DepositModal
+  // ...required props
+  assetMigrations={{ polymarket: true }}
+/>
+```
+
+When at least one provider is enabled, a **Migrate assets** row appears on the
+deposit entry screen and opens a picker over that provider's positions. The user
+picks one, and the modal pulls the funds into their smart account and bridges
+them to `targetChain` / `targetToken` like any other source.
+
+| Key | Status |
+|---|---|
+| `polymarket` | Live |
+| `aave` | Live |
+| `hyperliquid` | Coming soon |
+| `morpho` | Coming soon |
+
+Only the providers you enable are listed. Enabling one that isn't live yet shows it
+as a disabled "Coming soon" row rather than hiding it.
+
+## Polymarket
+
+Set `assetMigrations={{ polymarket: true }}`. The modal looks up the connected
+EOA's Polymarket proxy wallet on Polygon and surfaces any pUSD or USDC.e
+balance. pUSD is unwrapped to USDC.e on the way out; USDC.e is what lands in the
+smart account and what the orchestrator bridges from.
+
+Polymarket exposes two wallet types and the modal handles both: some transfer
+on-chain directly from the user's signed transaction, while others are relayed
+through your [backend proxy](/deposits/widget/backend), which must forward
+`POST /polymarket/withdraw`.
+
+### Open directly into Polymarket
+
+To skip the deposit-method home screen and land the user straight on the
+Polymarket transfer, pass `initialAssetMigration="polymarket"` alongside
+`assetMigrations={{ polymarket: true }}`. While balances load the modal shows a
+skeleton; if there's no account, no balance, or no connected wallet it falls
+back to the home screen.
+
+```tsx
+<DepositModal
+  // ...required props
+  assetMigrations={{ polymarket: true }}
+  initialAssetMigration="polymarket"
+/>
+```
+
+### Headless account lookup
+
+If you build your own UI and only need the data, the
+`@rhinestone/deposit-modal/polymarket` subpath exports a headless
+`getPolymarketAccount` — no React, modal, or wallet-connect code pulled into
+your bundle. Give it the connected EOA and it returns the user's Polymarket
+proxy wallet address and on-chain pUSD / USDC.e balances on Polygon.
+
+```ts
+import { getPolymarketAccount } from "@rhinestone/deposit-modal/polymarket";
+
+const account = await getPolymarketAccount({ eoa: connectedAddress });
+
+if (account) {
+  account.proxyWallet; // the user's Polymarket address on Polygon
+  account.pusd.formatted; // pUSD balance, e.g. "12.5"
+  account.usdce.formatted; // USDC.e balance
+  account.totalUsd; // combined USD value
+}
+```
+
+Returns `null` only when the EOA has no Polymarket account. A transient failure
+(network, 5xx, abort) rejects instead, so an outage is never mistaken for "no
+account". Pass `rpcUrl` to override the default public Polygon RPC, or a
+`signal` (`AbortSignal`) to cancel the lookup.
+
+## Aave
+
+Set `assetMigrations={{ aave: true }}`. The modal lists the connected EOA's Aave
+v3 supply positions across every chain you can take deposits from, and picking
+one produces a single `Pool.withdraw` that sends the proceeds **straight to the
+user's deposit address** — the funds never pass through their wallet, and the
+normal deposit pipeline ingests them like any other incoming transfer.
+
+Requires your [backend proxy](/deposits/widget/backend) to forward
+`GET /positions/:address` and `POST /positions/:address/unwind`. A read-scoped
+API key is enough for both.
+
+Three behaviours worth knowing, because they are deliberate:
+
+- **The amount offered is what can actually be withdrawn right now**, not the
+  full supplied balance. Aave caps a withdrawal against the user's health factor,
+  E-Mode thresholds, paused reserves and pool liquidity, so a position worth $100
+  may only permit $40 out. The modal offers the $40 — the user is never shown a
+  figure the pool would reject.
+- **The user's wallet signs; Rhinestone never holds a key on this path.** The
+  aTokens sit in the user's own EOA, so only they can authorise the withdraw. The
+  transaction we build is unsigned and inert until they sign it.
+- **A position whose proceeds your config would refuse is not offered at all** —
+  under your `minDepositUsd`, or outside your source-token allowlist. Offering it
+  and failing afterwards would leave the user having irreversibly exited a
+  position for funds we then reject.
+
+Positions are keyed by **market**, not chain: Ethereum alone hosts four Aave v3
+markets with distinct pools and risk parameters, so the same token supplied to two
+of them appears as two rows, each naming its market.
+
+If a market can't be read, the positions that did load are still listed and the
+screen says the list may be incomplete — an outage never silently reports a
+smaller balance than the user holds.
+
+### Open directly into Aave
+
+As with Polymarket, `initialAssetMigration="aave"` skips the home screen:
+
+```tsx
+<DepositModal
+  // ...required props
+  assetMigrations={{ aave: true }}
+  initialAssetMigration="aave"
+/>
+```

--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -12,6 +12,11 @@ Two ways to get one:
 - **Deploy Rhinestone's.** Open source and configurable — see [deploy the Rhinestone proxy](#deploy-the-rhinestone-proxy).
 - **Write your own.** A route table and a header — see [minimal proxy](#minimal-proxy).
 
+<Warning>
+If you have a deployed integration that never set `backendUrl`, it is running on
+Rhinestone's API key rather than yours. Point it at your own proxy.
+</Warning>
+
 ## Deploy the Rhinestone proxy
 
 [`rhinestonewtf/deposit-widget-proxy`](https://github.com/rhinestonewtf/deposit-widget-proxy) is the proxy Rhinestone runs, packaged so you can deploy it as-is. It covers every route in the [table below](#required-routes), and adds [regional payment methods](#regional-payment-methods) — which a hand-written proxy can't do, since resolving the user's country needs the edge that actually sees them.
@@ -157,7 +162,7 @@ Missing a route doesn't degrade the flow — the request 404s and that part of t
 | `POST` | `/onramp/swapped/connect-url` | Exchange connect |
 | `GET` | `/onramp/swapped/connect-exchanges` | Exchange list |
 | `GET` | `/onramp/swapped/status/:smartAccount` | On-ramp order status |
-| `POST` | `/safe/withdraw` | Relaying a signed Safe transfer with sponsored gas. Not used by the modal — proxy it only if your own [`onSendTransaction`](/deposits/widget/withdraw-modal#executing-the-transfer) relays through it |
+| `POST` | `/safe/withdraw` | Relaying a signed Safe transfer with sponsored gas. **Not called by the modal** — proxy it only if your own [`onSendTransaction`](/deposits/widget/withdraw-modal#executing-the-transfer) relays through it |
 
 <Warning>
 Proxy `GET /setup` only, never `POST /setup`. The POST is an admin write — it rotates

--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -155,7 +155,7 @@ Missing a route doesn't degrade the flow — the request 404s and that part of t
 | `GET` | `/qr/tokens` | Suggested source tokens for the QR flow, filtered to what your config accepts |
 | `GET` | `/onramp/swapped/payment-methods` | Fiat methods for the user's region. See [regional payment methods](#regional-payment-methods) |
 | `POST` | `/deposits/recover` | [Self-service recovery](/deposits/widget/claim-modal), authorized by the user's signature |
-| `GET` | `/positions/:address` | DeFi positions the user can migrate. Only for [asset migrations](/deposits/widget/deposit-modal#migrate-assets-from-other-apps) |
+| `GET` | `/positions/:address` | DeFi positions the user can migrate. Only for [asset migrations](/deposits/widget/asset-migrations) |
 | `POST` | `/positions/:address/unwind` | Builds the unsigned exit transaction for one position. Only for asset migrations |
 | `POST` | `/polymarket/withdraw` | Polymarket withdrawals |
 | `POST` | `/onramp/swapped/widget-url` | Fiat on-ramp |

--- a/deposits/widget/claim-modal.mdx
+++ b/deposits/widget/claim-modal.mdx
@@ -8,8 +8,9 @@ The `ClaimModal` returns a failed or rejected EVM deposit to the user, on the ch
 There is no source chain to pick — the hash is looked up across every chain, so a deposit that landed on a chain your deposit flow doesn't offer is still claimable.
 
 <Note>
-On the `./claim` subpath. Applies to deposits in `failed` or `rejected`
-status; see [troubleshooting](/deposits/troubleshooting) for the dashboard equivalent.
+On the `./claim` subpath. Applies to deposits in `failed` or `rejected` status. See
+[troubleshooting](/deposits/troubleshooting) for the operator-side equivalent in the
+dashboard.
 </Note>
 
 ## How authorization works

--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -99,7 +99,7 @@ Each method is a row on the modal's home screen. When exactly one is enabled the
 | `enableFiatOnramp` | `boolean` | `false` | Offer card / bank / Apple Pay payment via Swapped's embedded iframe |
 | `fiatMethods` | `FiatMethodsConfig` | regional | Restrict which Swapped payment groups the on-ramp offers. Omitting it uses [regional personalization](#regional-payment-methods) |
 | `enableExchangeConnect` | `boolean` | `false` | Offer "Connect exchange" — the user picks their CEX inside Swapped's iframe and withdraws from it |
-| `assetMigrations` | `AssetMigrationsConfig` | none | Offer [migrating balances or DeFi positions](#migrate-assets-from-other-apps) the user already holds in a supported third-party app |
+| `assetMigrations` | `AssetMigrationsConfig` | none | Offer [migrating balances or DeFi positions](/deposits/widget/asset-migrations) the user already holds in a supported third-party app |
 
 `enableFiatOnramp` and `enableExchangeConnect` require Swapped keys on your backend.
 
@@ -211,126 +211,11 @@ When several rules match the same deposit, the most specific one wins: `chain + 
 
 ## Migrate assets from other apps
 
-The modal can pull balances a user already holds in a supported third-party app
-and fund the deposit from there — no manual transfer first. Each provider is
-**off by default**; opt in per provider via `assetMigrations`.
+Fund a deposit from balances the user already holds in a supported third-party app,
+with no manual transfer first. Opt in per provider via `assetMigrations`.
 
-```tsx
-<DepositModal
-  // ...required props
-  assetMigrations={{ polymarket: true }}
-/>
-```
-
-When at least one provider is enabled, a **Migrate assets** row appears on the
-deposit entry screen and opens a picker over that provider's positions. The user
-picks one, and the modal pulls the funds into their smart account and bridges
-them to `targetChain` / `targetToken` like any other source.
-
-`polymarket` and `aave` are the providers available today. Only the providers you
-enable are listed, and one that isn't available yet renders as a disabled row
-rather than being hidden.
-
-### Polymarket
-
-Set `assetMigrations={{ polymarket: true }}`. The modal looks up the connected
-EOA's Polymarket proxy wallet on Polygon and surfaces any pUSD or USDC.e
-balance. pUSD is unwrapped to USDC.e on the way out; USDC.e is what lands in the
-smart account and what the orchestrator bridges from.
-
-Polymarket exposes two wallet types and the modal handles both: some transfer
-on-chain directly from the user's signed transaction, while others are relayed
-through your [backend proxy](/deposits/widget/backend), which must forward
-`POST /polymarket/withdraw`.
-
-#### Open directly into Polymarket
-
-To skip the deposit-method home screen and land the user straight on the
-Polymarket transfer, pass `initialAssetMigration="polymarket"` alongside
-`assetMigrations={{ polymarket: true }}`. While balances load the modal shows a
-skeleton; if there's no account, no balance, or no connected wallet it falls
-back to the home screen.
-
-```tsx
-<DepositModal
-  // ...required props
-  assetMigrations={{ polymarket: true }}
-  initialAssetMigration="polymarket"
-/>
-```
-
-#### Headless account lookup
-
-If you build your own UI and only need the data, the
-`@rhinestone/deposit-modal/polymarket` subpath exports a headless
-`getPolymarketAccount` — no React, modal, or wallet-connect code pulled into
-your bundle. Give it the connected EOA and it returns the user's Polymarket
-proxy wallet address and on-chain pUSD / USDC.e balances on Polygon.
-
-```ts
-import { getPolymarketAccount } from "@rhinestone/deposit-modal/polymarket";
-
-const account = await getPolymarketAccount({ eoa: connectedAddress });
-
-if (account) {
-  account.proxyWallet; // the user's Polymarket address on Polygon
-  account.pusd.formatted; // pUSD balance, e.g. "12.5"
-  account.usdce.formatted; // USDC.e balance
-  account.totalUsd; // combined USD value
-}
-```
-
-Returns `null` only when the EOA has no Polymarket account. A transient failure
-(network, 5xx, abort) rejects instead, so an outage is never mistaken for "no
-account". Pass `rpcUrl` to override the default public Polygon RPC, or a
-`signal` (`AbortSignal`) to cancel the lookup.
-
-### Aave
-
-Set `assetMigrations={{ aave: true }}`. The modal lists the connected EOA's Aave
-v3 supply positions across every chain you can take deposits from, and picking
-one produces a single `Pool.withdraw` that sends the proceeds **straight to the
-user's deposit address** — the funds never pass through their wallet, and the
-normal deposit pipeline ingests them like any other incoming transfer.
-
-Requires your [backend proxy](/deposits/widget/backend) to forward
-`GET /positions/:address` and `POST /positions/:address/unwind`. A read-scoped
-API key is enough for both.
-
-Three behaviours worth knowing, because they are deliberate:
-
-- **The amount offered is what can actually be withdrawn right now**, not the
-  full supplied balance. Aave caps a withdrawal against the user's health factor,
-  E-Mode thresholds, paused reserves and pool liquidity, so a position worth $100
-  may only permit $40 out. The modal offers the $40 — the user is never shown a
-  figure the pool would reject.
-- **The user's wallet signs; Rhinestone never holds a key on this path.** The
-  aTokens sit in the user's own EOA, so only they can authorise the withdraw. The
-  transaction we build is unsigned and inert until they sign it.
-- **A position whose proceeds your config would refuse is not offered at all** —
-  under your `minDepositUsd`, or outside your source-token allowlist. Offering it
-  and failing afterwards would leave the user having irreversibly exited a
-  position for funds we then reject.
-
-Positions are keyed by **market**, not chain: Ethereum alone hosts four Aave v3
-markets with distinct pools and risk parameters, so the same token supplied to two
-of them appears as two rows, each naming its market.
-
-If a market can't be read, the positions that did load are still listed and the
-screen says the list may be incomplete — an outage never silently reports a
-smaller balance than the user holds.
-
-#### Open directly into Aave
-
-As with Polymarket, `initialAssetMigration="aave"` skips the home screen:
-
-```tsx
-<DepositModal
-  // ...required props
-  assetMigrations={{ aave: true }}
-  initialAssetMigration="aave"
-/>
-```
+See [asset migrations](/deposits/widget/asset-migrations) for the provider list,
+Polymarket specifics, and the headless account lookup.
 
 ## Package entry points
 
@@ -344,7 +229,7 @@ Everything is on the root entry; the subpaths exist so you only bundle what you 
 | `@rhinestone/deposit-modal/claim` | [`ClaimModal`](/deposits/widget/claim-modal) and its types |
 | `@rhinestone/deposit-modal/server` | `createRefundHandler`. **Server-only** — holds your API key |
 | `@rhinestone/deposit-modal/constants` | `MODAL_VERSION`, chain registry, token and explorer helpers |
-| `@rhinestone/deposit-modal/polymarket` | [`getPolymarketAccount`](#headless-account-lookup), headless |
+| `@rhinestone/deposit-modal/polymarket` | [`getPolymarketAccount`](/deposits/widget/asset-migrations#headless-account-lookup), headless |
 | `@rhinestone/deposit-modal/styles.css` | Stylesheet, required |
 
 ## Display modes
@@ -405,7 +290,7 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 | `enableFiatOnramp` | `boolean` | `false` | Offer fiat payment via Swapped's iframe. Requires backend Swapped keys |
 | `fiatMethods` | `FiatMethodsConfig` | regional | [Restrict payment groups](#restricting-fiat-payment-methods) — `{ creditcard?, "bank-transfer"?, "apple-pay"? }`. Empty means none; omitted means [regional](#regional-payment-methods) |
 | `enableExchangeConnect` | `boolean` | `false` | Offer "Connect exchange". Requires backend Swapped keys |
-| `assetMigrations` | `AssetMigrationsConfig` | — | [Migrate balances or positions](#migrate-assets-from-other-apps) from third-party apps (e.g. `{ polymarket: true, aave: true }`) |
+| `assetMigrations` | `AssetMigrationsConfig` | — | [Migrate balances or positions](/deposits/widget/asset-migrations) from third-party apps (e.g. `{ polymarket: true, aave: true }`) |
 | `initialAssetMigration` | `keyof AssetMigrationsConfig` | — | Open the modal pre-routed into a migration provider (e.g. `"aave"`), skipping the home screen. Must name an enabled `assetMigrations` key. |
 
 ### Account

--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -442,11 +442,6 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 
 See [status tracking](/deposits/widget/status-tracking) for lifecycle event payloads.
 
-<Note>
-Solana sources follow your project's deposit whitelist like every other source —
-there is no separate client-side toggle.
-</Note>
-
 ## Content security policy
 
 The modal loads chain, token and exchange logos from Rhinestone's asset CDN. **If your app sets an explicit `img-src` policy, it must allow the CDN:**

--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -377,7 +377,7 @@ New in v0.3.0; existing code keeps working:
   deposit" row (`appBalanceUsd + amount`) instead of fetching a portfolio
   balance.
 - **`dappImports?: DappImportsConfig`** on `<DepositModal>` — pull balances from
-  third-party apps. See [migrating assets](/deposits/widget/deposit-modal#migrate-assets-from-other-apps).
+  third-party apps. See [migrating assets](/deposits/widget/asset-migrations).
 - **`defaultAmount: "max"`** — defaults the input to the user's full
   source-token balance.
 - **Solana destinations** — `targetChain: Chain | number | "solana"`,

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -32,9 +32,9 @@ npm install @reown/appkit-adapter-solana @solana/web3.js @solana/spl-token
 ```
 
 <Note>
-All five of the above are **optional** peers. An app that supplies its own wallet
-client never loads Reown — the modal imports it lazily, so it stays out of your
-bundle entirely.
+All five of the above are **optional** peer dependencies. An app that supplies its
+own wallet client never loads Reown — the modal imports it lazily, so it stays out
+of your bundle entirely.
 </Note>
 
 The modal ships with its own `wagmi` and `@tanstack/react-query` providers — you do not need to wrap your app with `WagmiProvider` or `QueryClientProvider`.

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart"
+title: "Widget quickstart"
 description: "Add the deposit widget to your React app and accept cross-chain deposits in minutes."
 ---
 

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -19,22 +19,25 @@ This quickstart has the modal connect the wallet itself, via Reown. If you don't
 npm install @rhinestone/deposit-modal viem wagmi @tanstack/react-query
 ```
 
-Add Reown only if you want the modal to connect the wallet — these are optional peer dependencies, so skip them when you pass your own `walletClient` or run a flow with no wallet:
+If you want the modal to connect the wallet — that is, you pass `reownAppId` — add
+all five of these:
 
 ```bash
-npm install @reown/appkit @reown/appkit-adapter-wagmi
+npm install @reown/appkit @reown/appkit-adapter-wagmi \
+  @reown/appkit-adapter-solana @solana/web3.js @solana/spl-token
 ```
 
-For Solana sources or destinations, add:
-
-```bash
-npm install @reown/appkit-adapter-solana @solana/web3.js @solana/spl-token
-```
+<Warning>
+The Solana three are **not** optional on this path, despite being marked optional
+peers. Reown's connect view always registers the Solana adapter, so the chunk that
+loads it imports all three statically — an EVM-only app that omits them gets a
+module-resolution failure when the modal opens.
+</Warning>
 
 <Note>
-All five of the above are **optional** peer dependencies. An app that supplies its
-own wallet client never loads Reown — the modal imports it lazily, so it stays out
-of your bundle entirely.
+Supply your own `walletClient` instead and you need none of the five. Reown is
+imported lazily, so it stays out of your bundle entirely — which is what makes them
+optional peers in `package.json`.
 </Note>
 
 The modal ships with its own `wagmi` and `@tanstack/react-query` providers — you do not need to wrap your app with `WagmiProvider` or `QueryClientProvider`.

--- a/docs.json
+++ b/docs.json
@@ -403,6 +403,7 @@
               "deposits/widget/quickstart",
               "deposits/widget/backend",
               "deposits/widget/deposit-modal",
+              "deposits/widget/asset-migrations",
               "deposits/widget/withdraw-modal",
               "deposits/widget/claim-modal",
               "deposits/widget/customization",

--- a/styles/config/vocabularies/Rhinestone/accept.txt
+++ b/styles/config/vocabularies/Rhinestone/accept.txt
@@ -202,3 +202,21 @@ widget('?s)?
 signable
 untrusted
 fundable
+
+# Pre-existing across the tree (deposits API, smart-wallet, sdk-reference).
+# The camelCase entries are SDK method names used as page `title:` values in
+# sdk-reference, where they cannot be wrapped in backticks.
+backoff
+deduplicat(e|es|ed)
+Idempotency
+integrators?
+preselect(s|ing|ed)?
+unix
+usdc
+walkthroughs?
+withdrawable
+assembleTransaction
+createSession
+disableSession
+enableSession
+toSession

--- a/styles/config/vocabularies/Rhinestone/accept.txt
+++ b/styles/config/vocabularies/Rhinestone/accept.txt
@@ -193,3 +193,12 @@ KYC
 iframes?
 WebViews?
 prefill(s|ed)?
+
+# Deposit widget (0.9.0 docs). Possessive forms follow the `validator('?s)?`
+# pattern already used above — Vale flags `Swapped's` even though `Swapped` is a
+# dictionary word.
+Swapped('?s)?
+widget('?s)?
+signable
+untrusted
+fundable


### PR DESCRIPTION
Follow-up to #183, applying the Stripe-comparison pass on the deposit pages.

## Version annotations belong in one place

The reference pages had accumulated thirteen "removed in v0.9.0" / "before v0.9.0" / "new in v0.9.0" notes. Reference should describe what exists; provenance belongs in the migration guide, which is organised by version and never needs re-touching. Annotating reference pages means every release re-annotates them — Timur's point on #183, generalised.

- **8 deleted** — notes that only recorded what used to be true
- **4 de-versioned** — statements that are simply current facts (`/register-managed` is required, AppKit peers are optional)
- **1 kept, reworded** — from changelog entry into the hazard it actually is: *an integration that never set `backendUrl` is live on Rhinestone's API key*

Two useful details were rescued from deleted notes rather than lost: subsetting sources needs a matching API key, and omitting the withdraw target opens a same-chain withdrawal.

`deposits/widget` now has zero version references outside `migration.mdx`.

## Split `deposit-modal.mdx`

398 lines across 11 top-level sections, ~3× the next reference page. Asset migrations was the one genuinely self-contained part — provider list, Polymarket specifics, the headless `getPolymarketAccount` helper — so it's now `deposits/widget/asset-migrations`, and the reference drops to **324 lines**. Old section is a two-sentence pointer; every inbound anchor repointed; page added to the nav.

## Named the quickstarts

Both were titled "Quickstart", so the sidebar showed the label twice and search couldn't disambiguate. Now **"Widget quickstart"** and **"API quickstart"**.

## Vale

`vale` reports **0 errors in 165 files** — the first time AGENTS.md's "should report 0 errors across the tree" has been true.

- 7 findings my #183 introduced: `Swapped's`, `widget's`, `signable`, `untrusted`, `fundable`
- 15 pre-existing elsewhere: `backoff`, `Idempotency`, `withdrawable` and friends, plus five SDK method names used as `sdk-reference` page `title:` values where backticks aren't possible

All added using the file's existing regex conventions so inflections are covered.

<details>
<summary>Two things worth knowing about the Vale setup</summary>

**Mintlify reports Vale findings as `neutral`, not `failure`.** The check never blocks and its findings are invisible unless you open the check run — which is how #183 merged with seven warnings. Enforcement would be a Mintlify-side setting.

**It's also diff-scoped**, so pre-existing errors in untouched files are never re-surfaced. That's how 15 sat on main while other PRs came back `success`.
</details>

## Verification

- `vale deposits` and `vale` across the tree: 0 errors
- `mintlify broken-links`: unchanged at the 9 pre-existing `api-reference` failures
- all 27 ts/tsx snippets validate against the modal's real types (71 props)
- every changed page plus the new one renders under `mintlify dev`

Context: [RHI-5125](https://linear.app/rhinestone/issue/RHI-5125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)