### PR TITLE
docs: clarify organization-wide sponsorship

### DIFF
--- a/dashboard/overview.mdx
+++ b/dashboard/overview.mdx
@@ -3,7 +3,7 @@ title: "Getting started"
 description: "Sign in, and find your way around the dashboard"
 ---
 
-The [Rhinestone Dashboard](https://dashboard.rhinestone.dev) is where you manage your project: create API keys, register JWT keys, fund sponsorship, invite your team, and monitor intents and deposits.
+The [Rhinestone Dashboard](https://dashboard.rhinestone.dev) is where you manage your organization and projects. Sponsorship funding is shared by every project in your organization, while API keys, intents, deposits, and per-intent sponsorship limits remain project-specific.
 
 ## Signing in
 
@@ -39,7 +39,7 @@ After signing in you land on your project. The sidebar holds the main sections:
 - **Intents** — monitor the intents your integration submits.
 - **Deposits** — monitor deposits, and retry or refund failed ones.
 - **API keys** — create and manage API keys and JWT keys.
-- **Settings** — sponsorship balance and team management.
+- **Settings** — fund your organization's shared sponsorship balance, manage project-specific sponsorship limits, and manage your team.
 
 <Frame>
   <img src="/images/dashboard/access/nav.png" />

--- a/dashboard/overview.mdx
+++ b/dashboard/overview.mdx
@@ -3,7 +3,7 @@ title: "Getting started"
 description: "Sign in, and find your way around the dashboard"
 ---
 
-The [Rhinestone Dashboard](https://dashboard.rhinestone.dev) is where you manage your organization and projects. Sponsorship funding is shared by every project in your organization, while API keys, intents, deposits, and per-intent sponsorship limits remain project-specific.
+The [Rhinestone Dashboard](https://dashboard.rhinestone.dev) is where you manage your project: create API keys, register JWT keys, fund sponsorship, invite your team, and monitor intents and deposits.
 
 ## Signing in
 
@@ -39,7 +39,7 @@ After signing in you land on your project. The sidebar holds the main sections:
 - **Intents** — monitor the intents your integration submits.
 - **Deposits** — monitor deposits, and retry or refund failed ones.
 - **API keys** — create and manage API keys and JWT keys.
-- **Settings** — fund your organization's shared sponsorship balance, manage project-specific sponsorship limits, and manage your team.
+- **Settings** — sponsorship balance and team management.
 
 <Frame>
   <img src="/images/dashboard/access/nav.png" />

--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -66,7 +66,7 @@ The `cost` object on each route describes what the user pays:
 |---|---|
 | `input` | Tokens spent. Array of `{ chainId, tokenAddress, symbol, decimals, price, amount }`. |
 | `output` | Tokens delivered to the recipient on the destination chain. Same shape as `input`. |
-| `fees` | `{ total: { usd }, breakdown: { gas, swap, bridge } }`. Each breakdown entry has `{ usd, sponsored }` — `sponsored` reflects what was actually covered for this route, given the request's `sponsorSettings` and the project's sponsorship balance. |
+| `fees` | `{ total: { usd }, breakdown: { gas, swap, bridge } }`. Each breakdown entry has `{ usd, sponsored }` — `sponsored` reflects what was actually covered for this route, given the request's `sponsorSettings` and the organization's shared sponsorship balance. |
 
 ```ts
 const inputAmount = route.cost.input[0].amount;

--- a/intents/guides/getting-a-quote.mdx
+++ b/intents/guides/getting-a-quote.mdx
@@ -66,7 +66,7 @@ The `cost` object on each route describes what the user pays:
 |---|---|
 | `input` | Tokens spent. Array of `{ chainId, tokenAddress, symbol, decimals, price, amount }`. |
 | `output` | Tokens delivered to the recipient on the destination chain. Same shape as `input`. |
-| `fees` | `{ total: { usd }, breakdown: { gas, swap, bridge } }`. Each breakdown entry has `{ usd, sponsored }` — `sponsored` reflects what was actually covered for this route, given the request's `sponsorSettings` and the organization's shared sponsorship balance. |
+| `fees` | `{ total: { usd }, breakdown: { gas, swap, bridge } }`. Each breakdown entry has `{ usd, sponsored }` — `sponsored` reflects what was actually covered for this route, given the request's `sponsorSettings` and the sponsorship balance. |
 
 ```ts
 const inputAmount = route.cost.input[0].amount;

--- a/smart-wallet/core/gas-fee-sponsorship.mdx
+++ b/smart-wallet/core/gas-fee-sponsorship.mdx
@@ -5,9 +5,11 @@ description: "Sponsor gas, bridging, and swap fees for your users"
 
 Rhinestone lets you cover the fees for your users with a single onchain deposit.
 
-All projects in your organization draw from the same available balance and credit balance. They also share one deposit address for USDC on Base, which can subsidise gas, bridge fees, and swap fees across all chains.
+You can deposit USDC on Base, and subsidise gas, bridge fees, and swap fees across all chains.
 
-<Note>Sponsorship is separate from the user's own token balance. Without sponsorship, fees are deducted from the user's tokens. With sponsorship enabled, fees come from your organization's deposit instead. The user's funds are never mixed with the sponsorship balance.</Note>
+All projects in your organization share the same available balance, credit balance, and deposit address.
+
+<Note>Sponsorship is separate from the user's own token balance. Without sponsorship, fees are deducted from the user's tokens. With sponsorship enabled, fees come from your developer deposit instead. The user's funds are never mixed with the sponsorship balance.</Note>
 
 ## Fee Types
 
@@ -23,9 +25,7 @@ You can sponsor both cross-chain and same-chain transactions.
 
 ## How it Works
 
-When your users make transactions, you can select which (if any) fees you are willing to sponsor. Rather than charging the user these costs, the Orchestrator instead applies them against your organization's sponsorship balance. You can sponsor up to the available amount, after which point, fees will be applied to your users' intents, ensuring continuity should you run out of funds.
-
-Per-intent sponsorship limits remain specific to each project.
+When your users make transactions, you can select which (if any) fees you are willing to sponsor. Rather than charging the user these costs, the Orchestrator instead applies them against your sponsorship balance. You can sponsor up to their deposited amount, after which point, fees will be applied to your users' intents, ensuring continuity should you run out of funds.
 
 For any given intent, the orchestrator calculates 3 types of fees: swap, bridge, and gas. Swap fees are a fixed 50 basis point spread between the offer and ask tokens. Bridge fees are a fixed 3 basis points on the input token being bridged between chains. Gas fees are the sum of the estimated fill gas (including any deployment costs if the account is undeployed) and all claim transactions a relayer will need to execute to fulfill an intent. 
 
@@ -35,7 +35,7 @@ When calculating the sponsored amount in USD, we take the cumulative fees that w
 
 You can test fee sponsorship on testnets out of the box.
 
-For production use, open **Settings → Sponsorship** in the [Dashboard](https://dashboard.rhinestone.dev) to find and fund your organization's deposit address. See [Set up sponsorship](/smart-wallet/gas-sponsorship/set-up-sponsorship) for top-up instructions.
+Open **Settings → Sponsorship** in the [Dashboard](https://dashboard.rhinestone.dev) to find and fund the address. See [Set up sponsorship](/smart-wallet/gas-sponsorship/set-up-sponsorship) for top-up instructions.
 
 Currently, we accept USDC deposits on Base. [Reach out to us](http://t.me/kurt_larsen) if you want to use fiat deposits.
 

--- a/smart-wallet/core/gas-fee-sponsorship.mdx
+++ b/smart-wallet/core/gas-fee-sponsorship.mdx
@@ -5,9 +5,9 @@ description: "Sponsor gas, bridging, and swap fees for your users"
 
 Rhinestone lets you cover the fees for your users with a single onchain deposit.
 
-You can deposit USDC on Base, and subsidise gas, bridge fees, and swap fees across all chains.
+All projects in your organization draw from the same available balance and credit balance. They also share one deposit address for USDC on Base, which can subsidise gas, bridge fees, and swap fees across all chains.
 
-<Note>Sponsorship is separate from the user's own token balance. Without sponsorship, fees are deducted from the user's tokens. With sponsorship enabled, fees come from your developer deposit instead. The user's funds are never mixed with the sponsorship balance.</Note>
+<Note>Sponsorship is separate from the user's own token balance. Without sponsorship, fees are deducted from the user's tokens. With sponsorship enabled, fees come from your organization's deposit instead. The user's funds are never mixed with the sponsorship balance.</Note>
 
 ## Fee Types
 
@@ -23,7 +23,9 @@ You can sponsor both cross-chain and same-chain transactions.
 
 ## How it Works
 
-When your users make transactions, you can select which (if any) fees you are willing to sponsor. Rather than charging the user these costs, the Orchestrator instead applies them against your sponsorship balance. You can sponsor up to their deposited amount, after which point, fees will be applied to your users' intents, ensuring continuity should you run out of funds.
+When your users make transactions, you can select which (if any) fees you are willing to sponsor. Rather than charging the user these costs, the Orchestrator instead applies them against your organization's sponsorship balance. You can sponsor up to the available amount, after which point, fees will be applied to your users' intents, ensuring continuity should you run out of funds.
+
+Per-intent sponsorship limits remain specific to each project.
 
 For any given intent, the orchestrator calculates 3 types of fees: swap, bridge, and gas. Swap fees are a fixed 50 basis point spread between the offer and ask tokens. Bridge fees are a fixed 3 basis points on the input token being bridged between chains. Gas fees are the sum of the estimated fill gas (including any deployment costs if the account is undeployed) and all claim transactions a relayer will need to execute to fulfill an intent. 
 
@@ -33,7 +35,7 @@ When calculating the sponsored amount in USD, we take the cumulative fees that w
 
 You can test fee sponsorship on testnets out of the box.
 
-[Reach out to us](http://t.me/kurt_larsen) if you need to set this up for production use. We will provide you with a wallet address to deposit to. Once you deposit, your sponsorship balance will automatically increase.
+For production use, open **Settings → Sponsorship** in the [Dashboard](https://dashboard.rhinestone.dev) to find and fund your organization's deposit address. See [Set up sponsorship](/smart-wallet/gas-sponsorship/set-up-sponsorship) for top-up instructions.
 
 Currently, we accept USDC deposits on Base. [Reach out to us](http://t.me/kurt_larsen) if you want to use fiat deposits.
 

--- a/smart-wallet/gas-sponsorship/overview.mdx
+++ b/smart-wallet/gas-sponsorship/overview.mdx
@@ -5,7 +5,9 @@ description: "Sponsor gas, bridging, and swap costs for your users"
 
 Rhinestone lets you cover the fees for your users with a single onchain deposit.
 
-All projects in your organization draw from the same available balance and credit balance. They also share one deposit address for USDC on Base, which can subsidise gas, bridge fees, and swap fees across all chains.
+You can deposit USDC on Base, and subsidise gas, bridge fees, and swap fees across all chains.
+
+All projects in your organization share the same available balance, credit balance, and deposit address.
 
 ## Fee Types
 
@@ -21,9 +23,7 @@ You can sponsor both cross-chain and same-chain transactions.
 
 ## How it Works
 
-When your users make transactions, you can select which (if any) fees you are willing to sponsor. Rather than charging the user these costs, the Orchestrator instead applies them against your organization's sponsorship balance. You can sponsor up to the available amount, after which point, fees will be applied to your users' intents, ensuring continuity should you run out of funds.
-
-Per-intent sponsorship limits remain specific to each project.
+When your users make transactions, you can select which (if any) fees you are willing to sponsor. Rather than charging the user these costs, the Orchestrator instead applies them against your sponsorship balance. You can sponsor up to their deposited amount, after which point, fees will be applied to your users' intents, ensuring continuity should you run out of funds.
 
 The sponsored amount is calculated in USD at the time of the intent, based on the cumulative fees that would otherwise be charged to the user.
 
@@ -31,7 +31,7 @@ The sponsored amount is calculated in USD at the time of the intent, based on th
 
 You can test fee sponsorship on testnets out of the box.
 
-For production use, open **Settings → Sponsorship** in the [Dashboard](https://dashboard.rhinestone.dev) to find and fund your organization's deposit address. See [Set up sponsorship](./set-up-sponsorship) for top-up instructions.
+Open **Settings → Sponsorship** in the [Dashboard](https://dashboard.rhinestone.dev) to find and fund the address. See [Set up sponsorship](./set-up-sponsorship) for top-up instructions.
 
 Currently, we accept USDC deposits on Base. [Reach out to us](http://t.me/kurt_larsen) if you want to use fiat deposits.
 

--- a/smart-wallet/gas-sponsorship/overview.mdx
+++ b/smart-wallet/gas-sponsorship/overview.mdx
@@ -5,7 +5,7 @@ description: "Sponsor gas, bridging, and swap costs for your users"
 
 Rhinestone lets you cover the fees for your users with a single onchain deposit.
 
-You can deposit USDC on Base, and subsidise gas, bridge fees, and swap fees across all chains.
+All projects in your organization draw from the same available balance and credit balance. They also share one deposit address for USDC on Base, which can subsidise gas, bridge fees, and swap fees across all chains.
 
 ## Fee Types
 
@@ -21,7 +21,9 @@ You can sponsor both cross-chain and same-chain transactions.
 
 ## How it Works
 
-When your users make transactions, you can select which (if any) fees you are willing to sponsor. Rather than charging the user these costs, the Orchestrator instead applies them against your sponsorship balance. You can sponsor up to their deposited amount, after which point, fees will be applied to your users' intents, ensuring continuity should you run out of funds.
+When your users make transactions, you can select which (if any) fees you are willing to sponsor. Rather than charging the user these costs, the Orchestrator instead applies them against your organization's sponsorship balance. You can sponsor up to the available amount, after which point, fees will be applied to your users' intents, ensuring continuity should you run out of funds.
+
+Per-intent sponsorship limits remain specific to each project.
 
 The sponsored amount is calculated in USD at the time of the intent, based on the cumulative fees that would otherwise be charged to the user.
 
@@ -29,7 +31,7 @@ The sponsored amount is calculated in USD at the time of the intent, based on th
 
 You can test fee sponsorship on testnets out of the box.
 
-[Reach out to us](http://t.me/kurt_larsen) if you need to set this up for production use. We will provide you with a wallet address to deposit to. Once you deposit, your sponsorship balance will automatically increase.
+For production use, open **Settings → Sponsorship** in the [Dashboard](https://dashboard.rhinestone.dev) to find and fund your organization's deposit address. See [Set up sponsorship](./set-up-sponsorship) for top-up instructions.
 
 Currently, we accept USDC deposits on Base. [Reach out to us](http://t.me/kurt_larsen) if you want to use fiat deposits.
 

--- a/smart-wallet/gas-sponsorship/set-up-sponsorship.mdx
+++ b/smart-wallet/gas-sponsorship/set-up-sponsorship.mdx
@@ -5,15 +5,13 @@ description: "Monitor and top up your sponsorship balance"
 
 Rhinestone lets you sponsor your users' activity by topping up a single onchain account ("gas tank").
 
-You manage your sponsorship balance in the [Dashboard](https://dashboard.rhinestone.dev) under **Settings → Sponsorship**.
+All projects in your organization share one available balance, credit balance, and deposit address. Per-intent sponsorship limits remain project-specific.
 
-<Warning>
-  We're moving sponsorship balances from projects to organizations. Your up-to-date balance and new deposit address will reappear here shortly. Do not send funds to or automate deposits against your current address. [Reach out to us](http://t.me/kurt_larsen) if you have questions.
-</Warning>
+You manage sponsorship in the [Dashboard](https://dashboard.rhinestone.dev) under **Settings → Sponsorship**.
 
 ## Viewing your balance
 
-The Sponsorship tab shows your available balance and the deposit address that funds it.
+The Sponsorship tab shows your organization's shared available balance, credit balance, and deposit address.
 
 <Frame>
   <img src="/images/dashboard/sponsorship/balance.png" />
@@ -26,7 +24,7 @@ There are two ways to top up:
 1. Using the deposit modal with a connected wallet
 2. Sending a token transfer manually from any wallet
 
-<Warning>Only ever send **USDC on Base**. Any other token will not be credited towards your sponsorship balance.</Warning>
+<Warning>Only ever send **USDC on Base**. Any other token will not be credited to your organization's sponsorship balance.</Warning>
 
 ### Using the modal
 
@@ -36,8 +34,8 @@ The easiest way to top up is the deposit modal. Press "Deposit", enter the amoun
   <img src="/images/dashboard/sponsorship/deposit-amount.png" />
 </Frame>
 
-Approve the transaction in your connected wallet. Once it confirms, your balance updates automatically.
+Approve the transaction in your connected wallet. Once it confirms, your organization's balance updates automatically.
 
 ### Manual deposits
 
-If you'd rather send from an external wallet (e.g. a Safe or mobile wallet), press "Copy" next to the deposit address and transfer USDC on Base to it directly. Once the transfer confirms, your balance updates automatically.
+If you'd rather send from an external wallet (e.g. a Safe or mobile wallet), press "Copy" next to the deposit address and transfer USDC on Base to it directly. Once the transfer confirms, your organization's balance updates automatically.

--- a/smart-wallet/gas-sponsorship/set-up-sponsorship.mdx
+++ b/smart-wallet/gas-sponsorship/set-up-sponsorship.mdx
@@ -13,10 +13,6 @@ You manage sponsorship in the [Dashboard](https://dashboard.rhinestone.dev) unde
 
 The Sponsorship tab shows your organization's shared available balance, credit balance, and deposit address.
 
-<Frame>
-  <img src="/images/dashboard/sponsorship/balance.png" />
-</Frame>
-
 ## Topping up
 
 There are two ways to top up:

--- a/smart-wallet/gas-sponsorship/set-up-sponsorship.mdx
+++ b/smart-wallet/gas-sponsorship/set-up-sponsorship.mdx
@@ -7,11 +7,11 @@ Rhinestone lets you sponsor your users' activity by topping up a single onchain 
 
 All projects in your organization share one available balance, credit balance, and deposit address. Per-intent sponsorship limits remain project-specific.
 
-You manage sponsorship in the [Dashboard](https://dashboard.rhinestone.dev) under **Settings → Sponsorship**.
+You manage your sponsorship balance in the [Dashboard](https://dashboard.rhinestone.dev) under **Settings → Sponsorship**.
 
 ## Viewing your balance
 
-The Sponsorship tab shows your organization's shared available balance, credit balance, and deposit address.
+The Sponsorship tab shows the shared available balance, credit balance, and deposit address.
 
 ## Topping up
 
@@ -20,7 +20,7 @@ There are two ways to top up:
 1. Using the deposit modal with a connected wallet
 2. Sending a token transfer manually from any wallet
 
-<Warning>Only ever send **USDC on Base**. Any other token will not be credited to your organization's sponsorship balance.</Warning>
+<Warning>Only ever send **USDC on Base**. Any other token will not be credited towards your sponsorship balance.</Warning>
 
 ### Using the modal
 
@@ -30,8 +30,8 @@ The easiest way to top up is the deposit modal. Press "Deposit", enter the amoun
   <img src="/images/dashboard/sponsorship/deposit-amount.png" />
 </Frame>
 
-Approve the transaction in your connected wallet. Once it confirms, your organization's balance updates automatically.
+Approve the transaction in your connected wallet. Once it confirms, your balance updates automatically.
 
 ### Manual deposits
 
-If you'd rather send from an external wallet (e.g. a Safe or mobile wallet), press "Copy" next to the deposit address and transfer USDC on Base to it directly. Once the transfer confirms, your organization's balance updates automatically.
+If you'd rather send from an external wallet (e.g. a Safe or mobile wallet), press "Copy" next to the deposit address and transfer USDC on Base to it directly. Once the transfer confirms, your balance updates automatically.

--- a/smart-wallet/tutorials/sponsor-fees.mdx
+++ b/smart-wallet/tutorials/sponsor-fees.mdx
@@ -18,11 +18,11 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
 <Steps>
   <Step title="Top up your sponsorship balance">
 
-    Open the [Rhinestone dashboard](https://dashboard.rhinestone.dev) and go to the **Sponsorship** tab.
+    Open the [Rhinestone dashboard](https://dashboard.rhinestone.dev) and go to **Settings → Sponsorship**.
 
-    Press **Deposit**, enter an amount of USDC, and confirm the transaction in your wallet. Your balance updates automatically once the transaction is confirmed.
+    Press **Deposit**, enter an amount of USDC, and confirm the transaction in your wallet. This tops up the sponsorship balance shared by every project in your organization.
 
-    <Note>On testnets, sponsorship works out of the box with no deposit required. For production, [reach out](https://t.me/kurt_larsen) to get your deposit address set up.</Note>
+    <Note>On testnets, sponsorship works out of the box with no deposit required. For production, fund your organization's deposit address by following [Set up sponsorship](../gas-sponsorship/set-up-sponsorship).</Note>
 
   </Step>
 
@@ -50,7 +50,7 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
     console.log('Transaction settled:', status)
     ```
 
-    Your user signs once. The Rhinestone orchestrator deducts the fees from your sponsorship balance and the user pays nothing.
+    Your user signs once. The Rhinestone orchestrator deducts the fees from your organization's shared sponsorship balance and the user pays nothing.
 
   </Step>
 

--- a/smart-wallet/tutorials/sponsor-fees.mdx
+++ b/smart-wallet/tutorials/sponsor-fees.mdx
@@ -20,9 +20,9 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
 
     Open the [Rhinestone dashboard](https://dashboard.rhinestone.dev) and go to **Settings → Sponsorship**.
 
-    Press **Deposit**, enter an amount of USDC, and confirm the transaction in your wallet. This tops up the sponsorship balance shared by every project in your organization.
+    Press **Deposit**, enter an amount of USDC, and confirm the transaction in your wallet. Your balance updates automatically once the transaction is confirmed.
 
-    <Note>On testnets, sponsorship works out of the box with no deposit required. For production, fund your organization's deposit address by following [Set up sponsorship](../gas-sponsorship/set-up-sponsorship).</Note>
+    <Note>On testnets, sponsorship works out of the box with no deposit required. To fund the address, follow [Set up sponsorship](../gas-sponsorship/set-up-sponsorship).</Note>
 
   </Step>
 
@@ -50,7 +50,7 @@ This tutorial builds on the [Quickstart](../quickstart). You'll need a working s
     console.log('Transaction settled:', status)
     ```
 
-    Your user signs once. The Rhinestone orchestrator deducts the fees from your organization's shared sponsorship balance and the user pays nothing.
+    Your user signs once. The Rhinestone orchestrator deducts the fees from your sponsorship balance and the user pays nothing.
 
   </Step>
 


### PR DESCRIPTION
- Clarify that sponsorship balances, credits, and deposit addresses are shared across an organization.
- Keep per-intent limits project-specific and remove the temporary migration warning and stale screenshot.

Closes [RHI-5458](https://linear.app/rhinestone/issue/RHI-5458)