### PR TITLE
docs(widget): GET /chains is a required proxy route

### DIFF
--- a/deposits/widget/backend.mdx
+++ b/deposits/widget/backend.mdx
@@ -52,6 +52,7 @@ const MODAL_VERSION_HEADER = "x-deposit-modal-version";
 // Every route the modal calls, and nothing else. `:param` segments are matched
 // by Hono, so a request can only reach a shape you listed here.
 const ROUTES: [method: "get" | "post", path: string][] = [
+  ["get", "/chains"],
   ["post", "/register-managed"],
   ["post", "/quotes/preview"],
   ["get", "/check/:address"],
@@ -141,8 +142,11 @@ processor directly.
 
 Missing a route doesn't degrade the flow — the request 404s and that part of the modal stops working.
 
+Two routes are load-bearing rather than partial: without `/chains` the modal has no chain set at all, and without `/register-managed` there is no deposit account to send to. Everything else costs you the feature in its row.
+
 | Method | Route | Used for |
 |---|---|---|
+| `GET` | `/chains` | The chain set, and each chain's tokens, explorer and gas asset. **Required** |
 | `POST` | `/register-managed` | Registering the deposit account. **Required** |
 | `POST` | `/quotes/preview` | Indicative fee/time quote on the review screen |
 | `GET` | `/check/:address` | Registration + target lookup |

--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -1,7 +1,35 @@
 ---
 title: "Migration guide"
-description: "Upgrade @rhinestone/deposit-modal to v0.9.0 — managed accounts, the withdraw callback, and renamed props. Plus v0.1.x / v0.2.x to v0.3.0."
+description: "Upgrade @rhinestone/deposit-modal — v0.12.0 requires GET /chains on your proxy; v0.9.0 brought managed accounts, the withdraw callback, and renamed props. Plus v0.1.x / v0.2.x to v0.3.0."
 ---
+
+## v0.11.x → v0.12.0
+
+One change, and it is proxy-side: **your proxy must forward `GET /chains`.**
+
+The modal has read the chain set from `/chains` since v0.11.0, but it still
+carried a compiled-in table it fell back to. That table is gone. A proxy that
+does not forward the route no longer degrades to a built-in chain list — it
+leaves every picker empty, and the deposit flow reports that supported chains are
+unavailable.
+
+| Change | Why it can't wait |
+|---|---|
+| Forward `GET /chains` | The only source of the chain set. Without it there are no chains to offer and no deposit can start |
+
+`deposit-widget-proxy` has forwarded it since 2026-08-11, so redeploying the
+packaged proxy is enough. A hand-written proxy needs the route added to its
+allowlist — see [required routes](/deposits/widget/backend#required-routes).
+This is not a CORS change: it is a `GET` using headers the modal already sends,
+so it cannot break a preflight.
+
+Nothing in your application code changes.
+
+<Note>
+  The upside of the removal is that the chain set is now whatever the backend
+  serves, in both directions — a chain we add appears without a modal release,
+  and one we withdraw stops being offered instead of lingering until you upgrade.
+</Note>
 
 ## v0.8.x → v0.9.0
 


### PR DESCRIPTION
Closes RHI-4953 follow-up — pairs with [deposit-modal#134](https://github.com/rhinestonewtf/deposit-modal/pull/134), and should merge before that ships to `@latest`.

`/chains` appeared **nowhere** on the backend page — not in the minimal-proxy `ROUTES` snippet, not in the required-routes table. A proxy written from these docs does not forward it.

That was survivable until now: the modal fell back to a compiled-in chain table, so a missing route cost the integrator a silently stale chain list. deposit-modal#134 deletes that table, so the same proxy now leaves every picker empty and the deposit flow reports that supported chains are unavailable.

- adds `GET /chains` to the route snippet and the required-routes table, marked **Required**
- qualifies *"missing a route doesn't degrade the flow — that part stops working"*, which holds for every route except this one and `/register-managed`
- adds a **v0.11.x → v0.12.0** migration section: one proxy-side change, no application code

No change needed to `home/resources/supported-chains.mdx` — it already fetches the catalog at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)