### PR TITLE
docs: rename the Deposits tab to Deposit

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -394,7 +394,7 @@
         ]
       },
       {
-        "tab": "Deposits",
+        "tab": "Deposit",
         "pages": [
           "deposits/overview",
           {


### PR DESCRIPTION
Renames the top-level nav tab from **Deposits** to **Deposit**.

[skip-linear] — one-word nav label change.

## Scope

One line in `docs.json`:

```diff
-        "tab": "Deposits",
+        "tab": "Deposit",
```

## No links break

In Mintlify the tab label is display-only — URLs come from the `pages[]` file paths, not the tab name. There's no `href` on this tab and no path prefix derived from it, so all 20 pages keep their existing `/deposits/*` URLs. No `redirects` entry is needed because nothing moved.

Verified:

- Ran the site locally and inspected the rendered nav — label reads "Deposit", the link still resolves to `/deposits/overview`.
- `mintlify broken-links` before vs. after is **identical**: 10 broken links in 5 files both ways, so this introduces zero new breakage. Those 10 are pre-existing — 9 `/api-reference/deposit-service/*` anchors the local checker can't resolve (that section is generated from a remote OpenAPI spec) plus a dead `/resources/support` in `deposits/widget/claim-modal.mdx`.
- Every internal link to the section is path-based (`/deposits/widget/backend` etc.) and untouched. External inbound links and SEO are unaffected.

## Left alone deliberately

The **API Reference** sidebar group is still labelled "Deposits" (`docs.json` L448 — the heading for the deposit-service OpenAPI pages). Happy to rename it too if we want consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)