### PR TITLE
docs: serve every chain list from the API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,15 @@ Docs: https://docs.rhinestone.dev
 
 Note: Mintlify requires Node 22 LTS. If you have multiple Node versions, ensure Node 22 is active.
 
+Gotcha: `mintlify dev` can report "A parsing error occured" for a page whose MDX is
+actually valid. The stale compile survives a server restart *and* deleting
+`~/.mintlify/mint/apps/client/.next/cache`; only a file-change event clears it. Before
+hunting the syntax, copy the file to an unused path (`cp x.mdx ztest.mdx`) and load
+that — if the byte-identical copy renders, the content is fine and you just need to
+re-save the original. Page content is client-rendered, so `curl` returns an empty app
+shell; you need a real browser to see errors. The CLI's own log carries the underlying
+message (`Could not parse expression with acorn`).
+
 ## Stack
 
 - Framework: Mintlify

--- a/deposits/api/account-registration.mdx
+++ b/deposits/api/account-registration.mdx
@@ -148,7 +148,7 @@ const { factory, factoryData } = account.getInitData();
 </Step>
 <Step title="Build session details">
 
-The deposit service uses a session key to sign bridging transactions on the user's behalf. You need to build session details for every chain the user can deposit from, plus the target chain.
+The deposit service uses a session key to sign bridging transactions on the user's behalf. Build session details for every chain you accept deposits from, plus the target chain — a deposit arriving on a chain with no session can't be bridged. See [supported chains and tokens](/deposits/overview#supported-chains-and-tokens) for the current set.
 
 ```ts
 import { toViewOnlyAccount } from "@rhinestone/sdk/utils";
@@ -157,7 +157,7 @@ import { base, optimism, arbitrum } from "viem/chains";
 const RHINESTONE_SIGNER_ADDRESS = "0x177bfcdd15bc01e99013dcc5d2b09cd87a18ce9c";
 const sessionSigner = toViewOnlyAccount(RHINESTONE_SIGNER_ADDRESS);
 
-const sourceChains = [base, optimism, arbitrum];
+const sourceChains = [base, optimism, arbitrum]; // extend to every chain you accept
 const sessions = sourceChains.map((chain) => ({
   owners: { type: "ecdsa" as const, accounts: [sessionSigner] },
   chain,

--- a/deposits/overview.mdx
+++ b/deposits/overview.mdx
@@ -3,6 +3,82 @@ title: "Overview"
 description: "Accept deposits from any chain into your app with Rhinestone's cross-chain deposit infrastructure."
 ---
 
+export const DepositChainsTable = ({ chains }) => (
+  <table className="min-w-full">
+    <thead>
+      <tr className="border-b border-gray-200 dark:border-gray-700">
+        <th className="text-left py-2 pr-4 font-semibold">Name</th>
+        <th className="text-center py-2 pr-4 font-semibold">Source</th>
+        <th className="text-center py-2 pr-4 font-semibold">Destination</th>
+        <th className="text-left py-2 font-semibold">Tokens</th>
+      </tr>
+    </thead>
+    <tbody>
+      {chains.map((chain) => (
+        <tr key={chain.id} className="border-b border-gray-100 dark:border-gray-800">
+          <td className="py-2 pr-4">{chain.name}</td>
+          <td className="py-2 pr-4 text-center">{chain.deposit ? '✓' : '—'}</td>
+          <td className="py-2 pr-4 text-center">{chain.destination ? '✓' : '—'}</td>
+          <td className="py-2">{chain.supportedTokens === 'all' ? 'All' : (chain.supportedTokens?.map(t => t.symbol).join(', ') || '-')}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export const DepositChains = () => {
+  const [chains, setChains] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch("https://v1.orchestrator.rhinestone.dev/deposit-processor/chains")
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to fetch chains');
+        return res.json();
+      })
+      .then(data => {
+        const byName = new Map();
+        Object.entries(data).forEach(([id, chain]) => {
+          const kept = byName.get(chain.name);
+          // A virtual chain can be advertised twice: once under its canonical
+          // CAIP-2 namespace and once as `eip155:<synthetic id>`. Keep the
+          // canonical entry, which carries the accurate capability flags.
+          const isCanonical = !id.startsWith('eip155:');
+          if (!kept || (isCanonical && kept.id.startsWith('eip155:'))) {
+            byName.set(chain.name, { ...chain, id });
+          }
+        });
+        setChains([...byName.values()].sort((a, b) => a.name.localeCompare(b.name)));
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return <div className="text-gray-500 dark:text-gray-400 py-4">Loading chains...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-500 dark:text-red-400 py-4">Error loading chains: {error}</div>;
+  }
+
+  const mainnets = chains.filter(chain => !chain.testnet);
+  const testnets = chains.filter(chain => chain.testnet);
+
+  return (
+    <>
+      <h3>Mainnet</h3>
+      <DepositChainsTable chains={mainnets} />
+      <h3>Testnet</h3>
+      <DepositChainsTable chains={testnets} />
+    </>
+  );
+};
+
 Rhinestone Deposits is a cross-chain deposit infrastructure that lets you accept tokens from users on any supported chain and deliver them to a target chain and token automatically. You don't need to build bridging logic, manage gas across chains, or handle token swaps — the service detects deposits, bridges them via [Warp](/home/introduction/rhinestone-intents), and notifies your app when funds arrive.
 
 It's built for teams that need reliable deposit rails: neobanks, modern dapps, DeFi protocols, or any app that onboards users from multiple chains.
@@ -71,7 +147,7 @@ Under the hood, Rhinestone aggregates multiple bridging providers, solvers, and 
 ## Key features
 
 - **Automatic bridging** — deposits are detected and bridged to the target chain without any user interaction beyond the initial transfer
-- **Multi-chain support** — accept deposits from Ethereum, Base, Arbitrum, Optimism, Polygon, and Solana, with more chains added regularly
+- **Multi-chain support** — accept deposits from [any supported chain](#supported-chains-and-tokens), EVM or Solana, with more added regularly
 - **1:1 stablecoin swaps** — USDC and USDT are swapped at parity
 - **Swap routing** — route between tokens as part of the deposit
 - **Fee sponsorship** — cover gas, bridging, and swap fees on a per-chain basis
@@ -86,49 +162,13 @@ With the **API**, you control the UX entirely. The user interacts with your app 
 
 ## Supported chains and tokens
 
-{/*
-  Source: GET https://v1.orchestrator.rhinestone.dev/deposit-processor/chains
-
-  Hardcoded as plain markdown tables so they render at SSR time (no client-side
-  fetch, no flash-of-loading). Refresh manually when the upstream list changes.
-*/}
-
 Rhinestone Deposits supports a wide range of EVM chains plus Solana. Each chain is enabled as a **source** (the user can send funds to it), a **destination** (funds can settle on it), or both.
 
 - **Source** — users can transfer tokens on this chain and have them bridged to the target.
 - **Destination** — accounts on this chain can be registered as the target where funds land.
 - **Tokens** — `All` means any token routable through Warp; otherwise, only the listed tokens are accepted.
 
-### Mainnet
-
-| Name            | Source  | Destination | Tokens                |
-| :-------------- | :-----: | :---------: | :-------------------- |
-| Ethereum        |    ✓    |      ✓      | All                   |
-| OP Mainnet      |    ✓    |      ✓      | All                   |
-| BNB Smart Chain |    ✓    |      ✓      | All                   |
-| Gnosis          |    ✓    |      ✓      | All                   |
-| Polygon         |    ✓    |      ✓      | All                   |
-| Sonic           |    ✓    |      ✓      | All                   |
-| HyperEVM        |    ✓    |      ✓      | All                   |
-| HyperCore       |    —    |      ✓      | USDC                  |
-| Soneium         |    ✓    |      ✓      | ETH, USDC, USDT, WETH |
-| Base            |    ✓    |      ✓      | All                   |
-| Plasma          |    ✓    |      ✓      | All                   |
-| Arbitrum One    |    ✓    |      ✓      | All                   |
-| Unichain        |    ✓    |      ✓      | All                   |
-| Monad           |    ✓    |      ✓      | All                   |
-| Katana          |    —    |      ✓      | ETH, USDC, USDT, WETH |
-| Solana          |    ✓    |      ✓      | USDC, USDT, SOL       |
-
-### Testnet
-
-| Name             | Source  | Destination | Tokens                   |
-| :--------------- | :-----: | :---------: | :----------------------- |
-| Sepolia          |    ✓    |      ✓      | ETH, USDC, WETH          |
-| OP Sepolia       |    ✓    |      ✓      | ETH, USDC, WETH          |
-| Base Sepolia     |    ✓    |      ✓      | ETH, USDC, WETH, MockUSD |
-| Arbitrum Sepolia |    ✓    |      ✓      | ETH, USDC, WETH          |
-| Plasma Testnet   |    —    |      ✓      | USDT0, USDC              |
+<DepositChains />
 
 <Info>
   This data is also available programmatically via the [List supported chains

--- a/home/resources/quick-reference.mdx
+++ b/home/resources/quick-reference.mdx
@@ -23,7 +23,7 @@ Authentication: pass your API key in the `x-api-key` header. [Request a key](htt
 
 ## Supported chains
 
-See [Supported chains](/home/resources/supported-chains) for the full list with token addresses.
+See [Supported chains](/home/resources/supported-chains) for the full list with supported tokens.
 
 ## Account types
 

--- a/home/resources/supported-chains.mdx
+++ b/home/resources/supported-chains.mdx
@@ -73,44 +73,11 @@ export const IntentChains = () => {
   );
 };
 
-## Intent-Based Transaction Support
-
-Rhinestone intents can be supported on any chain where an integrated settlement layer is deployed. Today, we support Across, Relay, and Eco.
+Rhinestone intents are supported on any chain where an integrated settlement layer is deployed.
 
 <IntentChains />
 
-## Smart Account Infra
-
 <Info>
-  See the [Address Book](../resources/address-book#modules) to get a breakdown
-  for each module
+  See the [Address Book](/home/resources/address-book) for the contract and
+  module addresses deployed on these chains.
 </Info>
-
-### Mainnet Support
-
-| Name            |  Chain |
-| :-------------- | -----: |
-| Ethereum        |      1 |
-| Base            |   8453 |
-| Optimism        |     10 |
-| Arbitrum One    |  42161 |
-| Polygon         |    137 |
-| Avalanche       |  43114 |
-| Gnosis          |    100 |
-| Scroll          | 534352 |
-| BNB Smart Chain |     56 |
-| ZKsync Era      |    324 |
-
-### Testnet Support
-
-| Name                        |    Chain |
-| :-------------------------- | -------: |
-| Sepolia                     | 11155111 |
-| Base Sepolia                |    84532 |
-| Optimism Sepolia            | 11155420 |
-| Arbitrum Sepolia            |   421614 |
-| Polygon Amoy                |    80002 |
-| Avalanche Fuji              |    43113 |
-| Scroll Sepolia              |   534351 |
-| Binance Smart Chain Testnet |       97 |
-| ZKsync Sepolia Testnet      |      300 |


### PR DESCRIPTION
## What

The deposits chain table was hand-maintained, and had drifted:

| | Table said | `/deposit-processor/chains` says |
|---|---|---|
| Avalanche | absent | source + destination, all tokens |
| Robinhood Chain | absent | source + destination, all tokens |
| Solana tokens | `USDC, USDT, SOL` | all |
| HyperCore source | `—` | `✓` |

It now fetches `GET /deposit-processor/chains`, the same way the intent table already fetches `/chains`. The endpoint is unauthenticated and sends `Access-Control-Allow-Origin: *`, so this costs a loading state and nothing else — a trade already made for the intent table on the same site.

## Also dropped

- **"Smart Account Infra" tables** on the supported chains page. Last touched 2025-08-12, diverged in both directions: listed Scroll and ZKsync Era (no longer in `/chains`), omitted every chain added since. No endpoint serves module deployments, so rather than leave a table nobody updates, the page points at the Address Book. Dropping Scroll and ZKsync Era is confirmed intentional.
- **"Today, we support Across, Relay, and Eco"** — out of date. Settlement layers aren't enumerated anywhere else in the docs; they only appear as illustrative `settlementLayers: ['ACROSS']` values.

Two prose fixes in the same vein: the deposits feature bullet claimed six source chains while its own table listed sixteen, and the account-registration guide said to build sessions for "every chain the user can deposit from" directly above a three-chain array — copy that and deposits arriving elsewhere have no session key to sign the bridge.

## The dedupe, and the bug behind it

The table dedupes by chain name, preferring a canonical CAIP-2 key over an `eip155:` one. Without it HyperCore renders **twice, with contradictory Source flags** — it's advertised under both `hypercore:mainnet` and a synthetic `eip155:1337`.

That's a processor-side bug: `src/constants/chains.ts` skips `vmType !== 'evm'` but not `virtual`, and shared-configs deliberately keeps virtual chains EVM-typed, so HyperCore leaks through keyed by `fromEvmChainId()` and its own `caip2` field is ignored. `hypercore:mainnet` is authoritative (its `deposit: true` is real). Being fixed separately — the dedupe is commented and can come out then.

## Verification

- All four pages rendered in a real browser: tables populate from the live API, no console errors
- `vale` clean on all changed files
- No new broken links (remaining ones are pre-existing `api-reference/*` paths)

Also added an `AGENTS.md` note about a `mintlify dev` false "parsing error" that survives a restart and cache clear — it cost real time here.


Closes [RHI-5284](https://linear.app/rhinestone/issue/RHI-5284)

