### PR TITLE
docs(widget): deposit history is always on, not a uiConfig flag

### DIFF
--- a/deposits/widget/customization.mdx
+++ b/deposits/widget/customization.mdx
@@ -45,7 +45,6 @@ Toggle UI elements, set deposit constraints, and control fee display via `uiConf
   // ...required props
   uiConfig={{
     showBackButton: true,
-    showHistoryButton: true,
     minDepositUsd: 1,
     maxDepositUsd: 10000,
     feeSponsored: true,
@@ -58,8 +57,11 @@ Toggle UI elements, set deposit constraints, and control fee display via `uiConf
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `showBackButton` | `boolean` | `true` | Show the back button in the header |
-| `showHistoryButton` | `boolean` | `false` | Show the deposit history button in the header |
 | `minDepositUsd` | `number` | — | Minimum deposit amount in USD |
 | `maxDepositUsd` | `number` | — | Maximum deposit amount in USD |
 | `feeSponsored` | `boolean` | `false` | When `true`, the network/protocol fee renders struck-through on the review, processing, and result screens, with a tooltip explaining the sponsorship |
 | `feeTooltip` | `string` | — | Custom copy for the fee info tooltip. Defaults to a generic message based on `feeSponsored`. |
+
+### Deposit history
+
+The header on the modal's home screen carries a history button that opens the recipient's past deposits, and it is always shown. Your [proxy](/deposits/widget/backend) must forward `GET /deposits` or the panel opens on an error.


### PR DESCRIPTION
Follows rhinestonewtf/deposit-modal#133, which removes `uiConfig.showHistoryButton` and moves the history button onto the modal's home screen for every integration.

Drops the property from the `uiConfig` example and table, and replaces it with a note naming the one thing an integrator still has to do: forward `GET /deposits` (already in the reference proxy allowlist on this page's [backend](/deposits/widget/backend) recipe).

**Hold merge until the modal release publishes** — until then npm `latest` still has the flag.

[skip-linear]

🤖 Generated with [Claude Code](https://claude.com/claude-code)