### PR TITLE
docs: add sponsorship migration warning

### DIFF
--- a/smart-wallet/gas-sponsorship/set-up-sponsorship.mdx
+++ b/smart-wallet/gas-sponsorship/set-up-sponsorship.mdx
@@ -7,6 +7,10 @@ Rhinestone lets you sponsor your users' activity by topping up a single onchain 
 
 You manage your sponsorship balance in the [Dashboard](https://dashboard.rhinestone.dev) under **Settings → Sponsorship**.
 
+<Warning>
+  We're moving sponsorship balances from projects to organizations. Your up-to-date balance and new deposit address will reappear here shortly. Do not send funds to or automate deposits against your current address. [Reach out to us](http://t.me/kurt_larsen) if you have questions.
+</Warning>
+
 ## Viewing your balance
 
 The Sponsorship tab shows your available balance and the deposit address that funds it.


### PR DESCRIPTION
- Warn users that sponsorship balances are moving from projects to organizations.
- Prevent deposits to the current address during the migration and direct questions to support.

Closes [RHI-5457](https://linear.app/rhinestone/issue/RHI-5457)