### PR TITLE
docs: correct the widget docs against what 0.9.0 actually ships

### DIFF
--- a/deposits/widget/deposit-modal.mdx
+++ b/deposits/widget/deposit-modal.mdx
@@ -97,15 +97,29 @@ Each method is a row on the modal's home screen. When exactly one is enabled the
 | `enableWallet` | `boolean` | `true` | Offer the connected wallet as a source. Turn off for a flow with no wallet even when a `walletClient` or `reownAppId` is supplied |
 | `enableQrTransfer` | `boolean` | `true` | Offer the "Transfer crypto" row — a deposit address and QR code the user sends to from anywhere |
 | `enableFiatOnramp` | `boolean` | `false` | Offer card / bank / Apple Pay payment via Swapped's embedded iframe |
-| `fiatMethods` | `FiatMethodsConfig` | all | Restrict which Swapped payment groups the on-ramp offers |
+| `fiatMethods` | `FiatMethodsConfig` | regional | Restrict which Swapped payment groups the on-ramp offers. Omitting it uses [regional personalization](#regional-payment-methods) |
 | `enableExchangeConnect` | `boolean` | `false` | Offer "Connect exchange" — the user picks their CEX inside Swapped's iframe and withdraws from it |
 | `assetMigrations` | `AssetMigrationsConfig` | none | Offer [migrating balances](#migrate-assets-from-other-apps) the user already holds in a supported third-party app |
 
 `enableFiatOnramp` and `enableExchangeConnect` require Swapped keys on your backend.
 
+### Regional payment methods
+
+Leave `fiatMethods` unset and the modal personalizes the Cash options for the user's region. It renders the method list the backend resolves — provider labels, icons, limits, and one optional **Popular** badge — and hands the exact method the user picked to the signed Swapped widget URL.
+
+This is the recommended default: which methods exist varies by country, and a hard-coded subset can only go stale.
+
+Personalization never blocks the flow. After 500 ms the standard card, bank transfer and Apple Pay rows render; a late regional result only replaces a picker the user hasn't touched; and any failure keeps the complete default set. Resolving the country happens at your proxy — see [regional payment methods](/deposits/widget/backend#regional-payment-methods) for what it needs.
+
+<Note>
+A known country with **no** available methods is authoritative merchant data, and the
+modal hides the Cash option entirely. That is different from an unresolved country,
+which renders the defaults.
+</Note>
+
 ### Restricting fiat payment methods
 
-`fiatMethods` is a boolean map keyed by Swapped `payment_group`. Omit it to offer all of them, which also tracks Swapped's lineup without you redeploying.
+`fiatMethods` is a boolean map keyed by Swapped `payment_group`. Passing it pins the Cash rows to that exact subset and opts this modal instance out of regional personalization.
 
 ```tsx
 <DepositModal
@@ -119,7 +133,7 @@ Valid keys are `creditcard`, `bank-transfer`, and `apple-pay`. Enabling one does
 
 <Warning>
 An empty or all-false `fiatMethods` offers **no** payment methods, not all of them.
-To offer everything, omit the prop.
+To offer everything, omit the prop — which also turns personalization back on.
 </Warning>
 
 ## Transfer configuration
@@ -142,9 +156,15 @@ For supported chains and tokens, see [supported chains](/deposits/overview#suppo
 
 ### HyperCore destinations
 
-HyperCore is `targetChain: 1337` (exported as `HYPERCORE_CHAIN_ID`), accepts USDC only, and **requires an EOA `recipient`**. The modal pre-screens the recipient on HyperEVM and shows an error if it's a contract; the orchestrator rejects it regardless, so a smart-account recipient cannot work here.
+HyperCore is `targetChain: 1337` (exported as `HYPERCORE_CHAIN_ID`) and accepts USDC only. The `recipient` can be an EOA or a smart account: deposits are credited through the MulticallHandler's `depositFor(recipient)`, which funds any address's HyperCore account identically and never executes on the recipient.
 
-The check fails open — an RPC error lets the flow continue rather than false-blocking a valid EOA.
+<Note>
+Earlier versions pre-screened the recipient's bytecode and blocked a contract with
+an `onError` code of `HYPERCORE_RECIPIENT_NOT_EOA`. That rule never matched the
+orchestrator and is gone as of v0.9.0 — the code is no longer emitted.
+</Note>
+
+HyperCore is also available as a deposit **source** in the QR / transfer flow, using the account's own EVM address as the deposit address; a native Hyperliquid L1 spot transfer lands there.
 
 ### Restricting which sources you accept
 
@@ -336,7 +356,7 @@ Set `closeOnOverlayClick={false}` to prevent the modal from closing when the use
 | `enableWallet` | `boolean` | `true` | [Offer the connected wallet](#funding-methods) as a source |
 | `enableQrTransfer` | `boolean` | `true` | Offer the "Transfer crypto" deposit-address / QR row |
 | `enableFiatOnramp` | `boolean` | `false` | Offer fiat payment via Swapped's iframe. Requires backend Swapped keys |
-| `fiatMethods` | `FiatMethodsConfig` | all | [Restrict payment groups](#restricting-fiat-payment-methods) — `{ creditcard?, "bank-transfer"?, "apple-pay"? }`. Empty means none |
+| `fiatMethods` | `FiatMethodsConfig` | regional | [Restrict payment groups](#restricting-fiat-payment-methods) — `{ creditcard?, "bank-transfer"?, "apple-pay"? }`. Empty means none; omitted means [regional](#regional-payment-methods) |
 | `enableExchangeConnect` | `boolean` | `false` | Offer "Connect exchange". Requires backend Swapped keys |
 | `assetMigrations` | `AssetMigrationsConfig` | — | [Migrate balances](#migrate-assets-from-other-apps) from third-party apps (e.g. `{ polymarket: true }`) |
 | `initialAssetMigration` | `keyof AssetMigrationsConfig` | — | Open the modal pre-routed into a migration provider (e.g. `"polymarket"`), skipping the home screen. Must name an enabled `assetMigrations` key. |

--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -10,10 +10,27 @@ transfer to your app, and renames or removes props that no longer described what
 they did. The account and withdraw changes need code; the
 [prop renames](#renamed-and-removed-props) are mechanical.
 
+### Deploy your proxy first
+
+Four of these changes are proxy-side and take effect the moment the new modal
+loads in a browser. None of them degrades — the request 404s, or the browser
+blocks it at preflight.
+
+| Change | Why it can't wait |
+|---|---|
+| Forward `POST /register-managed` | Replaces `/setup-account` + `/register`. Without it registration 404s: no deposit address and no QR code |
+| Forward `GET /qr/tokens` | Replaces `GET /tokens`, with **no fallback**. Without it the QR picker falls back to the modal's built-in token set, which can offer a token your deposit whitelist rejects on arrival |
+| Allow `x-deposit-modal-version` in CORS | Every request now carries it. A proxy with an explicit `allowHeaders` that omits it fails the **whole request** at preflight, not just the header |
+| Forward `POST /deposits/recover` | Only if you adopt the new [claim modal](/deposits/widget/claim-modal) |
+
+See [required routes](/deposits/widget/backend#required-routes) for the full
+table. `/setup-account` and `/register` are no longer called and can be dropped
+once no older modal version is in use.
+
 <Warning>
-If you run your own proxy, deploy `POST /register-managed` **before** shipping the
-new modal. Registration 404s without it, which means no deposit address and no QR
-code — the flow does not degrade, it stops.
+Bare Hono `cors()` is safe for the version header — with no `allowHeaders` it
+reflects whatever the preflight asks for. An explicit allow-list is what breaks,
+and it breaks on upgrade rather than on first deploy.
 </Warning>
 
 **Both modals** — the `signerAddress` and `sessionChainIds` props are gone,
@@ -105,6 +122,9 @@ checked and shown on the QR / transfer screen.
 belongs on your [backend proxy](/deposits/widget/backend), which attaches it upstream.
 Delete it; nothing consumed it.
 
+**`FiatPaymentMethodOption` is no longer exported.** It described a row descriptor
+that `fiatMethods` no longer takes.
+
 **`backendUrl` is now required** on all three modals, and the `DEFAULT_BACKEND_URL`
 export is gone. The old default pointed at a Rhinestone-internal service running on
 **our** API key, so any integration that omitted the prop was silently routing its
@@ -179,6 +199,17 @@ longer needs it installed. See [install](/deposits/widget/quickstart#install).
 - **Logos load from Rhinestone's asset CDN.** Apps with an explicit `img-src` CSP must
   allow `https://s3.rhinestone.dev` — a blocked image fails silently. See
   [content security policy](/deposits/widget/deposit-modal#content-security-policy).
+- **`HYPERCORE_RECIPIENT_NOT_EOA` is no longer emitted.** [HyperCore](/deposits/widget/deposit-modal#hypercore-destinations)
+  deposits now accept a smart-account `recipient`, and the pre-screen that blocked one
+  is gone. If you branch on that `onError` code, the branch is dead.
+- **A chain your deposit whitelist allows nothing on is no longer offered** in the QR
+  flow's chain picker, instead of appearing with built-in tokens the deposit would then
+  be rejected for. Chains the shortlist says nothing about keep their existing set.
+- **Fiat payment methods are personalized by region** unless you pass `fiatMethods`.
+  See [regional payment methods](/deposits/widget/deposit-modal#regional-payment-methods).
+- **The deposit review shows a single "Fees" row.** The per-category breakdown and its
+  tooltips are gone; `uiConfig.feeSponsored` and `uiConfig.feeTooltip` still apply on
+  the processing and result screens.
 
 ### Removed prop warnings
 

--- a/deposits/widget/status-tracking.mdx
+++ b/deposits/widget/status-tracking.mdx
@@ -146,7 +146,6 @@ onError={(data) => console.error(`[${data.code}] ${data.message}`)}
 
 | `code` | Meaning |
 |---|---|
-| `HYPERCORE_RECIPIENT_NOT_EOA` | [HyperCore](/deposits/widget/deposit-modal#hypercore-destinations) target with a contract `recipient`. The deposit cannot settle |
 | `WITHDRAW_MISSING_SEND_TRANSACTION` | `<WithdrawModal>` opened without an `onSendTransaction` function |
 | `WITHDRAW_REGISTER_FAILED` | Registering the withdrawal's deposit account failed |
 | `WITHDRAW_FLOW_ERROR` | The withdrawal failed after the form was submitted |

--- a/home/resources/supported-chains.mdx
+++ b/home/resources/supported-chains.mdx
@@ -73,8 +73,6 @@ export const IntentChains = () => {
   );
 };
 
-Rhinestone intents are supported on any chain where an integrated settlement layer is deployed.
-
 <IntentChains />
 
 <Info>

--- a/styles/config/vocabularies/Rhinestone/accept.txt
+++ b/styles/config/vocabularies/Rhinestone/accept.txt
@@ -67,6 +67,9 @@ Base
 Sepolia
 Solana
 Soneium
+HyperEVM
+HyperCore
+Hyperliquid
 ZKsync
 Binance
 
@@ -104,6 +107,7 @@ onboards?
 waitlist
 timeframes?
 timebox
+tooltips?
 incentivized
 declaratively
 learnings


### PR DESCRIPTION
Found scanning the deposit widget docs against `deposit-modal`'s `src/` before the 0.9.0 release. Four things the docs asserted that the shipped code contradicts.

## HyperCore no longer requires an EOA recipient

`deposit-modal.mdx` said a smart-account recipient "**cannot work here**" and `status-tracking.mdx` documented the `HYPERCORE_RECIPIENT_NOT_EOA` error code for it.

Deposits are credited through the MulticallHandler's `depositFor(recipient)`, which funds any address's HyperCore account identically and never executes on the recipient — so the rule never matched the orchestrator. The pre-screen is gone and the code appears nowhere in `src/` outside one test. Also notes HyperCore is a deposit *source*, which it has been since 0.8.0.

## `fiatMethods` does not default to "all"

Three places said the default is "all payment groups". Omitting it actually selects **regional personalization**: backend-resolved methods with provider labels, icons, limits and a Popular badge, a 500 ms deadline, and the standard card/bank/Apple Pay set as the fallback.

Personalization was documented nowhere on the site, so the recommended default read like the degraded one. Adds a section for it and corrects the two prop tables.

## Three proxy routes must ship before the modal, not one

The migration guide warned about `POST /register-managed` only. Also required:

- `GET /qr/tokens` — replaced `GET /tokens` with **no fallback**; without it the QR picker can offer a token the deposit whitelist rejects on arrival
- `x-deposit-modal-version` in CORS — fails the **whole request** at preflight against a fixed `allowHeaders`, not just the header
- `POST /deposits/recover` — gates the claim modal

All three are in `backend.mdx`, but never surfaced as upgrade steps, which is where an integrator upgrading looks.

## Four behaviour changes missing from the migration guide

The dead HyperCore error code, the QR picker dropping chains the whitelist empties, regional fiat methods, and the collapsed single "Fees" row — plus the `FiatPaymentMethodOption` export removal.

## Also

- Drops the settlement-layer sentence above the intents chain table on `home/resources/supported-chains.mdx`.
- Adds `Hyperliquid` / `HyperEVM` / `HyperCore` / `tooltips` to the Vale vocabulary. Vale is clean on every line this PR touches; three pre-existing errors on untouched lines are left alone.

Pairs with rhinestonewtf/deposit-modal#113, which fixes the same four gaps in that repo's `MIGRATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqSkxQdBTwteLyuMhWK62Y


[skip-linear]
