### PR TITLE
docs(widget): v0.12.0 also drops showHistoryButton

### DIFF
--- a/deposits/widget/migration.mdx
+++ b/deposits/widget/migration.mdx
@@ -1,11 +1,18 @@
 ---
 title: "Migration guide"
-description: "Upgrade @rhinestone/deposit-modal — v0.12.0 requires GET /chains on your proxy; v0.9.0 brought managed accounts, the withdraw callback, and renamed props. Plus v0.1.x / v0.2.x to v0.3.0."
+description: "Upgrade @rhinestone/deposit-modal — v0.12.0 requires GET /chains on your proxy and drops showHistoryButton; v0.9.0 brought managed accounts, the withdraw callback, and renamed props. Plus v0.1.x / v0.2.x to v0.3.0."
 ---
 
 ## v0.11.x → v0.12.0
 
-One change, and it is proxy-side: **your proxy must forward `GET /chains`.**
+Two changes: one proxy-side, one a single line to delete.
+
+| Change | Why it can't wait |
+|---|---|
+| Forward `GET /chains` | The only source of the chain set. Without it there are no chains to offer and no deposit can start |
+| Delete `uiConfig.showHistoryButton` | The prop is gone from the type, so TypeScript fails to compile until you remove it |
+
+### Forward `GET /chains`
 
 The modal has read the chain set from `/chains` since v0.11.0, but it still
 carried a compiled-in table it fell back to. That table is gone. A proxy that
@@ -13,23 +20,34 @@ does not forward the route no longer degrades to a built-in chain list — it
 leaves every picker empty, and the deposit flow reports that supported chains are
 unavailable.
 
-| Change | Why it can't wait |
-|---|---|
-| Forward `GET /chains` | The only source of the chain set. Without it there are no chains to offer and no deposit can start |
-
 `deposit-widget-proxy` has forwarded it since 2026-08-11, so redeploying the
 packaged proxy is enough. A hand-written proxy needs the route added to its
 allowlist — see [required routes](/deposits/widget/backend#required-routes).
 This is not a CORS change: it is a `GET` using headers the modal already sends,
 so it cannot break a preflight.
 
-Nothing in your application code changes.
-
 <Note>
   The upside of the removal is that the chain set is now whatever the backend
   serves, in both directions — a chain we add appears without a modal release,
   and one we withdraw stops being offered instead of lingering until you upgrade.
 </Note>
+
+### Delete `uiConfig.showHistoryButton`
+
+Deposit history is now always available, so the flag has nothing left to switch.
+Delete the line; the button renders regardless, from the screen where the user
+picks a deposit method.
+
+```diff
+  uiConfig={{
+-   showHistoryButton: true,
+    showBackButton: true,
+  }}
+```
+
+If your proxy does not forward `GET /deposits`, this is the release where that
+becomes visible: the panel is now reachable and shows the failure, where before
+the button could be switched off and the gap stayed hidden.
 
 ## v0.8.x → v0.9.0
 


### PR DESCRIPTION
#205 wrote the v0.12.0 migration section against the chain-fallback change alone, and closed it with "Nothing in your application code changes." That is wrong as the release shipped: 0.12.0 also removes `uiConfig.showHistoryButton` (#204 covered the reference page but not the upgrade path), and the prop is gone from the type — a TypeScript host fails to compile until the line is deleted. Hit exactly that bumping deposit-widget-demo to 0.12.0.

Splits the section into the two changes, adds the `showHistoryButton` deletion with a diff block, and notes the second-order effect: a proxy that never forwarded `GET /deposits` could previously hide the gap by switching the button off, and now surfaces it in the panel.

`GET /deposits` stays optional in the required-routes table — the failure is a broken history panel, not a broken deposit.

[skip-linear] — corrects a page shipped in #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)