### PR TITLE
docs: make both deposit quickstarts runnable, on mainnet

### DIFF
--- a/deposits/api/quickstart.mdx
+++ b/deposits/api/quickstart.mdx
@@ -11,10 +11,15 @@ a component — UI, funding methods, withdrawals and refunds included — on top
 same API.
 </Tip>
 
+<Warning>
+This runs on mainnet and moves real funds. The deposit step below sends 1 USDC —
+keep it small until the flow works end to end.
+</Warning>
+
 ## Prerequisites
 
-- A Rhinestone API key
-- A wallet with testnet USDC on Optimism Sepolia ([Circle faucet](https://faucet.circle.com/))
+- A [Rhinestone API key](https://tally.so/r/wg22x4)
+- A wallet with USDC on Arbitrum
 
 <Steps>
 
@@ -36,8 +41,8 @@ const response = await fetch(`${DEPOSIT_SERVICE_URL}/setup`, {
   body: JSON.stringify({
     params: {
       sponsorship: {
-        "eip155:84532": { gas: "all" }, // Base Sepolia
-        "eip155:11155420": { gas: "all" }, // Optimism Sepolia
+        "eip155:8453": { gas: "all" }, // Base
+        "eip155:42161": { gas: "all" }, // Arbitrum
       },
     },
   }),
@@ -61,8 +66,8 @@ import { keccak256, toHex } from "viem";
 const salt = keccak256(toHex("user-123"));
 
 const RECIPIENT = "0xYOUR_RECIPIENT_ADDRESS";
-const TARGET_CHAIN = "eip155:84532"; // Base Sepolia
-const TARGET_TOKEN = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"; // USDC on Base Sepolia
+const TARGET_CHAIN = "eip155:8453"; // Base
+const TARGET_TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // USDC on Base
 
 const registerResponse = await fetch(
   `${DEPOSIT_SERVICE_URL}/register-managed`,
@@ -98,7 +103,9 @@ You should see two deposit addresses printed. The `evmDepositAddress` is where u
 <Step title="Verify registration">
 
 ```ts
-const check = await fetch(`${DEPOSIT_SERVICE_URL}/check/${evmDepositAddress}`);
+const check = await fetch(`${DEPOSIT_SERVICE_URL}/check/${evmDepositAddress}`, {
+  headers: { "x-api-key": API_KEY },
+});
 const checkData = await check.json();
 console.log(checkData);
 ```
@@ -108,12 +115,12 @@ You should see:
 ```json
 {
   "isRegistered": true,
-  "targetChain": "eip155:84532",
-  "targetToken": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  "targetChain": "eip155:8453",
+  "targetToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   "sources": [
-    { "chain": "eip155:84532", "depositAddress": "<evmDepositAddress>" },
-    { "chain": "eip155:11155420", "depositAddress": "<evmDepositAddress>" },
-    { "chain": "eip155:421614", "depositAddress": "<evmDepositAddress>" }
+    { "chain": "eip155:8453", "depositAddress": "<evmDepositAddress>" },
+    { "chain": "eip155:42161", "depositAddress": "<evmDepositAddress>" },
+    { "chain": "eip155:10", "depositAddress": "<evmDepositAddress>" }
   ]
 }
 ```
@@ -122,7 +129,7 @@ You should see:
 
 <Step title="Deposit tokens">
 
-Transfer USDC to the deposit address on Optimism Sepolia. The deposit service detects it and bridges it to Base Sepolia automatically.
+Transfer USDC to the deposit address on Arbitrum. The deposit service detects it and bridges it to Base automatically.
 
 ```ts
 import {
@@ -133,17 +140,17 @@ import {
   parseUnits,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { optimismSepolia } from "viem/chains";
+import { arbitrum } from "viem/chains";
 
 const funder = privateKeyToAccount("0xYOUR_FUNDING_KEY");
 const walletClient = createWalletClient({
   account: funder,
-  chain: optimismSepolia,
+  chain: arbitrum,
   transport: http(),
 });
 
-// USDC on Optimism Sepolia
-const USDC = "0x5fd84259d66Cd46123540766Be93DFE6D43130D7";
+// USDC on Arbitrum
+const USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
 
 const txHash = await walletClient.sendTransaction({
   to: USDC,
@@ -191,7 +198,7 @@ async function waitForDeposit(txHash: string) {
 await waitForDeposit(txHash);
 ```
 
-Once bridging completes, the deposit status changes to `completed` and includes the destination transaction hash. The USDC is now at the recipient address on Base Sepolia.
+Once bridging completes, the deposit status changes to `completed` and includes the destination transaction hash. The USDC is now at the recipient address on Base.
 
 </Step>
 

--- a/deposits/widget/quickstart.mdx
+++ b/deposits/widget/quickstart.mdx
@@ -32,9 +32,9 @@ npm install @reown/appkit-adapter-solana @solana/web3.js @solana/spl-token
 ```
 
 <Note>
-All five of the above are **optional** peers as of v0.9.0. An app that supplies its
-own wallet client never loads Reown — the modal imports it lazily, so it stays out
-of your bundle entirely.
+All five of the above are **optional** peers. An app that supplies its own wallet
+client never loads Reown — the modal imports it lazily, so it stays out of your
+bundle entirely.
 </Note>
 
 The modal ships with its own `wagmi` and `@tanstack/react-query` providers — you do not need to wrap your app with `WagmiProvider` or `QueryClientProvider`.
@@ -42,6 +42,29 @@ The modal ships with its own `wagmi` and `@tanstack/react-query` providers — y
 The package ships no `"use client"` directive, so in the Next.js App Router put it in a component that has one.
 
 <Steps>
+
+<Step title="Run a backend">
+
+The modal can't hold your API key, so every request it makes goes through a proxy you run. Clone Rhinestone's and start it locally:
+
+```bash
+git clone https://github.com/rhinestonewtf/deposit-widget-proxy
+cd deposit-widget-proxy
+bun install
+RHINESTONE_API_KEY=your-key bun run dev
+```
+
+No Bun? `docker build -t deposit-widget-proxy . && docker run -p 4000:4000 -e RHINESTONE_API_KEY=your-key deposit-widget-proxy` does the same.
+
+Check it:
+
+```bash
+curl localhost:4000/health
+```
+
+You should see `{"ok":true}`. That URL is your `backendUrl` below. See [backend](/deposits/widget/backend) for deploying it properly, or for writing your own instead.
+
+</Step>
 
 <Step title="Render the deposit modal">
 
@@ -64,7 +87,7 @@ function App() {
         targetChain={8453}
         targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
         recipient="0xYOUR_RECIPIENT_ADDRESS"
-        backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL!}
+        backendUrl="http://localhost:4000"
         reownAppId={process.env.NEXT_PUBLIC_REOWN_PROJECT_ID!}
       />
     </>
@@ -72,7 +95,9 @@ function App() {
 }
 ```
 
-This renders a modal where the user connects their wallet, picks a source chain and token, enters an amount, and confirms the deposit. Bridging to the target chain is handled automatically.
+Click the button and the modal should open on the wallet-connect screen. From there the user picks a source chain and token, enters an amount, and confirms the deposit; bridging to the target chain is handled automatically.
+
+If the modal opens but the token list is empty, the proxy isn't reachable — check the terminal running it.
 
 </Step>
 
@@ -87,7 +112,7 @@ Add the `onLifecycle` callback and react to the `"complete"` event when tokens a
   targetChain={8453}
   targetToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   recipient="0xYOUR_RECIPIENT_ADDRESS"
-  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL!}
+  backendUrl="http://localhost:4000"
   reownAppId={process.env.NEXT_PUBLIC_REOWN_PROJECT_ID!}
   onLifecycle={(event) => {
     if (event.type === "complete") {
@@ -106,7 +131,9 @@ Add the `onLifecycle` callback and react to the `"complete"` event when tokens a
 
 ## Before production
 
-`backendUrl` above has to point at a real proxy — one you run, holding your API key. There is no default, because a default would put your users on someone else's key. See [backend](/deposits/widget/backend) for a minimal one and the routes it must forward.
+`localhost:4000` is fine while you build, not for your users. Deploy the proxy somewhere real and point `backendUrl` at it — see [backend](/deposits/widget/backend) for the routes it must forward.
+
+This quickstart runs on **mainnet**, so a deposit moves real funds. Start with an amount you don't mind losing to a mistake.
 
 You'll also want [webhooks](/deposits/widget/backend#webhooks) for anything that must happen whether or not the modal is still open.
 


### PR DESCRIPTION
Part of [RHI-5164](https://linear.app/rhinestone/issue/RHI-5164). Stacks conceptually on #187 (which open-sources the proxy) and #188 (prose sweep), but touches neither file — no conflicts.

## ⚠️ Merge ordering

Links `github.com/rhinestonewtf/deposit-widget-proxy`, which **404s until the repo is public**. Merge after visibility flips, same as #187.

## The widget quickstart couldn't be followed

`backendUrl` is required with no default, but standing up a proxy sat in **"Before production"** — *below both code steps*. Step 1 told the reader to pass `process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL`, which they had no way of having set. There was no path from "install" to "it works".

Now that the proxy is open source, that becomes a real first step:

```bash
git clone https://github.com/rhinestonewtf/deposit-widget-proxy
cd deposit-widget-proxy && bun install
RHINESTONE_API_KEY=your-key bun run dev
curl localhost:4000/health   # {"ok":true}
```

The code blocks now carry `backendUrl="http://localhost:4000"` literally rather than an env var, so they're copy-pasteable. A Docker one-liner is offered for readers without Bun. "Before production" keeps only what belongs there — deploy it somewhere real.

## Both quickstarts now agree on mainnet

They disagreed: `api/quickstart` ran on Base Sepolia + Optimism Sepolia with a Circle faucet link, while `widget/quickstart` was already on mainnet Base. One sibling in test mode, the other in live mode.

The API page moves to **Arbitrum USDC → Base USDC**. Both addresses (`0xaf88d065…`, `0x833589fCD…`) are already used elsewhere in these docs, so nothing is newly asserted. Optimism is deliberately not the example source: the docs reference bridged USDC.e (`0x7f5c764c…`) there, which would invite the wrong token.

Mainnet means real funds, so both pages say so — a `<Warning>` on the API page and a line in the widget page's "Before production". The amount stays at 1 USDC.

## Smaller fixes

- `api/quickstart` `/check` was the only call not sending `x-api-key`.
- Its API key prerequisite now links the same form the widget page uses.
- The widget page had **no** confirmation steps; it now follows the API page's "You should see…" pattern, including the failure hint (empty token list = proxy unreachable).
- `widget/quickstart.mdx:35` drops "as of v0.9.0" — the 13th of the 14 version traces from the audit, left out of #188 to avoid touching this file twice.

## Verification

`vale` clean on both files (0 errors, matching main's baseline for the same two). `bunx mintlify broken-links` reports no quickstart entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)