### PR TITLE
docs: drop the proxy refund shape from the claim flow

### DIFF
--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -31,7 +31,6 @@ Point `backendUrl` at it and check `GET /health`. Everything else is optional an
 |---|---|
 | `RHINESTONE_API_KEY` | Attached as `x-api-key` upstream. The process exits if it's unset |
 | `DEPOSIT_SERVICE_URL` | The upstream processor. Defaults to production |
-| `REFUND_TOKEN_SECRET` | Opts into [self-service refunds](/deposits/widget/claim-modal). Unset, that route isn't registered |
 | `TRUSTED_COUNTRY_HEADER`, `TRUSTED_PROXY_HOPS`, `TRUSTED_PROXY_CIDRS` | [Regional payment methods](#regional-payment-methods) |
 
 ## Minimal proxy
@@ -110,13 +109,11 @@ that loop passes the browser's body straight through with your API key attached 
 which for a refund means anyone could return any of your recoverable deposits to an
 address they chose.
 
-It needs a handler that authorizes the specific refund, and derives the upstream
-call from that authorization rather than from the request body:
-
-- **your own route** — use [`createRefundHandler`](/deposits/widget/claim-modal#implementing-the-endpoint), which checks the deposit belongs to the caller before spending the key
-- **a proxy** — verify a per-refund `x-user-token` and take *every* upstream field from the token, ignoring the body
-
-Register it only when that verification is in place. See
+So a refund is not a route a proxy can carry: a proxy authenticates nobody, and it
+would attach your API key to whatever reached it. Authorize it in your own backend
+with [`createRefundHandler`](/deposits/widget/claim-modal#implementing-the-endpoint),
+which checks the deposit belongs to the caller before spending the key, and call the
+processor directly. See
 [claim modal](/deposits/widget/claim-modal#why-your-app-authorizes-it).
 
 ## Required routes

--- a/deposits/widget/claim-modal.mdx
+++ b/deposits/widget/claim-modal.mdx
@@ -16,12 +16,9 @@ status; see [troubleshooting](/deposits/troubleshooting) for the dashboard equiv
 
 Deposit accounts are [service-managed](/deposits/widget/deposit-modal#account-setup), so no user wallet can sign for a refund, and an exchange-funded deposit has no signable sender either. Only your app knows which of its users a deposit belongs to, so `refundEndpoint` points at something you control.
 
-Two shapes, depending on where that endpoint lives:
-
-<Tabs>
-<Tab title="Your own route (same-origin)">
-
-The browser's session cookie travels with the request, so your route authenticates the user the way it always does. No token needed — omit `getUserToken`.
+`refundEndpoint` is your own route, same-origin, so the browser's session cookie
+travels with the request and your route authenticates the user the way it always
+does.
 
 ```tsx
 import { ClaimModal } from "@rhinestone/deposit-modal/claim";
@@ -35,45 +32,15 @@ import "@rhinestone/deposit-modal/styles.css";
 />
 ```
 
-</Tab>
-<Tab title="A deposit-widget-proxy (cross-origin)">
+<Note>
+There is deliberately no cross-origin variant. A proxy authenticates nobody, so it
+cannot decide which user a deposit belongs to — and pointing `refundEndpoint` at
+another origin drops the session cookie anyway, since `fetch` omits credentials
+cross-origin. If you can authenticate the user, you can authorize the refund
+directly.
+</Note>
 
-The cookie won't travel cross-origin, so `getUserToken` mints a short-lived token that the modal sends as `x-user-token`.
-
-The proxy takes **every** field of the upstream refund from the signed token and ignores the request body, so the token must carry the whole refund — not just the user's identity.
-
-The route registers only when `REFUND_TOKEN_SECRET` is set. That's a registration gate rather than a 401 inside the handler, so bumping the proxy version can't silently expose an endpoint that spends your API key.
-
-[Rhinestone's proxy](/deposits/widget/backend#deploy-the-rhinestone-proxy) implements this already — see its [refund token contract](https://github.com/rhinestonewtf/deposit-widget-proxy#self-service-refunds) for the exact claims to sign. Note that `recipient` there is the user's in-app recipient, checked for ownership, while `destination` is where the money goes.
-
-```tsx
-import { ClaimModal } from "@rhinestone/deposit-modal/claim";
-import "@rhinestone/deposit-modal/styles.css";
-
-<ClaimModal
-  isOpen={isOpen}
-  onClose={() => setIsOpen(false)}
-  refundEndpoint="https://proxy.example.com/deposits/refund"
-  backendUrl={process.env.NEXT_PUBLIC_DEPOSIT_PROXY_URL}
-  getUserToken={async (request) => {
-    const res = await fetch("/api/refund-token", {
-      method: "POST",
-      body: JSON.stringify(request),
-    });
-    return (await res.json()).token;
-  }}
-/>
-```
-
-<Warning>
-Bind the token to **this specific refund**, not to the user alone. An
-identity-only token is a bearer credential that can be spent on any destination —
-mint it from the `RefundRequest` you were handed and sign over its fields,
-including the destination.
-</Warning>
-
-</Tab>
-</Tabs>
+`GET /deposits` still has to be proxied for the lookup step.
 
 ## Implementing the endpoint
 
@@ -140,12 +107,6 @@ The modal POSTs a `RefundRequest`. It comes from the page, so treat it as untrus
 | `onClose` | `() => void` | Called when the user closes the modal |
 | `refundEndpoint` | `string` | Endpoint the modal POSTs the refund to |
 | `backendUrl` | `string` | Your [backend proxy](/deposits/widget/backend), which holds your API key |
-
-### Authorization
-
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `getUserToken` | `(request: RefundRequest) => Promise<string>` | — | Mints a token authorizing exactly this refund, sent as `x-user-token`. Required when `refundEndpoint` is cross-origin |
 
 ### Prefills
 


### PR DESCRIPTION
Part of RHI-5256. Pairs with rhinestonewtf/deposit-modal#109 and
rhinestonewtf/deposit-widget-proxy#16, which remove the prop and the route this
documented.

`ClaimModal` no longer supports authorizing a refund with a token minted for a
cross-origin `deposit-widget-proxy`. `getUserToken` is gone in 0.9.0 and the proxy's
`POST /deposits/refund` is deleted — both were unused: `ClaimModal` has never shipped
to `@latest`, and `REFUND_TOKEN_SECRET` was set in no environment, ours or a client's.

## Changes

- **claim-modal**: collapses the two tabs to the one shape. The second tab is replaced
  by why there isn't one — a proxy authenticates nobody, so it can't decide which user
  a deposit belongs to, and pointing `refundEndpoint` at another origin drops the
  session cookie anyway (`fetch` omits credentials cross-origin). Removes the
  Authorization props table, which had `getUserToken` as its only row.
- **backend**: drops the `REFUND_TOKEN_SECRET` env row and the "a proxy — verify a
  per-refund `x-user-token`" bullet, which described the deleted route. The remaining
  text says plainly that a refund isn't a route a proxy can carry.

## Checks

Vale reports 3 spelling errors across both files (`signable`, `untrusted`,
`widget's`) — all pre-existing on `main` at the same words, verified by running Vale
against the pre-change versions. This PR introduces none and fixes none; they look
like vocab entries for whoever is working through `docs/vale-vocab-and-version-notes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)