### PR TITLE
docs: describe the deposit widget in the present tense

### DIFF
--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -5,18 +5,12 @@ description: "The widget needs a proxy holding your Rhinestone API key. Write on
 
 The widget runs in the browser, so it can't hold your Rhinestone API key — the key authorizes writes against your project, from registering accounts to spending sponsorship. Every request the modal makes goes to a proxy **you** run, which attaches the key and forwards to the deposit processor.
 
-All three modals take it as a required `backendUrl`. There is deliberately no default: a Rhinestone-operated fallback would mean your users' deposits ride our key.
+All three modals take it as a required `backendUrl`. There is no default — point it at a proxy you run, on your own key.
 
 Two ways to get one:
 
 - **Write your own.** A route table and a header — see [minimal proxy](#minimal-proxy).
 - **Deploy Rhinestone's.** We're open-sourcing the proxy we run for clients, so you can deploy it as-is. Coming soon.
-
-<Note>
-Before v0.9.0 `backendUrl` was optional and defaulted to a Rhinestone-internal
-service. If you never set it, you were using ours — set it now. See
-[migration](/deposits/widget/migration).
-</Note>
 
 ## Minimal proxy
 
@@ -108,7 +102,7 @@ Missing a route doesn't degrade the flow — the request 404s and that part of t
 
 | Method | Route | Used for |
 |---|---|---|
-| `POST` | `/register-managed` | Registering the deposit account. **Required from modal v0.9.0** |
+| `POST` | `/register-managed` | Registering the deposit account. **Required** |
 | `POST` | `/quotes/preview` | Indicative fee/time quote on the review screen |
 | `GET` | `/check/:address` | Registration + target lookup |
 | `GET` | `/portfolio/:address` | EVM balances |
@@ -124,7 +118,7 @@ Missing a route doesn't degrade the flow — the request 404s and that part of t
 | `POST` | `/onramp/swapped/connect-url` | Exchange connect |
 | `GET` | `/onramp/swapped/connect-exchanges` | Exchange list |
 | `GET` | `/onramp/swapped/status/:smartAccount` | On-ramp order status |
-| `POST` | `/safe/withdraw` | Relaying a signed Safe transfer with sponsored gas. **Not used by the modal from v0.9.0** — proxy it only if your own [`onSendTransaction`](/deposits/widget/withdraw-modal#executing-the-transfer) relays through it |
+| `POST` | `/safe/withdraw` | Relaying a signed Safe transfer with sponsored gas. Not used by the modal — proxy it only if your own [`onSendTransaction`](/deposits/widget/withdraw-modal#executing-the-transfer) relays through it |
 
 <Warning>
 Proxy `GET /setup` only, never `POST /setup`. The POST is an admin write — it rotates
@@ -147,7 +141,7 @@ header fails the **whole request** at preflight against a proxy with a fixed
 allow-list, not just the header. Deploy proxy changes before the modal that needs them.
 </Warning>
 
-The header tells us which versions are live, so we can warn you about one with a known bug and reproduce issues against the build you're running. Forwarding it upstream is optional. To read the value in your own app, for a bug report:
+Forwarding it upstream is optional, but it lets a support request be matched to the exact build you're running. To read the value in your own app, for a bug report:
 
 ```ts
 import { MODAL_VERSION } from "@rhinestone/deposit-modal/constants";

--- a/deposits/widget/claim-modal.mdx
+++ b/deposits/widget/claim-modal.mdx
@@ -8,7 +8,7 @@ The `ClaimModal` returns a failed or rejected EVM deposit to the user, on the ch
 No wallet is involved, and there is no source chain to pick — the hash is looked up across every chain, so a deposit that landed on a chain your deposit flow doesn't offer is still claimable.
 
 <Note>
-New in v0.9.0, on the `./claim` subpath. Applies to deposits in `failed` or `rejected`
+On the `./claim` subpath. Applies to deposits in `failed` or `rejected`
 status; see [troubleshooting](/deposits/troubleshooting) for the dashboard equivalent.
 </Note>
 

--- a/deposits/widget/customization.mdx
+++ b/deposits/widget/customization.mdx
@@ -63,10 +63,3 @@ Toggle UI elements, set deposit constraints, and control fee display via `uiConf
 | `maxDepositUsd` | `number` | — | Maximum deposit amount in USD |
 | `feeSponsored` | `boolean` | `false` | When `true`, the network/protocol fee renders struck-through on the review, processing, and result screens, with a tooltip explaining the sponsorship |
 | `feeTooltip` | `string` | — | Custom copy for the fee info tooltip. Defaults to a generic message based on `feeSponsored`. |
-
-<Note>
-`checkLiquidity` was removed in v0.9.0. It cost an orchestrator round trip per
-continue to compute a warning the review screen never rendered. The liquidity cap
-is still checked and shown where it matters — on the QR / transfer screen. See
-[migration](/deposits/widget/migration).
-</Note>

--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -11,12 +11,6 @@ The `DepositModal` component handles the full deposit flow: funding method, sour
 
 The deposit account is [service-managed](#account-setup) and derived from `(recipient, targetChain, targetToken)`, so it doesn't depend on which wallet the user pays from — or on a wallet existing at all. Changing the target changes the deposit address.
 
-<Note>
-Before v0.9.0 the account was derived from the connected wallet, and a `dappAddress`
-prop carried the user's identity through the flow. Both are gone — see
-[migration](/deposits/widget/migration).
-</Note>
-
 ## Connecting a wallet
 
 Three options. The wallet is optional in all of them.
@@ -154,22 +148,19 @@ The check fails open — an RPC error lets the flow continue rather than false-b
 
 ### Restricting which sources you accept
 
-Which chains and tokens you accept is your project's **deposit whitelist**, set via `POST /setup` and enforced by the processor when a deposit arrives. Configure it there rather than in the modal.
+Which chains and tokens you accept is your project's **deposit whitelist**, set via `POST /setup` and enforced by the processor when a deposit arrives. Configure it there rather than in the modal. To offer a restricted subset, use an API key whose whitelist matches.
 
-<Note>
-The `allowedRoutes` prop was removed in v0.9.0. It filtered the pickers on the
-client only, with no enforcement behind it — so a whitelist and an `allowedRoutes`
-list that drifted apart would offer the user a source the processor then rejected.
-To offer a restricted subset, use an API key whose whitelist matches. See
-[migration](/deposits/widget/migration).
-</Note>
+<Warning>
+Filtering the pickers client-side instead offers the user a source the processor then
+rejects, as soon as the two lists drift apart. The whitelist is the only place the
+restriction is enforced.
+</Warning>
 
 ## Account setup
 
-From v0.9.0 the modal uses **service-managed accounts**: the deposit account is
-owned by Rhinestone and settles to your `recipient`, so there is no session key
-to configure and the user is never asked to sign during setup. The
-`signerAddress` and `sessionChainIds` props were removed in that release.
+The modal uses **service-managed accounts**: the deposit account is owned by
+Rhinestone and settles to your `recipient`, so there is no session key to configure
+and the user is never asked to sign during setup.
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
@@ -216,15 +207,9 @@ deposit entry screen and opens a picker over that provider's positions. The user
 picks one, and the modal pulls the funds into their smart account and bridges
 them to `targetChain` / `targetToken` like any other source.
 
-| Key | Status |
-|---|---|
-| `polymarket` | Live |
-| `hyperliquid` | Coming soon |
-| `aave` | Coming soon |
-| `morpho` | Coming soon |
-
-Only the providers you enable are listed. Enabling one that isn't live yet shows it
-as a disabled "Coming soon" row rather than hiding it.
+`polymarket` is the provider available today. Only the providers you enable are
+listed, and one that isn't available yet renders as a disabled row rather than being
+hidden.
 
 ### Polymarket
 
@@ -391,8 +376,8 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 See [status tracking](/deposits/widget/status-tracking) for lifecycle event payloads.
 
 <Note>
-`enableSolana` was removed in v0.9.0. Solana sources follow your project's deposit
-whitelist like every other source, so there is no separate client-side toggle.
+Solana sources follow your project's deposit whitelist like every other source —
+there is no separate client-side toggle.
 </Note>
 
 ## Content security policy

--- a/deposits/widget/status-tracking.mdx
+++ b/deposits/widget/status-tracking.mdx
@@ -40,8 +40,7 @@ If the bridge fails after submission, `"failed"` is emitted instead of
 <Warning>
 `"connected"` fires only for wallet funding. QR transfer, fiat on-ramp and exchange
 connect involve no wallet, so it never fires — use `onReady` if you need a "flow
-started" signal. Before v0.9.0 it fired with the declared address as though a wallet
-had connected.
+started" signal.
 </Warning>
 
 ## onLifecycle

--- a/deposits/widget/withdraw-modal.mdx
+++ b/deposits/widget/withdraw-modal.mdx
@@ -88,10 +88,6 @@ Safe's `eth_sign` path requires adding 4 to the `v` value of a `personal_sign` s
 
 To keep gas sponsored, relay the signed transaction through `POST /safe/withdraw` on your proxy rather than submitting `execTransaction` from the user's wallet. Note that a relayed transaction cannot use Safe's pre-validated (`v = 1`) signature shortcut: that only validates when `msg.sender` is the owner, and for a relayed call the sender is the relayer.
 
-<Note>
-Before v0.9.0 the modal did all of this internally, behind a `safeAddress` prop and an `onSignTransaction` callback. See [migration](/deposits/widget/migration) if you are upgrading.
-</Note>
-
 ## Props reference
 
 ### Required
@@ -116,10 +112,9 @@ Before v0.9.0 the modal did all of this internally, behind a `safeAddress` prop 
 | `defaultAmount` | `string` | — | Pre-filled withdrawal amount |
 
 <Note>
-`targetChain` and `targetToken` became **optional** in v0.9.0 — they only ever
-seeded the form, which lets the user pick any supported destination. Omit them to
-open on a same-chain, same-token withdrawal. `allowedRoutes` was removed in the same
-release; see [migration](/deposits/widget/migration).
+`targetChain` and `targetToken` are optional — they seed the form, and the user can
+pick any supported destination. Omit them to open on a same-chain, same-token
+withdrawal.
 </Note>
 
 ### Account


### PR DESCRIPTION
Strips version archaeology and our-side rationale from the deposits docs. Part of [RHI-5164](https://linear.app/rhinestone/issue/RHI-5164).

## Version traces removed (12 of 14)

Audited the whole deposits section: 14 inline version deltas outside the migration guide. These are the 12 that can go now.

The key finding is that **`migration.mdx` already documents every removed prop** it mentioned — `checkLiquidity`, `allowedRoutes`, `enableSolana`, `safeAddress`, `onSignTransaction`, `dappAddress`, `signerAddress`, `sessionChainIds`, and `backendUrl` becoming required, at lines 19–125. So this is deduplication, not information loss.

Where a note carried a **present-tense fact** wrapped in a version delta, the fact is kept and restated without the version framing:

- `targetChain`/`targetToken` are optional and seed the form
- Solana sources follow the deposit whitelist, no client-side toggle
- filtering the pickers client-side offers a source the processor rejects (kept, promoted to a `<Warning>` since it's the actual hazard)

## Rationale written from our side

- `backend.mdx` — "There is **deliberately** no default: a Rhinestone-operated fallback would mean your users' deposits ride **our** key" → "There is no default — point it at a proxy you run, on your own key."
- `backend.mdx` — "The header tells **us** which versions are live, so **we** can warn you…" → says what forwarding buys the reader.
- `deposit-modal.mdx` — the asset-migration table advertised `hyperliquid`/`aave`/`morpho` as **"Coming soon"**. Roadmap doesn't belong in a reference table. The behaviour it was really documenting (a disabled row appears rather than being hidden) is kept as a sentence, so nobody setting one of those keys is surprised.

## Deliberately untouched

- `backend.mdx:13` — the "Coming soon" proxy bullet, rewritten by #187. Left alone to avoid a conflict.
- `quickstart.mdx:35` — "optional peers **as of v0.9.0**", which the quickstart restructure will handle.

## Verification

`vale deposits/` reports **18 errors, identical to `main`'s baseline** (compared via `git archive origin/main`) — no new errors introduced. Net −34 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)