### PR TITLE
chore: retrigger docs deployment

### DIFF
--- a/deposits/api/deposit-processing.mdx
+++ b/deposits/api/deposit-processing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deposit processing"
-description: "How deposits are detected, bridged, and settled — plus status tracking, retries, and error handling."
+description: "How deposits are detected, bridged, and settled, including status tracking, retries, and error handling."
 ---
 
 Once an account is registered, the deposit service handles everything from detection to settlement. This page explains what happens at each stage and how to monitor the process.


### PR DESCRIPTION
- Make a harmless copy edit so Mintlify detects a deployable docs change.
- Republish the generated API reference after the deposit-service OpenAPI update.