### PR TITLE
fix: drop the Demos page, which pointed at a dead host

### DIFF
--- a/smart-wallet/demos.mdx
+++ b/smart-wallet/demos.mdx
@@ -1,4 +1,0 @@
----
-title: "Demos"
-url: "https://demos.rhinestone.dev"
----


### PR DESCRIPTION
`smart-wallet/demos.mdx` was four lines of frontmatter whose only purpose was `url: "https://demos.rhinestone.dev"` — a Mintlify external-link page.

```
$ dig +short demos.rhinestone.dev @1.1.1.1
(nothing)
```

NXDOMAIN. No Vercel project has served it for some time, and it is not in the authoritative Route53 zone config either.

Deleting rather than retargeting, because there is no content to keep — the file is a pointer and nothing else. It is also not in `docs.json`'s nav, so it was reachable only by direct URL or from search, which is the worst way to meet a broken link.

Found while decommissioning the rhinestone Vercel team (RHI-5675). The only other Vercel-backed host in the docs is `docs.rhinestone.dev` itself, which is Mintlify's own infrastructure and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbn5DjAFVvhhZ8dp5svKay