### PR TITLE
docs(deposits): key a whitelist on depositTokens, not supportedTokens

### DIFF
--- a/deposits/api/initial-setup.mdx
+++ b/deposits/api/initial-setup.mdx
@@ -94,9 +94,21 @@ await fetch(`${DEPOSIT_SERVICE_URL}/setup`, {
 
 | Field       | Type     | Description                                                      |
 | ----------- | -------- | ---------------------------------------------------------------- |
-| `token`     | `string` | Token address (`0x`-prefixed)                                    |
+| `token`     | `string` | Token identifier, as `GET /chains` reports it in `depositTokens` |
 | `minAmount` | `string` | Optional. Minimum accepted amount in raw token units (inclusive) |
 | `maxAmount` | `string` | Optional. Maximum accepted amount in raw token units (inclusive) |
+
+<Warning>
+Take `token` from a chain's **`depositTokens`** in `GET /chains`, not from
+`supportedTokens`. The two answer different questions — what you can deposit
+*from* a chain, and what can be delivered *to* it — and on HyperCore they are
+different identifiers for the same asset. Everywhere else they match.
+
+A whitelist keyed on an identifier deposits are not matched on rejects every
+deposit with `TOKEN-3`, and `/setup` still returns `200`, so the only symptom is
+that nothing arrives. `minAmount` / `maxAmount` are in the units of the
+identifier you used — for HyperCore USDC that is 8 decimals, not 6.
+</Warning>
 
 If no whitelist is set, all [supported tokens](/deposits/overview#supported-chains-and-tokens) are accepted with no amount restrictions.
 

--- a/deposits/overview.mdx
+++ b/deposits/overview.mdx
@@ -3,6 +3,16 @@ title: "Overview"
 description: "Accept deposits from any chain into your app with Rhinestone's cross-chain deposit infrastructure."
 ---
 
+{/* A chain answers what it accepts as a deposit and what can be delivered to it
+    separately, because on HyperCore those are different identifiers for the
+    same asset. Listing one field alone understates the other side. */}
+export const chainTokenSymbols = (chain) => {
+  const lists = [chain.depositTokens, chain.supportedTokens].filter(Boolean);
+  if (lists.some((l) => l === 'all')) return 'All';
+  const symbols = [...new Set(lists.flatMap((l) => l.map((t) => t.symbol)))];
+  return symbols.join(', ') || '-';
+};
+
 export const DepositChainsTable = ({ chains }) => (
   <table className="min-w-full">
     <thead>
@@ -19,7 +29,7 @@ export const DepositChainsTable = ({ chains }) => (
           <td className="py-2 pr-4">{chain.name}</td>
           <td className="py-2 pr-4 text-center">{chain.deposit ? '✓' : '—'}</td>
           <td className="py-2 pr-4 text-center">{chain.destination ? '✓' : '—'}</td>
-          <td className="py-2">{chain.supportedTokens === 'all' ? 'All' : (chain.supportedTokens?.map(t => t.symbol).join(', ') || '-')}</td>
+          <td className="py-2">{chainTokenSymbols(chain)}</td>
         </tr>
       ))}
     </tbody>


### PR DESCRIPTION
`GET /chains` now reports both directions per chain: `depositTokens` (what you can deposit *from* it) alongside `supportedTokens` (what can be delivered *to* it). They are the same list everywhere except HyperCore, where a deposit is identified by its **Core spot token id at 8 decimals** and a delivery by the token's **HyperEVM ERC20 at 6**.

## Why this page

It is the page that tells an integrator how to build a `depositWhitelist`, and it pointed at the delivery side. Keying a whitelist on an identifier deposits are not matched on rejects every deposit with `TOKEN-3` — while `/setup` still returns `200`, so the only symptom is that nothing arrives. That failure ran for three weeks against a real client before anyone connected the two.

The amount units follow the identifier too, which was undocumented: HyperCore USDC bounds are in 8 decimals, not 6. A whitelist copied from the ERC20's decimals is off by 100×.

## Also

The supported-chains table rendered `supportedTokens` alone, which understated what HyperCore accepts as a **source** — it lists USDC where you can deposit USDC and USDT0. It now shows the union, and degrades to today's behaviour against a backend that does not publish `depositTokens`.

`home/resources/supported-chains.mdx` is deliberately untouched: it reads the **orchestrator's** `/chains`, which is a different endpoint with no such field.

[skip-linear]