### PR TITLE
docs: unbreak deposits/overview, which is a 🚧 parse error in prod

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,18 @@ re-save the original. Page content is client-rendered, so `curl` returns an empt
 shell; you need a real browser to see errors. The CLI's own log carries the underlying
 message (`Could not parse expression with acorn`).
 
+Gotcha: **never put a `//` or `/* */` comment inside an `export const` block in MDX**,
+even though it is valid JavaScript and `mintlify dev` renders it fine. The hosted build
+re-prints the ESM node from its ESTree (this is what produces the `<page>.md` variant),
+and the printer hoists a leading comment *out* of the function body to the line above
+`export`. On the next parse that `//` line is a paragraph and the `export …` line
+becomes a lazy continuation of it, so the JSX braces are parsed as MDX expressions →
+`Could not parse expression with acorn` → the whole page body is replaced with
+"🚧 A parsing error occured". This only bites in production, and it is silent: nothing
+in CI checks it. Encode the explanation in variable names instead. (Broke
+`deposits/overview` for the whole of the a5bfaea deploy; fetch `https://docs.rhinestone.dev/<page>.md`
+to see exactly what the hosted build re-printed.)
+
 ## Stack
 
 - Framework: Mintlify

--- a/deposits/overview.mdx
+++ b/deposits/overview.mdx
@@ -41,11 +41,9 @@ export const DepositChains = () => {
         const byName = new Map();
         Object.entries(data).forEach(([id, chain]) => {
           const kept = byName.get(chain.name);
-          // A virtual chain can be advertised twice: once under its canonical
-          // CAIP-2 namespace and once as `eip155:<synthetic id>`. Keep the
-          // canonical entry, which carries the accurate capability flags.
-          const isCanonical = !id.startsWith('eip155:');
-          if (!kept || (isCanonical && kept.id.startsWith('eip155:'))) {
+          const isCanonicalNamespace = !id.startsWith('eip155:');
+          const keptIsSynthetic = kept?.id.startsWith('eip155:');
+          if (!kept || (isCanonicalNamespace && keptIsSynthetic)) {
             byName.set(chain.name, { ...chain, id });
           }
         });


### PR DESCRIPTION
`deposits/overview` renders as "🚧 A parsing error occured" on docs.rhinestone.dev, and has since the a5bfaea deploy. It is the only broken page — I swept all 172 pages in `docs.json`.

## The source is fine; the hosted build breaks it

`mintlify dev` renders the page, `vale` is clean, and both `@mdx-js/mdx` and Mintlify's own `@mintlify/mdx` serializer compile it without complaint.

`export const DepositChains` had three `//` comment lines inside the arrow-function body. The hosted build re-prints every ESM node from its ESTree — this is what generates the `<page>.md` / LLM variant — and the printer hoists a leading comment **out** of the function body onto the line above `export`. You can read the result off production itself:

```console
$ curl https://docs.rhinestone.dev/deposits/overview.md
// A virtual chain can be advertised twice: once under its canonical
// CAIP-2 namespace and once as `eip155:<synthetic id>`. Keep the
// canonical entry, which carries the accurate capability flags.
export const DepositChains = () => {
```

On the next parse that `//` line is a paragraph, so `export const … => {` is a *lazy continuation* of it rather than an ESM block, and the JSX braces get read as MDX expressions. Feeding production's own re-printed output back through the compiler reproduces the failure exactly:

```
Could not parse expression with acorn   line: 29 col: 3
```

`serialize` catches it, `parseFailed` goes true, and the whole page body is swapped for the fallback — which is why the page shows its frontmatter title and description and nothing else.

`home/resources/supported-chains.mdx` uses the identical `export const` + `React.useState` + `fetch` pattern and is fine. It just has no comments in the block. Those three lines were the only JS comments inside an ESM block anywhere in the repo.

## The change

Drop the comments, move the meaning into the names (`isCanonicalNamespace`, `keptIsSynthetic`). Dedupe behaviour is unchanged.

`AGENTS.md` gets the gotcha, because this is invisible locally and nothing in CI compiles pages — the only signal is the deployed site.

## Verification

Reproduced the hosted re-print locally (parse the ESM node to ESTree, print it back with `estree-util-to-js`, re-serialize, re-parse) and ran it against the pre-fix file restored from `HEAD`:

| file | hoisted comment | re-parse |
|---|---|---|
| `ztest-orig.mdx` (pre-fix) | yes | **FAIL** — `Could not parse expression with acorn` (line 24) |
| `deposits/overview.mdx` (fixed) | none | OK |
| `home/resources/supported-chains.mdx` | none | OK |

Same error and same line as production. Ran it across all 193 `.mdx` files in the repo — no other page is affected, matching the live sweep.

One caveat worth stating plainly: the harness is my reconstruction of Mintlify's step, not their code. It is validated in both directions — it reproduces prod's exact failure on the old file, and its output matches the hoist visible in prod's own `.md` — but the deploy is the only proof that ships.

[skip-linear]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gzy1e4wjokhWfnYr8jCjZx